### PR TITLE
Adding InvertedGamma random variables

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -873,33 +873,37 @@ insupport(d::Gamma, x::Number) = real_valued(x) && isfinite(x) && 0 <= x
 
 ###########################################################################
 ## InvertedGamma distribution, cf Bayesian Theory (Barnardo & Smith) p 119
+## Note that B&S parametrize in terms of shape/rate, but this is uses
+## shape/scale so that it is consistent with the implementation of Gamma
 ###########################################################################
 immutable InvertedGamma <: ContinuousUnivariateDistribution
-    alpha::Float64
-    beta::Float64
-    InvertedGamma(alpha,beta) = alpha > 0 && beta > 0 ? new(float64(alpha), float64(beta)) : error("Both shape and scale must be positive")
+    shape::Float64 # location
+    scale::Float64 # scale
+    InvertedGamma(sh,sc) = sh > 0 && sc > 0 ? new(float64(sh), float64(sc)) : error("Both shape and scale must be positive")
 end
-InvertedGamma(alpha) = InvertedGamma(alpha, 1.)
-InvertedGamma() = InvertedGamma(1., 1.)
-mean(d::InvertedGamma) = d.alpha > 1. ? d.beta / (d.alpha - 1.) : error("Expectation only defined if alpha > 1")
-var(d::InvertedGamma) = d.alpha > 2. ? d.beta^2 / ((d.alpha - 1.)^2 * (d.alpha - 2.)) : error("Variance only defined if alpha > 2")
-rand(d::InvertedGamma) = 1. / rand(Gamma(d.alpha, d.beta))
+mean(d::InvertedGamma) = d.shape > 1. ? (1. / d.scale) / (d.shape - 1.) : error("Expectation only defined if shape > 1")
+var(d::InvertedGamma) = d.shape > 2. ? (1. / d.scale)^2 / ((d.shape - 1.)^2 * (d.shape - 2.)) : error("Variance only defined if shape > 2")
+function rand(d::InvertedGamma)
+   1. / rand(Gamma(d.shape, d.scale))
+end
 function rand!(d::InvertedGamma, A::Array{Float64})
-    gammas = rand!(Gamma(d.alpha, d.beta), A)
-    1./A
+    A = rand!(Gamma(d.shape, d.scale), A)
+    1. / A
 end
 insupport(d::InvertedGamma, x::Number) = real_valued(x) && isfinite(x) && 0 <= x
 function logpdf(d::InvertedGamma, x::Real)
-    (d.alpha * log(d.beta)) - lgamma(d.alpha) - ((d.alpha + 1) * log(x)) - (d.beta / x)
+    -(d.shape * log(d.scale)) - lgamma(d.shape) - ((d.shape + 1) * log(x)) - 1./(d.scale * x)
 end
 function pdf(d::InvertedGamma, x::Real)
     exp(logpdf(d, x))
 end
 function cdf(d::InvertedGamma, x::Real)
-  1-cdf(Gamma(d.alpha,1),d.beta/x)
+    1. - cdf(Gamma(d.shape, d.scale), 1./x)
 end
-modes(d::InvertedGamma) = [d.beta / (d.alpha + 1)]
-## TODO: add quantile function
+function quantile(d::InvertedGamma, p::Real)
+    1. / quantile(Gamma(d.shape, d.scale), 1 - p)
+end
+modes(d::InvertedGamma) = [(1./d.scale) / (d.shape + 1)]
 
 immutable Geometric <: DiscreteUnivariateDistribution
     # In the form of # of failures before the first success


### PR DESCRIPTION
This adds the random number generation, pdf, cdf, and quantile functions for InvertedGamma random variables.  This is my first module hack so I'm not entirely sure how to run the tests, but I've manually compared to the igamma methods in R's pscl package and it all checks out.  Comments welcome...
