### PR TITLE
Dirichlet speedup

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -1476,6 +1476,21 @@ function rand(d::Dirichlet)
   x ./ sum(x)
 end
 
+function rand!(d::Dirichlet, X::Matrix)
+  m, n = size(X)
+  for i in 1:n
+    X[:,i] = rand(Gamma(d.alpha[i]), m)
+  end
+  for i in 1:m
+    isum = sum(X[i,:])
+    for j in 1:n
+      X[i,j] /= isum
+    end
+  end
+  return X
+end
+
+
 ##
 ##
 ## Categorical distribution


### PR DESCRIPTION
As a response to #18. The main problem here is that each call to the gamma rng has some setup costs and the fall back method for sampling is completely devectorized. If the gamma variates are returned as vectors it is much faster. On my machine this version is faster than Scipy and maybe it can be made faster. Please check the code before merging. I rarely use the Dirichlet so I haven't tested it thoroughly. 
