### PR TITLE
Fix InexactError() in Constructor of Categorical

### DIFF
--- a/src/univariate/categorical.jl
+++ b/src/univariate/categorical.jl
@@ -2,6 +2,7 @@ immutable Categorical <: DiscreteUnivariateDistribution
     prob::Vector{Float64}
     drawtable::DiscreteDistributionTable
     function Categorical{T <: Real}(p::Vector{T})
+        p = convert(Vector{FloatingPoint},p)
         if length(p) <= 1
             error("Categorical: there must be at least two categories")
         end


### PR DESCRIPTION
Fix InexactError() in Constructor of Categorical if called with Vector{Integer}

fixes Issue #72
