### PR TITLE
Alternate definition of mean, variance for Categorical distribution.

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -1493,6 +1493,10 @@ function Categorical(d::Integer)
   Categorical(ones(d) / d)
 end
 
+mean(d::Categorical) = sum([1:length(d.prob)] .* d.prob)
+var(d::Categorical, m::Number) = sum(([1:length(d.prob)] - m).^2 .* d.prob)
+var(d::Categorical) = var(d, mean(d))
+
 function insupport(d::Categorical, x::Real)
   integer_valued(x) && 1 <= x <= length(d.prob) && d.prob[x] != 0.0
 end


### PR DESCRIPTION
In order to display properly, it seems that all Distributions need to have `mean` and `var` defined.  This does so for the Categorical distribution.

There is more than one possible way to define the mean and variance for the Categorical distribution.  This version calculates the mean and variance of `x` using standard definitions.

An alternate version (requested separately) is based the expected value of the statement, `[x = i]`, which is just `p_i`.  

(My preference is this request.)
