### PR TITLE
Fixes for kde

### DIFF
--- a/src/kde.jl
+++ b/src/kde.jl
@@ -50,7 +50,7 @@ function kde(data::Vector, npoints::Integer)
     # Find transform of KDE by convolving grid with FT of kernel
     # Hardcodes a Gaussian kernel
     for j = 2:length(ft)
-        ft[j] *= exp(-fac1 * j^2)
+        ft[j] *= exp(-fac1 * (j-1)^2)
     end
 
     # Invert the Fourier transform to get the KDE


### PR DESCRIPTION
This fixes #29
- Switches to using `rfft` and `irfft`, which removes some redundant operations.
- Fixes the interlacing and integration problems.
