### PR TITLE
Enable release and nightlies on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,13 @@ compiler:
     - gcc
 notifications:
     email: false
+env:
+    matrix: 
+        - JULIAVERSION="juliareleases" 
+        - JULIAVERSION="julianightlies" 
 before_install:
     - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-    - sudo add-apt-repository ppa:staticfloat/julianightlies -y
+    - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
     - sudo apt-get update -qq -y
     - sudo apt-get install libpcre3-dev julia -y
     - git config --global user.name "Dummy Travis User"


### PR DESCRIPTION
This change enables the running of travis tests with both nightly and release versions of Julia.

Current tests run only using Julia nightly. This PR itself will prove if current StatsBase actually works in 0.2. So lets wait for Travis.

Note that enabling this kind of testing should not be considered to be a irrevocable promise of supporting release julia by this package. Package maintainers can easily remove tests for older julia. However, these tests will make that decision explicit, and motivate correct dependency declaration via REQUIRE
