### PR TITLE
Added mean, var for Categorical distribution.

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -1493,6 +1493,9 @@ function Categorical(d::Integer)
   Categorical(ones(d) / d)
 end
 
+mean(d::Categorical) = d.prob
+var(d::Categorical) = d.prob .* (1-d.prob)
+
 function insupport(d::Categorical, x::Real)
   integer_valued(x) && 1 <= x <= length(d.prob) && d.prob[x] != 0.0
 end


### PR DESCRIPTION
In order to display properly, it seems that all Distributions need to have `mean` and `var` defined.  This does so for the Categorical distribution.

There is more than one possible way to define the mean and variance for the Categorical distribution.  This version is based the expected value of the statement, `[x = i]`, which is just `p_i`.  

An alternate version (requested separately) actually calculates the mean and variance of `x` using standard definitions.

(My preference is the other request.)
