### PR TITLE
Fix no longer exported Cholesky in LinAlg

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -3,6 +3,7 @@ module Distributions
 using NumericExtensions
 using PDMats
 using StatsBase
+import Base.LinAlg: Cholesky
 
 export
     # types


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/issues/6407

Requires this to be merged in PDStats as well https://github.com/lindahua/PDMats.jl/pull/3
