### PR TITLE
Make MixtureModel parametric so that it works with the fallbacks

### DIFF
--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -40,6 +40,8 @@ function insupport(d::MatrixDistribution, X::Array)
     return true
 end
 
+dim(d::UnivariateDistribution) = 1
+
 # generic function to get number of samples
 
 nsamples{D<:UnivariateDistribution}(dt::Type{D}, x::Array) = length(x)

--- a/src/mixturemodel.jl
+++ b/src/mixturemodel.jl
@@ -7,6 +7,10 @@ immutable MixtureModel{VF<:VariateForm,VS<:ValueSupport} <: Distribution{VF,VS}
         if length(c) != length(p)
             error("components and probs must have the same number of elements")
         end
+        dims = map(dim, c)
+        if !all(dims .== dims[1])
+            error("MixtureModel: mixture components have different dimensions")
+        end
         sump = 0.0
         for i in 1:length(p)
             if p[i] < 0.0
@@ -18,6 +22,8 @@ immutable MixtureModel{VF<:VariateForm,VS<:ValueSupport} <: Distribution{VF,VS}
         new(c, p ./ sump, table)
     end
 end
+
+dim(d::MixtureModel) = dim(d.components[1])
 
 function mean(d::MixtureModel)
     m = 0.0


### PR DESCRIPTION
MixtureModel defines a Distribution, but unlike all (?) other distributions, its type does not tell us if its univariate, multivariate or matrixvariate, and similarly whether it is discrete or continuous. Consequently, the methods in fallback.jl do not apply to it. This change brings MixtureModel into the fold, by parametrizing it w.r.t to these aspects. 
The immediate motivation for doing so was using one of the variants of rand/rand! that is defined in fallbacks.jl. It generally seems like better design IMO.
