### PR TITLE
Huffman coding tree for sampling discrete vars

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -127,6 +127,8 @@ import Base.show, Base.sprand
 import Stats.kurtosis, Stats.skewness
 
 include("drawtable.jl")
+include("huffman.jl")
+include("alias.jl")
 include("tvpack.jl")
 
 abstract Distribution

--- a/src/alias.jl
+++ b/src/alias.jl
@@ -1,0 +1,42 @@
+immutable AliasTable
+    accept::Vector{Float64}
+    alias::Vector{Int}
+end
+
+function AliasTable(probs)
+
+    n = length(probs)
+    accept = float64(probs*n)
+
+    alias = Array(Int,n)
+    larges = Array(Int,0)
+    smalls = Array(Int,0)
+
+    for i = 1:n
+        accept[i] > 1.0 ? push!(larges,i) : push!(smalls,i)
+    end
+    while !isempty(larges) && !isempty(smalls)
+        s = pop!(smalls)
+        l = pop!(larges)
+        alias[s] = l
+        accept[l] = (accept[l] - 1.0) + accept[s]
+        if accept[l] > 1
+            push!(larges,l)
+        else
+            push!(smalls,l)
+        end
+    end
+
+    # this loop should be redundant, except for rounding
+    for s = smalls
+        accept[s] = 1.0
+    end
+
+    AliasTable(accept,alias)
+end
+
+function rand(a::AliasTable)
+    i = rand(1:length(a.accept))
+    u = rand()
+    u < a.accept[i] ? i : a.alias[i]
+end

--- a/src/drawtable.jl
+++ b/src/drawtable.jl
@@ -60,7 +60,7 @@ function DiscreteDistributionTable{T <: Real}(probs::Vector{T})
 	return DiscreteDistributionTable(table, bounds)
 end
 
-function draw(table::DiscreteDistributionTable)
+function rand(table::DiscreteDistributionTable)
 	# 64^9 - 1 == 0x003fffffffffffff
 	i = rand(1:(64^9 - 1))
 	# if i == 64^9

--- a/src/huffman.jl
+++ b/src/huffman.jl
@@ -1,0 +1,73 @@
+# Constructs a Huffman coding tree for efficiently generating discrete random
+# variables by relative weights.  
+
+# Maximum granularity is 1/float64(typemax(Uint64)) = 5.4-20, but also
+# supports non-base2 divisions via rejection sampling.
+
+import Base.isless, Base.show, Base.getindex, Base.rand
+
+abstract HuffmanNode{T}
+
+immutable HuffmanLeaf{T} <: HuffmanNode{T}
+    value::T
+    weight::Uint64
+end
+
+immutable HuffmanBranch{T} <: HuffmanNode{T}
+    left::HuffmanNode{T}
+    right::HuffmanNode{T}
+    weight::Uint64
+end
+HuffmanBranch{T}(ha::HuffmanNode{T},hb::HuffmanNode{T}) = HuffmanBranch(ha, hb, ha.weight + hb.weight)
+
+isless{T}(ha::HuffmanNode{T}, hb::HuffmanNode{T}) = isless(ha.weight,hb.weight)
+
+show{T}(io::IO, t::HuffmanNode{T}) = show(io,typeof(t))
+
+function getindex{T}(h::HuffmanBranch{T},u::Uint64) 
+    while isa(h,HuffmanBranch{T})
+        if u < h.left.weight
+            h = h.left
+        else 
+            u -= h.left.weight
+            h = h.right
+        end
+    end
+    h.value
+end
+
+# build the huffman tree
+# could be slightly more efficient using a Deque.
+function huffman{T}(values::AbstractVector{T},weights::AbstractVector{Uint64})
+    leafs = [HuffmanLeaf{T}(values[i],weights[i]) for i = 1:length(weights)]
+    sort!(leafs,Base.Sort.Reverse)
+    
+    branches = Array(HuffmanBranch{T},0)
+        
+    while !isempty(leafs) || length(branches) > 1
+        left = isempty(branches) || (!isempty(leafs) && first(leafs) < first(branches)) ? pop!(leafs) : pop!(branches)
+        right = isempty(branches) || (!isempty(leafs) && first(leafs) < first(branches)) ? pop!(leafs) : pop!(branches)
+        unshift!(branches,HuffmanBranch(left,right))
+    end
+    
+    pop!(branches)    
+end
+
+function rand{T}(h::HuffmanNode{T})
+    w = h.weight
+    # generate uniform Uint64 objects on the range 0:(w-1)
+    # unfortunately we can't use Range objects, as they don't have sufficient length
+    u = rand(Uint64)
+    if (w & (w-1)) == 0
+        # power of 2
+        u = u & (w-1)
+    else
+        m = typemax(Uint64)
+        lim = m - (rem(m,w)+1)
+        while u > lim
+            u = rand(Uint64)
+        end
+        u = rem(u,w)
+    end
+    h[u]
+end

--- a/src/mixturemodel.jl
+++ b/src/mixturemodel.jl
@@ -2,7 +2,7 @@ immutable MixtureModel <: Distribution
     components::Vector # Vector should be able to contain any type of
                        # distribution with comparable support
     probs::Vector{Float64}
-    drawtable::DiscreteDistributionTable
+    aliastable::AliasTable
     function MixtureModel(c::Vector, p::Vector{Float64})
         if length(c) != length(p)
             error("components and probs must have the same number of elements")
@@ -14,7 +14,7 @@ immutable MixtureModel <: Distribution
             end
             sump += p[i]
         end
-        table = DiscreteDistributionTable(p)
+        table = AliasTable(p)
         new(c, p ./ sump, table)
     end
 end
@@ -36,7 +36,7 @@ function pdf(d::MixtureModel, x::Any)
 end
 
 function rand(d::MixtureModel)
-    i = draw(d.drawtable)
+    i = rand(d.aliastable)
     return rand(d.components[i])
 end
 

--- a/src/multivariate/multinomial.jl
+++ b/src/multivariate/multinomial.jl
@@ -1,7 +1,7 @@
 immutable Multinomial <: DiscreteMultivariateDistribution
     n::Int
     prob::Vector{Float64}
-    drawtable::DiscreteDistributionTable
+    aliastable::AliasTable
     function Multinomial{T <: Real}(n::Integer, p::Vector{T})
         p = float(p)
         if n <= 0
@@ -17,7 +17,7 @@ immutable Multinomial <: DiscreteMultivariateDistribution
         for i in 1:length(p)
             p[i] /= sump
         end
-        new(int(n), p, DiscreteDistributionTable(p))
+        new(int(n), p, AliasTable(p))
     end
 end
 
@@ -91,7 +91,7 @@ end
 
 function rand!(d::Multinomial, x::Vector)
     for itr in 1:d.n
-        i = draw(d.drawtable)
+        i = rand(d.aliastable)
         x[i] += 1
     end
     return x

--- a/src/univariate/categorical.jl
+++ b/src/univariate/categorical.jl
@@ -1,13 +1,13 @@
 immutable Categorical <: DiscreteUnivariateDistribution
     prob::Vector{Float64}
-    drawtable::DiscreteDistributionTable
+    aliastable::AliasTable
     function Categorical{T <: Real}(p::Vector{T})
         length(p) > 1 || error("Categorical: there must be at least two categories")
         pv = T <: Float64 ? copy(p) : float64(p)
         all(pv .>= 0.) || error("Categorical: probabilities must be non-negative")
         sump = sum(pv); sump > 0. || error("Categorical: sum(p) = 0.")
         pv ./= sump
-        new(pv, DiscreteDistributionTable(pv))
+        new(pv, AliasTable(pv))
     end
 end
 
@@ -78,7 +78,7 @@ modes(d::Categorical) = [indmax(d.prob)]
 
 pdf(d::Categorical, x::Real) = !insupport(d, x) ? 0.0 : d.prob[x]
 
-rand(d::Categorical) = draw(d.drawtable)
+rand(d::Categorical) = rand(d.aliastable)
 
 function skewness(d::Categorical)
     m = mean(d)

--- a/test/discrete-perf.jl
+++ b/test/discrete-perf.jl
@@ -1,0 +1,44 @@
+using Distributions
+
+n = 1_000_000
+p = fill(1/n,n)
+pu = fill(uint(1),n)
+
+println("Set-up condensed table")
+d = Distributions.DiscreteDistributionTable(p)
+gc()
+@time d = Distributions.DiscreteDistributionTable(p)
+
+println("Set-up Huffman tree")
+h = Distributions.huffman(1:length(pu),pu)
+gc()
+@time h = Distributions.huffman(1:length(pu),pu)
+
+println("Set-up alias table")
+a = Distributions.AliasTable(p)
+gc()
+@time a = Distributions.AliasTable(p)
+
+function runsample(d,N)
+    x = Array(Int,N)
+    for i = 1:N
+        x[i] = rand(d) 
+    end
+    x
+end
+
+
+println("Sample condensed table")
+x = runsample(d,10)
+gc()
+@time x = runsample(d,1_000_000)
+
+println("Sample Huffman tree")
+x = runsample(h,10)
+gc()
+@time x = runsample(h,1_000_000)
+
+println("Sample alias table")
+x = runsample(a,10)
+gc()
+@time x = runsample(a,1_000_000)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,14 +1,20 @@
 probs = [0.2245, 0.1271, 0.3452, 0.3032]
-table = Distributions.DiscreteDistributionTable(probs)
-Distributions.draw(table)
+drawtable = Distributions.DiscreteDistributionTable(probs)
+rand(drawtable)
 
-N = 1_000_000
-results = Array(Int64, N)
-for i in 1:N
-	results[i] = Distributions.draw(table)
+aliastable = Distributions.AliasTable(probs)
+rand(aliastable)
+
+for table = [drawtable,aliastable]
+
+    N = 1_000_000
+    results = Array(Int64, N)
+    for i in 1:N
+	results[i] = rand(table)
+    end
+
+    @assert abs(sum(results .== 1) / N - probs[1]) < 0.1
+    @assert abs(sum(results .== 2) / N - probs[2]) < 0.1
+    @assert abs(sum(results .== 3) / N - probs[3]) < 0.1
+    @assert abs(sum(results .== 4) / N - probs[4]) < 0.1
 end
-
-@assert abs(sum(results .== 1) / N - probs[1]) < 0.1
-@assert abs(sum(results .== 2) / N - probs[2]) < 0.1
-@assert abs(sum(results .== 3) / N - probs[3]) < 0.1
-@assert abs(sum(results .== 4) / N - probs[4]) < 0.1


### PR DESCRIPTION
This adds a Huffman coding tree for simulating high-dimensional discrete variables (which is theoretically the optimal way to do it) in an attempt to fix #70. At the moment it is still a bit slower than the current alias table implementation in simulating random variables (which is why I haven't "plugged it in" yet), but it is much, much quicker in setting up. 

It also has some other desirable features:
- it has a larger state-space: the minimum "granularity" is 1/float64(typemax(Uint64)) = 5.4-20.
- it can handle non-base2 divisions via rejection sampling.
