### PR TITLE
move functions inside module

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -1866,8 +1866,6 @@ include("show.jl")
 include("fit.jl")
 
                   
-end  #module
-
 function getEndpoints(distr::UnivariateDistribution, epsilon::Real)
     (left,right) = map(x -> quantile(distr,x), (0,1))
     leftEnd = left!=-Inf ? left : quantile(distr, epsilon)
@@ -1901,3 +1899,5 @@ end
 function KL(P::UnivariateDistribution, Q::UnivariateDistribution)
     expectation(P, x -> log(pdf(P,x)/pdf(Q,x)))
 end
+
+end  #module


### PR DESCRIPTION
Some functions were defined outside the module, while the types they operate on were defined inside the module. As a result, Distributions.jl fails to compile 

``` jlcon
julia> using Distributions
ERROR: UnivariateDistribution not defined
 in include_from_node1 at loading.jl:92
 in reload_path at loading.jl:112
 in require at loading.jl:48
at /Users/aviks/.julia/Distributions/src/Distributions.jl:1876
```
