### PR TITLE
fix bug in IsoNormalKnownSigma constructor

### DIFF
--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -150,7 +150,8 @@ typealias MvNormalKnownSigma   GenericMvNormalKnownSigma{PDMat}
 typealias DiagNormalKnownSigma GenericMvNormalKnownSigma{PDiagMat}
 typealias IsoNormalKnownSigma  GenericMvNormalKnownSigma{ScalMat}
 
-IsoNormalKnownSigma(σ::Float64) = IsoNormalKnownSigma(abs2(σ))
+IsoNormalKnownSigma(dimension::Int, σ::Float64) =
+    IsoNormalKnownSigma(ScalMat(dimension, abs2(σ)))
 DiagNormalKnownSigma(σ::Vector{Float64}) = DiagNormalKnownSigma(abs2(σ))
 MvNormalKnownSigma(C::Matrix{Float64}) = MvNormalKnownSigma(PDMat(C)) 
 

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -198,6 +198,12 @@ mu, C = _gauss_mle(x, w)
 @test_approx_eq g.μ mu
 @test_approx_eq g.Σ.value mean(diag(C))
 
+assumed_g = Distributions.IsoNormalKnownSigma(3, 1.)
+g = fit_mle(assumed_g, x, w)
+mu, C = _gauss_mle(x, w)
+@test_approx_eq g.μ mu
+@test_approx_eq diag(g.Σ) diag(assumed_g.Σ)
+
 g = fit(DiagNormal, x)
 mu, C = _gauss_mle(x)
 @test_approx_eq g.μ mu


### PR DESCRIPTION
IsoNormalKnownSigma's constructor tried to pass a Float64 where an AbstractPDMat was expected.
