### PR TITLE
add missing argument to normalize! in one of the fit_mle methods

### DIFF
--- a/src/univariate/categorical.jl
+++ b/src/univariate/categorical.jl
@@ -211,7 +211,7 @@ suffstats{T<:Integer}(::Type{Categorical}, data::(Int, Array{T}), w::Array{Float
 ### Model fitting
 
 function fit_mle(::Type{Categorical}, ss::CategoricalStats)
-    Categorical(normalize!(ss.h))
+    Categorical(normalize!(ss.h,1))
 end
 
 function fit_mle{T<:Integer}(::Type{Categorical}, k::Integer, x::Array{T}) 

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -122,6 +122,10 @@ d = fit(Categorical, (3, x), w)
 @test isa(d, Categorical)
 @test_approx_eq d.prob h / sum(h)
 
+d = fit(Categorical, suffstats(Categorical, 3, x, w))
+@test isa(d, Categorical)
+@test_approx_eq d.prob (h / sum(h))
+
 d = fit(Categorical, rand(Categorical(p), N))
 @test isa(d, Categorical)
 @test_approx_eq_eps d.prob p 0.01


### PR DESCRIPTION
add missing argument to normalize! in one of the fit_mle methods of Categorical variables
