### PR TITLE
Add insupport methods for distribution types when appropriate

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -72,12 +72,13 @@ invlogcdf(d::Distribution, lp::Real) = quantile(d, exp(lp))
 insupport(d::Distribution, x) = false
 
 function insupport(d::UnivariateDistribution, X::Array)
-    for el in X
-        if !insupport(d, el)
-            return false
-        end
-    end
-    return true
+    for x in X; insupport(d, x) || return false; end
+    true
+end
+
+function insupport(t::DataType, X::Array)
+    for x in X; insupport(t, x) || return false; end
+    true
 end
 
 function insupport(d::MultivariateDistribution, X::Matrix)

--- a/src/univariate/arcsine.jl
+++ b/src/univariate/arcsine.jl
@@ -17,13 +17,8 @@ end
 # calculated using higher-precision arithmetic 
 entropy(d::Arcsine) = -0.24156447527049044469
 
-function insupport(d::Arcsine, x::Real)
-    if 0 <= x <= 1.0
-        return true
-    else
-        return false
-    end
-end
+insupport(d::Arcsine, x::Real) = zero(x) <= x <= one(x)
+insupport(::Type{Arcsine}, x::Real) = zero(x) <= x <= one(x)
 
 kurtosis(d::Arcsine) = -1.5
 

--- a/src/univariate/bernoulli.jl
+++ b/src/univariate/bernoulli.jl
@@ -32,7 +32,8 @@ function entropy(d::Bernoulli)
     p0 == 0. || p0 == 1. ? 0. : -(p0 * log(p0) + p1 * log(p1))
 end
 
-insupport(d::Bernoulli, x::Number) = (x == 0) || (x == 1)
+insupport(::Bernoulli, x::Real) = (x == 0) || (x == 1)
+insupport(::Type{Bernoulli}, x::Real) = (x == 0) || (x == 1)
 
 mean(d::Bernoulli) = d.p1
 

--- a/src/univariate/beta.jl
+++ b/src/univariate/beta.jl
@@ -23,7 +23,8 @@ function entropy(d::Beta)
     return o
 end
 
-insupport(d::Beta, x::Number) = isreal(x) && 0.0 < x < 1.0
+insupport(::Beta, x::Real) = zero(x) < x < one(x)
+insupport(::Type{Beta}, x::Real) = zero(x) < x < one(x)
 
 function kurtosis(d::Beta)
     α, β = d.alpha, d.beta

--- a/src/univariate/betaprime.jl
+++ b/src/univariate/betaprime.jl
@@ -20,7 +20,8 @@ BetaPrime() = BetaPrime(1.0, 1.0)
 
 cdf(d::BetaPrime, q::Real) = inc_beta(q / 1.0 + q, d.alpha, d.beta)
 
-insupport(d::BetaPrime, x::Number) = isreal(x) && x > 0.0 ? true : false
+insupport(::BetaPrime, x::Real) = zero(x) < x
+insupport(::Type{BetaPrime}, x::Real) = zero(x) < x
 
 function mean(d::BetaPrime)
     if d.beta > 1.0

--- a/src/univariate/cauchy.jl
+++ b/src/univariate/cauchy.jl
@@ -17,7 +17,8 @@ Cauchy() = Cauchy(0.0, 1.0)
 
 entropy(d::Cauchy) = log(d.scale) + log(4.0 * pi)
 
-insupport(d::Cauchy, x::Number) = isreal(x) && isfinite(x)
+insupport(::Cauchy, x::Real) = isfinite(x)
+insupport(::Type{Cauchy}, x::Real) = isfinite(x)
 
 kurtosis(d::Cauchy) = NaN
 

--- a/src/univariate/chi.jl
+++ b/src/univariate/chi.jl
@@ -6,17 +6,12 @@ end
 
 cdf(d::Chi, x::Real) = regularized_gamma(d.df / 2.0, x^2 / 2.0)
 
-function mean(d::Chi)
-	return sqrt(2.0) * gamma((d.df + 1.0) / 2.0) / gamma(d.df / 2.0)
-end
+mean(d::Chi) = sqrt(2.0) * gamma((d.df + 1.0) / 2.0) / gamma(d.df / 2.0)
 
-function modes(d::Chi)
-	if d.df < 1.0
-		error("Modes undefined for k < 1")
-	else
-		return [sqrt(d.df - 1)]
-	end
-end
+insupport(::Chi, x::Real) = zero(x) <= x < Inf
+insupport(::Type{Chi}, x::Real) = zero(x) <= x < Inf
+
+modes(d::Chi) = d.df >= 1.0 ? [sqrt(d.df - 1)] : error("Modes undefined for k < 1")
 
 var(d::Chi) = d.df - mean(d)^2
 

--- a/src/univariate/chisq.jl
+++ b/src/univariate/chisq.jl
@@ -17,7 +17,8 @@ function entropy(d::Chisq)
     return x
 end
 
-insupport(d::Chisq, x::Number) = isreal(x) && isfinite(x) && 0.0 <= x
+insupport(::Chisq, x::Real) = zero(x) <= x < Inf
+insupport(::Type{Chisq}, x::Real) = zero(x) <= x < Inf
 
 kurtosis(d::Chisq) = 12.0 / d.df
 

--- a/src/univariate/cosine.jl
+++ b/src/univariate/cosine.jl
@@ -18,13 +18,8 @@ end
 
 entropy(d::Cosine) = log(4.0 * pi) - 1.0
 
-function insupport(d::Cosine, x::Real)
-    if 0 <= x <= 1.0
-        return true
-    else
-        return false
-    end
-end
+insupport(::Cosine, x::Real) = zero(x) <= x <= one(x)
+insupport(::Type{Cosine}, x::Real) = zero(x) <= x <= one(x)
 
 kurtosis(d::Cosine) = -1.5
 
@@ -37,13 +32,7 @@ median(d::Cosine) = 0.5
 
 modes(d::Cosine) = [0.5]
 
-function pdf(d::Cosine, x::Number)
-    if 0.0 <= x <= 1.0
-        return 0.5 * cos(x)
-    else
-        return 0.0
-    end
-end
+pdf(d::Cosine, x::Number) =  0 <= x <= 1 ? 0.5 * cos(x) : 0.0
 
 quantile(d::Cosine, p::Real) = asin(2.0 * p - 1.0)
 

--- a/src/univariate/erlang.jl
+++ b/src/univariate/erlang.jl
@@ -23,7 +23,8 @@ cdf(d::Erlang, x::Real) = cdf(d.nested_gamma, x)
 
 entropy(d::Erlang) = entropy(d.nested_gamma)
 
-insupport(d::Erlang, x::Number) = isreal(x) && isfinite(x) && 0.0 <= x
+insupport(::Erlang, x::Real) = zero(x) <= x < Inf
+insupport(::Type{Erlang}, x::Real) = zero(x) <= x < Inf
 
 kurtosis(d::Erlang) = kurtosis(d.nested_gamma)
 

--- a/src/univariate/exponential.jl
+++ b/src/univariate/exponential.jl
@@ -48,7 +48,8 @@ end
 
 entropy(d::Exponential) = 1.0 - log(1.0 / d.scale)
 
-insupport(d::Exponential, x::Number) = isreal(x) && isfinite(x) && 0.0 <= x
+insupport(::Exponential, x::Real) = zero(x) <= x < Inf
+insupport(::Type{Exponential}, x::Real) = zero(x) <= x < Inf
 
 kurtosis(d::Exponential) = 6.0
 

--- a/src/univariate/fdist.jl
+++ b/src/univariate/fdist.jl
@@ -12,7 +12,8 @@ end
 
 @_jl_dist_2p FDist f
 
-insupport(d::FDist, x::Number) = isreal(x) && isfinite(x) && 0.0 <= x
+insupport(::FDist, x::Number) = zero(x) <= x < Inf
+insupport(::Type{FDist}, x::Number) = zero(x) <= x < Inf
 
 mean(d::FDist) = 2.0 < d.ddf ? d.ddf / (d.ddf - 2.0) : NaN
 

--- a/src/univariate/gamma.jl
+++ b/src/univariate/gamma.jl
@@ -21,7 +21,8 @@ function entropy(d::Gamma)
     return x
 end
 
-insupport(d::Gamma, x::Number) = isreal(x) && isfinite(x) && 0.0 <= x
+insupport(::Gamma, x::Real) = zero(x) <= x < Inf
+insupport(::Type{Gamma}, x::Real) = zero(x) <= x < Inf
 
 kurtosis(d::Gamma) = 6.0 / d.shape
 

--- a/src/univariate/geometric.jl
+++ b/src/univariate/geometric.jl
@@ -23,7 +23,8 @@ end
 
 entropy(d::Geometric) = (-xlogx(1.0 - d.prob) - xlogx(d.prob)) / d.prob
 
-insupport(d::Geometric, x::Number) = isinteger(x) && 0.0 <= x
+insupport(::Geometric, x::Real) = isinteger(x) && zero(x) <= x
+insupport(::Type{Geometric}, x::Real) = isinteger(x) && zero(x) <= x
 
 kurtosis(d::Geometric) = 6.0 + d.prob^2 / (1.0 - d.prob)
 

--- a/src/univariate/gumbel.jl
+++ b/src/univariate/gumbel.jl
@@ -19,7 +19,8 @@ logcdf(d::Gumbel, x::Real) = -exp((d.mu - x) / d.beta)
 
 entropy(d::Gumbel) = log(d.beta) - digamma(1.0) + 1.0
 
-insupport(d::Gumbel, x::Number) = isreal(x) && isfinite(x)
+insupport(::Gumbel, x::Real) = isfinite(x)
+insupport(::Type{Gumbel}, x::Real) = isfinite(x)
 
 kurtosis(d::Gumbel) = 2.4
 

--- a/src/univariate/invertedgamma.jl
+++ b/src/univariate/invertedgamma.jl
@@ -27,7 +27,8 @@ function entropy(d::InvertedGamma)
     return a + log(b) + lgamma(a) - (1.0 + a) * digamma(a)
 end
 
-insupport(d::InvertedGamma, x::Number) = isreal(x) && isfinite(x) && 0 <= x
+insupport(::InvertedGamma, x::Real) = zero(x) <= x < Inf
+insupport(::Type{InvertedGamma}, x::Real) = zero(x) <= x < Inf
 
 function kurtosis(d::InvertedGamma)
     a = d.shape

--- a/src/univariate/laplace.jl
+++ b/src/univariate/laplace.jl
@@ -22,7 +22,8 @@ end
 
 entropy(d::Laplace) = log(2.0 * d.scale) + 1.0
 
-insupport(d::Laplace, x::Number) = isreal(x) && isfinite(x)
+insupport(d::Laplace, x::Real) = isfinite(x)
+insupport(d::Type{Laplace}, x::Real) = isfinite(x)
 
 kurtosis(d::Laplace) = 3.0
 

--- a/src/univariate/logistic.jl
+++ b/src/univariate/logistic.jl
@@ -2,22 +2,19 @@ immutable Logistic <: ContinuousUnivariateDistribution
     location::Real
     scale::Real
     function Logistic(l::Real, s::Real)
-    	if s > 0.0
-    		new(float64(l), float64(s))
-    	else
-    		error("scale must be positive")
-    	end
-	end
+    	s > zero(s) || error("scale must be positive")
+    	new(float64(l), float64(s))
+    end
+    Logistic(l::Real) = new(float64(l), 1.0)
+    Logistic() = new(0.0, 1.0)
 end
-
-Logistic(l::Real) = Logistic(l, 1.0)
-Logistic()  = Logistic(0.0, 1.0)
 
 @_jl_dist_2p Logistic logis
 
 entropy(d::Logistic) = log(d.scale) + 2.0
 
-insupport(d::Logistic, x::Number) = isreal(x) && isfinite(x)
+insupport(::Logistic, x::Real) = isfinite(x)
+insupport(::Type{Logistic}, x::Real) = isfinite(x)
 
 kurtosis(d::Logistic) = 1.2
 

--- a/src/univariate/lognormal.jl
+++ b/src/univariate/lognormal.jl
@@ -17,7 +17,8 @@ LogNormal() = LogNormal(0.0, 1.0)
 
 entropy(d::LogNormal) = 0.5 + 0.5 * log(2.0 * pi * d.sdlog^2) + d.meanlog
 
-insupport(d::LogNormal, x::Number) = isreal(x) && isfinite(x) && 0 < x
+insupport(::LogNormal, x::Real) = zero(x) < x < Inf
+insupport(::Type{LogNormal}, x::Real) = zero(x) < x < Inf
 
 function kurtosis(d::LogNormal)
     return exp(4.0 * d.sdlog^2) + 2.0 * exp(3.0 * d.sdlog^2) +

--- a/src/univariate/negativebinomial.jl
+++ b/src/univariate/negativebinomial.jl
@@ -9,12 +9,8 @@ immutable NegativeBinomial <: DiscreteUnivariateDistribution
     prob::Float64
 
     function NegativeBinomial(r::Real, p::Real)
-        if p <= 0. || p > 1.
-            error("prob must be in (0, 1].")
-        end
-        if r <= 0
-            error("r must be positive.")
-        end
+        zero(p) < p <= one(p) || error("prob must be in (0, 1].")
+        zero(r) < r || error("r must be positive.")
         new(float64(r), float64(p))
     end
 
@@ -23,7 +19,8 @@ end
 
 @_jl_dist_2p NegativeBinomial nbinom
 
-insupport(d::NegativeBinomial, x::Real) = isinteger(x) && 0.0 <= x
+insupport(::NegativeBinomial, x::Real) = isinteger(x) && zero(x) <= x
+insupport(::Type{NegativeBinomial}, x::Real) = isinteger(x) && zero(x) <= x
 
 function mgf(d::NegativeBinomial, t::Real)
     r, p = d.size, d.prob

--- a/src/univariate/noncentralchisq.jl
+++ b/src/univariate/noncentralchisq.jl
@@ -12,4 +12,5 @@ end
 
 @_jl_dist_2p NoncentralChisq nchisq
 
-insupport(d::NoncentralChisq, x::Number) = isreal(x) && isfinite(x) && 0.0 < x
+insupport(::NoncentralChisq, x::Real) = zero(x) < x < Inf
+insupport(::Type{NoncentralChisq}, x::Real) = zero(x) < x < Inf

--- a/src/univariate/noncentralf.jl
+++ b/src/univariate/noncentralf.jl
@@ -13,4 +13,5 @@ end
 
 @_jl_dist_3p NoncentralF nf
 
-insupport(d::NoncentralF, x::Number) = isreal(x) && isfinite(x) && 0.0 <= x
+insupport(::NoncentralF, x::Number) = zero(x) <= x < Inf
+insupport(::Type{NoncentralF}, x::Number) = zero(x) <= x < Inf

--- a/src/univariate/noncentralt.jl
+++ b/src/univariate/noncentralt.jl
@@ -2,14 +2,12 @@ immutable NoncentralT <: ContinuousUnivariateDistribution
     df::Float64
     ncp::Float64
     function NonCentralT(d::Real, nc::Real)
-    	if d >= 0.0 && nc >= 0.0
-    		new(float64(d), float64(nc))
-    	else
-    		error("df and ncp must be non-negative")
-    	end
+    	d >= zero(d) && nc >= zero(nc) || error("df and ncp must be non-negative")
+        new(float64(d), float64(nc))
     end
 end
 
 @_jl_dist_2p NoncentralT nt
 
-insupport(d::NoncentralT, x::Number) = isreal(x) && isfinite(x)
+insupport(::NoncentralT, x::Real) = isfinite(x)
+insupport(::Type{NoncentralT}, x::Real) = isfinite(x)

--- a/src/univariate/normal.jl
+++ b/src/univariate/normal.jl
@@ -2,11 +2,8 @@ immutable Normal <: ContinuousUnivariateDistribution
     mean::Float64
     std::Float64
     function Normal(mu::Real, sd::Real)
-    	if sd > 0.0
-    		new(float64(mu), float64(sd))
-    	else
-    		error("std must be positive")
-    	end
+    	sd > zero(sd) || error("std must be positive")
+    	new(float64(mu), float64(sd))
     end
 end
 

--- a/src/univariate/pareto.jl
+++ b/src/univariate/pareto.jl
@@ -2,16 +2,13 @@ immutable Pareto <: ContinuousUnivariateDistribution
     scale::Float64
     shape::Float64
     function Pareto(sc::Real, sh::Real)
-        if sc > 0.0 && sh > 0.0
-            new(float64(sc), float64(sh))
-        else
-            error("shape and scale must be positive")
-        end
+        sc > zero(sc) && sh > zero(sh) || error("shape and scale must be positive")
+        new(float64(sc), float64(sh))
     end
+    Pareto() = new(1.0, 1.0)
 end
 
 Pareto(scale::Real) = Pareto(scale, 1.0)
-Pareto() = Pareto(1.0, 1.0)
 
 cdf(d::Pareto, q::Real) = q >= d.scale ? 1.0 - (d.scale / q)^d.shape : 0.0
 

--- a/src/univariate/poisson.jl
+++ b/src/univariate/poisson.jl
@@ -1,15 +1,10 @@
 immutable Poisson <: DiscreteUnivariateDistribution
     lambda::Float64
     function Poisson(l::Real)
-    	if l > 0.0
-    		new(float64(l))
-    	else
-    		error("lambda must be positive")
-    	end
+    	l > zero(l) ? new(float64(l)) : error("lambda must be positive")
     end
+    Poisson() = new(1.0)
 end
-
-Poisson() = Poisson(1.0)
 
 @_jl_dist_1p Poisson pois
 
@@ -29,7 +24,8 @@ function entropy(d::Poisson)
     end
 end
 
-insupport(d::Poisson, x::Number) = isinteger(x) && 0.0 <= x
+insupport(::Poisson, x::Real) = isinteger(x) && zero(x) <= x
+insupport(::Type{Poisson}, x::Real) = isinteger(x) && zero(x) <= x
 
 kurtosis(d::Poisson) = 1.0 / d.lambda
 

--- a/src/univariate/rayleigh.jl
+++ b/src/univariate/rayleigh.jl
@@ -7,21 +7,17 @@
 immutable Rayleigh <: ContinuousUnivariateDistribution
     scale::Float64
     function Rayleigh(s::Real)
-        if s > 0.0
-            new(float64(s))
-        else
-            error("scale must be positive")
-        end
+        s > zero(s) ? new(float64(s)) : error("scale must be positive")
     end
+    Rayleigh() = new(1.0)
 end
-
-Rayleigh() = Rayleigh(1.0)
 
 cdf(d::Rayleigh, x::Real) = 1.0 - exp(-x^2 / (2.0 * d.scale^2))
 
 entropy(d::Rayleigh) = 1.0 + log(d.scale) - log(sqrt(2.0)) - digamma(1.0) / 2.0
 
-insupport(d::Rayleigh, x::Number) = isreal(x) && isfinite(x) && 0.0 < x
+insupport(::Rayleigh, x::Real) = zero(x) < x < Inf
+insupport(::Type{Rayleigh}, x::Real) = zero(x) < x < Inf
 
 kurtosis(d::Rayleigh) = -(6.0 * pi^2 - 24.0 * pi + 16.0) / (4.0 - pi)^2
 

--- a/src/univariate/skellam.jl
+++ b/src/univariate/skellam.jl
@@ -4,38 +4,31 @@ immutable Skellam <: DiscreteUnivariateDistribution
     Skellam(m1::Real, m2::Real) = new(float64(m1), float64(m2))
 end
 
-insupport(d::Skellam, k::Real) = isinteger(k)
+insupport(::Skellam, k::Real) = isinteger(k)
+insupport(::Type{Skellam}, k::Real) = isinteger(k)
 
 kurtosis(d::Skellam) = 1.0 / (d.mu1 + d.mu2)
 
 mean(d::Skellam) = d.mu1 - d.mu2
 
 function mgf(d::Skellam, t::Real)
-    return exp(-(d.mu1 + d.mu2) + d.mu1 * exp(t) + d.mu2 * exp(-t))
+    exp(-(d.mu1 + d.mu2) + d.mu1 * exp(t) + d.mu2 * exp(-t))
 end
 
 function cf(d::Skellam, t::Real)
-    return exp(-(d.mu1 + d.mu2) + d.mu1 * exp(im * t) + d.mu2 * exp(im * -t))
+    exp(-(d.mu1 + d.mu2) + d.mu1 * exp(im * t) + d.mu2 * exp(im * -t))
 end
 
 function pdf(d::Skellam, k::Real)
-    if !isinteger(k)
-        return 0.0
-    else
-        return exp(-(d.mu1 + d.mu2)) *
-               (d.mu1 / d.mu2)^(k / 2.0) *
-               real(besseli(k, 2.0 * sqrt(d.mu1 * d.mu2)))
-    end
+    isinteger(k) || return 0.0
+    exp(-(d.mu1 + d.mu2)) * (d.mu1 / d.mu2)^(k / 2.0) *
+        real(besseli(k, 2.0 * sqrt(d.mu1 * d.mu2)))
 end
 
 function logpdf(d::Skellam, k::Real)
-    if !isinteger(k)
-        return 0.0
-    else
-        return -(d.mu1 + d.mu2) +
-               (k / 2.0) * log(d.mu1) - log(d.mu2) +
-               log(real(besseli(k, 2.0 * sqrt(d.mu1 * d.mu2))))
-    end
+    isinteger(k) || return 0.0
+     -(d.mu1 + d.mu2) + (k / 2.0) * log(d.mu1) - log(d.mu2) +
+           log(real(besseli(k, 2.0 * sqrt(d.mu1 * d.mu2))))
 end
 
 rand(d::Skellam) = rand(Poisson(d.mu1)) - rand(Poisson(d.mu2))

--- a/src/univariate/tdist.jl
+++ b/src/univariate/tdist.jl
@@ -1,24 +1,20 @@
 immutable TDist <: ContinuousUnivariateDistribution
     df::Float64 # non-integer degrees of freedom allowed
     function TDist(d::Real)
-    	if d > 0.0
-    		new(float64(d))
-    	else
-    		error("df must be positive")
-    	end
+    	d > zero(d) ? new(float64(d)) : error("df must be positive")
     end
 end
 
 @_jl_dist_1p TDist t
 
 function entropy(d::TDist)
-	return ((d.df + 1.0) / 2.0) *
-	       (digamma((d.df + 1.0) / 2.0) - digamma((d.df) / 2.0)) +
-	       (1.0 / 2.0) * log(d.df) +
-	       lbeta(d.df + 1.0, 1.0 / 2.0)
+    ((d.df + 1.0) / 2.0) *
+        (digamma((d.df + 1.0) / 2.0) - digamma((d.df) / 2.0)) +
+        (1.0 / 2.0) * log(d.df) + lbeta(d.df + 1.0, 1.0 / 2.0)
 end
 
-insupport(d::TDist, x::Number) = isreal(x) && isfinite(x)
+insupport(::TDist, x::Real) = isfinite(x)
+insupport(::Type{TDist}, x::Real) = isfinite(x)
 
 mean(d::TDist) = d.df > 1 ? 0.0 : NaN
 
@@ -27,16 +23,12 @@ median(d::TDist) = 0.0
 modes(d::TDist) = [0.0]
 
 function pdf(d::TDist, x::Real)
-	return 1.0 / (sqrt(d.df) * beta(0.5, 0.5 * d.df)) *
-	       (1.0 + x^2 / d.df)^(-0.5 * (d.df + 1.0))
+    1.0 / (sqrt(d.df) * beta(0.5, 0.5 * d.df)) *
+        (1.0 + x^2 / d.df)^(-0.5 * (d.df + 1.0))
 end
 
 function var(d::TDist)
-	if d.df > 2.0
-		return d.df / (d.df - 2.0)
-	elseif d.df > 1.0
-		return Inf
-	else
-		return NaN
-	end
+    d.df > 2.0 && return d.df / (d.df - 2.0)
+    d.df > 1.0 && return Inf
+    NaN
 end

--- a/src/univariate/triangular.jl
+++ b/src/univariate/triangular.jl
@@ -8,11 +8,8 @@ immutable Triangular <: ContinuousUnivariateDistribution
     location::Float64
     scale::Float64
     function Triangular(l::Real, s::Real)
-        if s > 0.0
-            new(float64(l), float64(s))
-        else
-            error("scale must be positive")
-        end
+        s > zero(s) || error("scale must be positive")
+        new(float64(l), float64(s))
     end
 end
 

--- a/src/univariate/uniform.jl
+++ b/src/univariate/uniform.jl
@@ -2,21 +2,17 @@ immutable Uniform <: ContinuousUnivariateDistribution
     a::Float64
     b::Float64
     function Uniform(a::Real, b::Real)
-	    if a < b
-	    	new(float64(a), float64(b))
-	    else
-	    	error("a < b required for range [a, b]")
-	    end
-	end
+	a < b || error("a < b required for range [a, b]")
+	new(float64(a), float64(b))
+    end
+    Uniform() = new(0.0, 1.0)
 end
-
-Uniform() = Uniform(0.0, 1.0)
 
 @_jl_dist_2p Uniform unif
 
 entropy(d::Uniform) = log(d.b - d.a)
 
-insupport(d::Uniform, x::Number) = isreal(x) && d.a <= x <= d.b
+insupport(d::Uniform, x::Real) = d.a <= x <= d.b
 
 kurtosis(d::Uniform) = -6.0 / 5.0
 

--- a/src/univariate/weibull.jl
+++ b/src/univariate/weibull.jl
@@ -2,11 +2,8 @@ immutable Weibull <: ContinuousUnivariateDistribution
     shape::Float64
     scale::Float64
     function Weibull(sh::Real, sc::Real)
-    	if 0.0 < sh && 0.0 < sc
-    		new(float64(sh), float64(sc))
-    	else
-    		error("Both shape and scale must be positive")
-    	end
+    	zero(sh) < sh && zero(sc) < sc || error("Both shape and scale must be positive")
+    	new(float64(sh), float64(sc))
     end
 end
 
@@ -27,7 +24,8 @@ function entropy(d::Weibull)
     return ((k - 1.0) / k) * -digamma(1.0) + log(l / k) + 1.0
 end
 
-insupport(d::Weibull, x::Number) = isreal(x) && isfinite(x) && 0.0 <= x
+insupport(::Weibull, x::Real) = zero(x) <= x < Inf
+insupport(::Type{Weibull}, x::Real) = zero(x) <= x < Inf
 
 function kurtosis(d::Weibull)
     λ, k = d.scale, d.shape


### PR DESCRIPTION
For many distributions the support does not depend on the parameters of the distribution. This adds methods for

``` julia
insupport(Normal, x)
```

in addition to

``` julia
insupport(Normal(), x)
```

Also many of the checks in constructors were condensed to the

``` julia
check || error("check failed")
```

or

``` julia
check ? new(args...) : error("check failed")
```

form.

Some external constructors were moved to internal constructors when possible.

Checks of the form `x > 0.0` were rewritten as `x > zero(x)` so that `x` is not converted before the check.
