### PR TITLE
Add basic location-scale family support

### DIFF
--- a/run_tests.jl
+++ b/run_tests.jl
@@ -14,7 +14,8 @@ tests = [
 	"kolmogorov",
 	"edgeworth",
 	"matrix",
-	"vonmisesfisher"]
+	"vonmisesfisher",
+	"locationscale"]
 
 println("Running tests:")
 

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -14,6 +14,7 @@ export
     Continuous,
     Distribution,
     UnivariateDistribution,
+    UnivariateLocationScaleFamily,
     MultivariateDistribution,
     MatrixDistribution,
     NonMatrixDistribution,
@@ -107,6 +108,7 @@ export
     isprobvec,     # Is a probability vector?
     kde,           # Kernel density estimator
     kurtosis,      # kurtosis of the distribution
+    location,      # location of a location-scale family
     logccdf,       # ccdf returning log-probability
     logcdf,        # cdf returning log-probability
     loglikelihood, # log probability of array of IID draws
@@ -138,6 +140,7 @@ export
     rand!,         # replacement random sampler
     sample,        # sample from a source array
     sampler,       # create a Sampler object for efficient samples
+    scale,         # scale of a location-scale family
     skewness,      # skewness of the distribution
     sprand,        # random sampler for sparse matrices
     std,           # standard deviation of distribution
@@ -278,5 +281,8 @@ include("conjugates.jl")
 include("qq.jl")
 
 include("estimators.jl")
+
+# Location-scale families
+include("locationscale.jl")
 
 end # module

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -290,4 +290,3 @@ posterior_mode(pri::Distribution, G::GenerativeFormulation, x, w) = mode(posteri
 posterior_make{D<:Distribution}(::Type{D}, θ) = D(θ) 
 fit_map{D<:Distribution}(pri::Distribution, ::Type{D}, x) = posterior_make(D, posterior_mode(pri, D, x))
 fit_map{D<:Distribution}(pri::Distribution, ::Type{D}, x, w) = posterior_make(D, posterior_mode(pri, D, x, w))
-

--- a/src/locationscale.jl
+++ b/src/locationscale.jl
@@ -1,0 +1,108 @@
+immutable UnivariateLocationScaleFamily{T <: UnivariateDistribution} <: ContinuousUnivariateDistribution
+    d::T
+    location::Float64
+    scale::Float64
+    function UnivariateLocationScaleFamily(d::T, l::Real, s::Real)
+        if s <= 0.0
+            throw(ArgumentError("Scale must be non-negative"))
+        end
+        new(d, float64(l), float64(s))
+    end
+end
+
+function UnivariateLocationScaleFamily{T <: UnivariateDistribution}(d::T, l::Real = 0.0, s::Real = 1.0)
+    UnivariateLocationScaleFamily{T}(d, l, s)
+end
+
+function cdf(d::UnivariateLocationScaleFamily, x::Real)
+    cdf(d.d, (x - d.location) / d.scale)
+end
+
+cf(d::UnivariateLocationScaleFamily) = error("Not yet implemented")
+
+entropy(d::UnivariateLocationScaleFamily) = entropy(d.d)
+
+function insupport(d::UnivariateLocationScaleFamily, x::Real)
+    insupport(d.d, (x - d.location) / d.scale)
+end
+
+kurtosis(d::UnivariateLocationScaleFamily) = error("Not yet implemented")
+
+location(d::UnivariateLocationScaleFamily) = d.location
+
+function mean(d::UnivariateLocationScaleFamily)
+    mean(d.d) * d.scale + d.location
+end
+
+function median(d::UnivariateLocationScaleFamily)
+    median(d.d) * d.scale + d.location
+end
+
+mgf(d::UnivariateLocationScaleFamily) = error("Not yet implemented")
+
+function modes(d::UnivariateLocationScaleFamily)
+    m = modes(d.d)
+    for i in 1:length(m)
+        m[i] = m[i] * d.scale + d.location
+    end
+    return m
+end
+
+function pdf(d::UnivariateLocationScaleFamily, x::Real)
+    1 / d.scale * pdf(d.d, (x - d.location) / d.scale)
+end
+
+function quantile(d::UnivariateLocationScaleFamily, p::Real)
+    quantile(d.d, p) * d.scale + d.location
+end
+
+scale(d::UnivariateLocationScaleFamily) = d.scale
+
+skewness(d::UnivariateLocationScaleFamily) = error("Not yet implemented")
+
+var(d::UnivariateLocationScaleFamily) = var(d.d) * d.scale^2
+
+function rand(d::UnivariateLocationScaleFamily)
+    rand(d.d) * d.scale + d.location
+end
+
+# Fallbacks
+location(d::ContinuousUnivariateDistribution) = 0.0
+scale(d::ContinuousUnivariateDistribution) = 1.0
+
+location(d::DiscreteUnivariateDistribution) = 0
+scale(d::DiscreteUnivariateDistribution) = 1
+
+# Relocate
+function Base.(:+)(d::UnivariateDistribution, a::Real)
+    UnivariateLocationScaleFamily(d, a)
+end
+
+function Base.(:+)(a::Real, d::UnivariateDistribution)
+    UnivariateLocationScaleFamily(d, a)
+end
+
+function Base.(:+)(d::UnivariateLocationScaleFamily, a::Real)
+    UnivariateLocationScaleFamily(d.d, location(d) + a, scale(d))
+end
+
+function Base.(:+)(a::Real, d::UnivariateLocationScaleFamily)
+    UnivariateLocationScaleFamily(d.d, location(d) + a, scale(d))
+end
+
+# Rescale
+function Base.(:*)(d::UnivariateDistribution, b::Real)
+    UnivariateLocationScaleFamily(d, 0.0, b)
+end
+
+function Base.(:*)(b::Real, d::UnivariateDistribution)
+    UnivariateLocationScaleFamily(d, 0.0, b)
+end
+
+function Base.(:*)(d::UnivariateLocationScaleFamily, b::Real)
+    UnivariateLocationScaleFamily(d.d, location(d), scale(d) * b)
+end
+
+function Base.(:*)(b::Real, d::UnivariateLocationScaleFamily)
+    UnivariateLocationScaleFamily(d.d, location(d), scale(d) * b)
+end

--- a/src/univariate/cauchy.jl
+++ b/src/univariate/cauchy.jl
@@ -41,3 +41,6 @@ function fit{T <: Real}(::Type{Cauchy}, x::Array{T})
     l, u = iqr(x)
     Cauchy(median(x), (u - l) / 2.0)
 end
+
+location(d::Cauchy) = d.location
+scale(d::Cauchy) = d.scale

--- a/src/univariate/laplace.jl
+++ b/src/univariate/laplace.jl
@@ -71,3 +71,6 @@ function fit_mle(::Type{Laplace}, x::Array)
     a = median(x)
     Laplace(a, mad(x, a))
 end
+
+location(d::Laplace) = d.location
+scale(d::Laplace) = d.scale

--- a/src/univariate/levy.jl
+++ b/src/univariate/levy.jl
@@ -47,3 +47,6 @@ end
 quantile(d::Levy, p::Real) = d.location + d.scale / (2.erfcinv(p)^2)
 
 rand(d::Levy) = d.location + 1 / rand(Normal(0.0, 1.0 / sqrt(d.scale)))^2
+
+location(d::Levy) = d.location
+scale(d::Levy) = d.scale

--- a/src/univariate/logistic.jl
+++ b/src/univariate/logistic.jl
@@ -30,3 +30,6 @@ skewness(d::Logistic) = 0.0
 std(d::Logistic) = pi * d.scale / sqrt(3.0)
 
 var(d::Logistic) = (pi * d.scale)^2 / 3.0
+
+location(d::Logistic) = d.location
+scale(d::Logistic) = d.scale

--- a/src/univariate/lognormal.jl
+++ b/src/univariate/lognormal.jl
@@ -45,3 +45,6 @@ function fit_mle{T <: Real}(::Type{LogNormal}, x::Array{T})
     lx = log(x)
     LogNormal(mean(lx), std(lx))
 end
+
+location(d::LogNormal) = d.meanlog
+scale(d::LogNormal) = d.sdlog

--- a/src/univariate/normal.jl
+++ b/src/univariate/normal.jl
@@ -207,3 +207,11 @@ function fit_mle{T<:Real}(::Type{Normal}, x::Array{T}, w::Array{Float64}; mu::Fl
     end    
 end
 
+location(d::Normal) = d.μ
+scale(d::Normal) = d.σ
+
+Base.(:+)(d::Normal, a::Real) = Normal(d.μ + a, d.σ)
+Base.(:+)(a::Real, d::Normal) = Normal(d.μ + a, d.σ)
+
+Base.(:*)(d::Normal, b::Real) = Normal(d.μ, b * d.σ)
+Base.(:*)(b::Real, d::Normal) = Normal(d.μ, b * d.σ)

--- a/src/univariate/triangular.jl
+++ b/src/univariate/triangular.jl
@@ -83,3 +83,6 @@ function skewness(d::Triangular)
 end
 
 var(d::Triangular) = d.scale^2 / 6.0
+
+location(d::Triangular) = d.location
+scale(d::Triangular) = d.scale

--- a/test/locationscale.jl
+++ b/test/locationscale.jl
@@ -1,0 +1,20 @@
+using Base.Test
+using Distributions
+
+dpairs = {(UnivariateLocationScaleFamily(Normal(), 2.0, 2.0), Normal(2.0, 2.0)),
+          (UnivariateLocationScaleFamily(Uniform(), 1.0, 2.0), Uniform(1.0, 3.0))}
+
+for (d1, d2) in dpairs
+    for x in -5.0:0.5:5.0
+        @test_approx_eq pdf(d1, x) pdf(d2, x)
+        @test_approx_eq cdf(d1, x) cdf(d2, x)
+    end
+
+    for p in 0.1:0.1:0.9
+        @test_approx_eq quantile(d1, p) quantile(d2, p)
+    end
+
+    # Do a KS-test here
+    # rand(d1, 10000)
+    # rand(d2, 10000)
+end


### PR DESCRIPTION
This adds an initial draft of support for location-scale families of univariate distribution. This makes it possible to rescale and relocate univariate distributions using scalar arithmetic, giving things like `d1 = Normal(0, 1) + 3` and `d2 = 3 * Uniform(0, 1) + 11`.

The basic principle is simple: unless there is a clear way in which changing the location or scale of a distribution produces another distribution of the same type, we create an ad hoc `UnivariateLocationScaleFamily` type, which maintains a separate `location` and `scale` parameter. Thus, one has two ways of writing some distributions. for example, the two distributions below are meant to be identical:
- `UnivariateLocationScaleFamily(Normal(0, 1), 2.0, 2.0)`
- `Normal(2.0, 2.0)`

But special cases are handled as needed, so that `3 * Normal(0, 1)` gives `Normal(0, 3)` rather than the less efficient `UnivariateLocationScaleFamily(Normal(0, 1), 0.0, 3.0)`.
