### PR TITLE
make MixtureModel a parametrized subtype of Distribution

### DIFF
--- a/runtests.jl
+++ b/runtests.jl
@@ -19,6 +19,7 @@ tests = [
     "conjugates_normal",
     "conjugates_mvnormal",
     "wishart",
+    "mixture",
     "gradloglik"]
 
 println("Running tests:")

--- a/src/mixturemodel.jl
+++ b/src/mixturemodel.jl
@@ -1,11 +1,21 @@
-immutable MixtureModel <: Distribution
-    components::Vector # Vector should be able to contain any type of
-                       # distribution with comparable support
+immutable MixtureModel{VF,VS,Component<:Distribution} <: Distribution{VF,VS}
+    components::Vector{Component}
     probs::Vector{Float64}
     aliastable::AliasTable
-    function MixtureModel(c::Vector, p::Vector{Float64})
+    function MixtureModel(c::Vector{Component}, p::Vector{Float64})
+        if !(Component <: Distribution{VF,VS})
+            throw(TypeError(:MixtureModel,
+                            "Mixture components type mismatch",
+                            Distribution{VF,VS},
+                            Component))
+        end
         if length(c) != length(p)
-            error("components and probs must have the same number of elements")
+            throw(ArgumentError(string("components and probs must have",
+                                       " the same number of elements")))
+        end
+        sizes = [size(component)::Tuple for component in c]
+        if !all(sizes .== sizes[1])
+            error("MixtureModel: mixture components have different dimensions")
         end
         sump = 0.0
         for i in 1:length(p)
@@ -19,6 +29,14 @@ immutable MixtureModel <: Distribution
     end
 end
 
+function MixtureModel{C<:Distribution}(cs::Vector{C}, ps::Vector{Float64})
+    VF = variate_form(C)
+    VS = value_support(C)
+    MixtureModel{VF,VS,C}(cs, ps)
+end
+
+dim(d::MixtureModel{Multivariate}) = dim(d.components[1])
+
 function mean(d::MixtureModel)
     m = 0.0
     for i in 1:length(d.components)
@@ -27,13 +45,29 @@ function mean(d::MixtureModel)
     return m
 end
 
-function pdf(d::MixtureModel, x::Any)
+function _pdf(d::MixtureModel, x)
     p = 0.0
     for i in 1:length(d.components)
         p += pdf(d.components[i], x) * d.probs[i]
     end
     return p
 end
+
+function _logpdf(d::MixtureModel, x)
+    l = [(logpdf(d.components[i],x)+log(d.probs[i]))::Float64
+         for i in find(d.probs .> 0.)]
+    m = maximum(l)
+    log(sum(exp(l.-m))) + m
+end
+
+# avoid dispatch ambiguity by defining sufficiently specific methods
+pdf(d::MixtureModel{Univariate}, x::Real) = _pdf(d, x)
+pdf(d::MixtureModel{Multivariate}, x::Vector) = _pdf(d, x)
+pdf(d::MixtureModel{Matrixvariate}, x::Matrix) = _pdf(d, x)
+
+logpdf(d::MixtureModel{Univariate}, x::Real) = _logpdf(d,x)
+logpdf(d::MixtureModel{Multivariate}, x::Vector) = _logpdf(d,x)
+logpdf(d::MixtureModel{Matrixvariate}, x::Matrix) = _logpdf(d,x)
 
 function rand(d::MixtureModel)
     i = rand(d.aliastable)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -88,6 +88,14 @@ macro checkquantile(p,ex)
     :(zero($p) <= $p <= one($p) ? $ex : NaN)
 end
 
+# get the variate form (uni/multi/matrix-variate) of a Distribution
+variate_form{VF<:VariateForm,VS<:ValueSupport}(::Type{Distribution{VF,VS}}) = VF
+variate_form{T<:Distribution}(::Type{T}) = variate_form(super(T))
+
+# get the value support (discrete/continuous) of a Distribution
+value_support{VF<:VariateForm,VS<:ValueSupport}(::Type{Distribution{VF,VS}}) = VS
+value_support{T<:Distribution}(::Type{T}) = value_support(super(T))
+
 macro checkinvlogcdf(lp,ex)
     :($lp <= zero($lp) ? $ex : NaN)
 end

--- a/test/mixture.jl
+++ b/test/mixture.jl
@@ -1,0 +1,10 @@
+using Distributions
+using Base.Test
+
+m = MixtureModel([Poisson(2.0), Binomial(10, 0.3)],
+                 [0.4, 0.6])
+x = rand(m, (100,))
+@test_approx_eq exp(logpdf(m,x)) pdf(m,x)
+@test Distributions.variate_form(typeof(m))===Univariate
+@test Distributions.value_support(typeof(m))===Discrete
+


### PR DESCRIPTION
- Since a MixtureModel is a type of distribution, every MixtureModel is now a subtype Distribution with the correct VariateForm and ValueSupport. This is an update for PR #208.
- to implement this, I added new utility functions: variate_form and value_support which return the type parameters of a Distribution
- along the way, I generalized the fallbacks for pdf and logpdf so that they work with any VariateForm.
