### PR TITLE
Add travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: cpp
+compiler: 
+    - gcc
+notifications:
+    email: false
+before_install:
+    - sudo apt-get update -qq -y
+    - sudo apt-get install zlib1g-dev
+    - sudo add-apt-repository ppa:staticfloat/julia-deps -y
+    - sudo add-apt-repository ppa:staticfloat/julianightlies -y
+    - sudo apt-get update -qq -y
+    - sudo apt-get install patchelf gfortran llvm-3.2-dev libsuitesparse-dev libncurses5-dev libopenblas-dev liblapack-dev libarpack2-dev libfftw3-dev libgmp-dev libpcre3-dev libunwind7-dev libreadline-dev libdouble-conversion-dev libopenlibm-dev -y
+    - sudo apt-get install julia
+    - git config --global user.name "Dummy Travis User"
+    - git config --global user.email "travis@example.net"
+script:
+    - julia -e 'versioninfo(); Pkg.init();'
+    - mkdir -p ~/.julia/Distributions
+    - cp -R ./* ~/.julia/Distributions/
+    - julia ~/.julia/Distributions/test/Distributions.jl
+    - julia ~/.julia/Distributions/test/Wisharts.jl


### PR DESCRIPTION
This pull request adds a travis configuration. 

Prior to merging this in, someone with commit access to JuliaStats/Distributions should enable the integration at https://travis-ci.org/

An example of a successful build with this configuration, see https://travis-ci.org/aviks/Distributions.jl .

This should hopefully catch some of the minor issues we've seen today. 
