### PR TITLE
move back samplers

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.3-
 ArrayViews 0.4.3-
 PDMats 0.1.3-
-Sampling
 StatsBase 0.5-

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -2,11 +2,17 @@ module Distributions
 
 using ArrayViews
 using PDMats
-using Sampling
 using StatsBase
 
+import Base.Random
+import Base: size, length, show, getindex, scale, rand, rand!
+import Base: sum, mean, median, maximum, minimum, quantile, std, var, cov, cor
+import Base.LinAlg: Cholesky
+import StatsBase: kurtosis, skewness, entropy, mode, modes, randi, RandIntSampler, fit
+import PDMats: dim, PDMat, invquad
+
 export
-    # reexport from StatsBase
+    # generic types
     VariateForm,
     ValueSupport,
     Univariate,
@@ -15,12 +21,6 @@ export
     Discrete,
     Continuous,
     Sampleable,
-
-    rand, rand!,            # random sampling
-    sample, sample!,        # sample from a source array
-    wsample, wsample!,      # weighted sampling from a source array
-
-    # types
     Distribution,
     UnivariateDistribution,
     MultivariateDistribution,
@@ -35,6 +35,8 @@ export
     ContinuousMultivariateDistribution,
     ContinuousMatrixDistribution,
     SufficientStats,
+
+    # distribution types
     Arcsine,
     Bernoulli,
     Beta,
@@ -107,119 +109,87 @@ export
     QQPair,
 
     # methods
-    binaryentropy, # entropy of distribution in bits
-    canonform,     # get canonical form of a distribution
-    ccdf,          # complementary cdf, i.e. 1 - cdf
-    cdf,           # cumulative distribution function
-    cf,            # characteristic function
-    cgf,           # cumulant generating function
-    cquantile,     # complementary quantile (i.e. using prob in right hand tail)
-    cumulant,      # cumulants of distribution
-    complete,      # turn an incomplete formulation into a complete distribution
-    dim,           # sample dimension of multivariate distribution
-    entropy,       # entropy of distribution in nats
-    fit,           # fit a distribution to data (using default method)
-    fit_mle,       # fit a distribution to data using MLE
-    fit_mle!,      # fit a distribution to data using MLE (inplace update to initial guess)
-    fit_map,       # fit a distribution to data using MAP
-    freecumulant,  # free cumulants of distribution
-    gmvnormal,     # a generic function to construct multivariate normal distributions
-    insupport,     # predicate, is x in the support of the distribution?
-    invcov,        # get the inversed covariance
-    invlogccdf,    # complementary quantile based on log probability
-    invlogcdf,     # quantile based on log probability
-    isplatykurtic, # Is excess kurtosis > 0.0?
-    isleptokurtic, # Is excess kurtosis < 0.0?
-    ismesokurtic,  # Is excess kurtosis = 0.0?
-    isprobvec,     # Is a probability vector?
+    binaryentropy,      # entropy of distribution in bits
+    canonform,          # get canonical form of a distribution
+    ccdf,               # complementary cdf, i.e. 1 - cdf
+    cdf,                # cumulative distribution function
+    cf,                 # characteristic function
+    cgf,                # cumulant generating function
+    cquantile,          # complementary quantile (i.e. using prob in right hand tail)
+    cumulant,           # cumulants of distribution
+    complete,           # turn an incomplete formulation into a complete distribution
+    dim,                # sample dimension of multivariate distribution
+    entropy,            # entropy of distribution in nats
+    fit,                # fit a distribution to data (using default method)
+    fit_mle,            # fit a distribution to data using MLE
+    fit_mle!,           # fit a distribution to data using MLE (inplace update to initial guess)
+    fit_map,            # fit a distribution to data using MAP
+    freecumulant,       # free cumulants of distribution
+    gmvnormal,          # a generic function to construct multivariate normal distributions
+    insupport,          # predicate, is x in the support of the distribution?
+    invcov,             # get the inversed covariance
+    invlogccdf,         # complementary quantile based on log probability
+    invlogcdf,          # quantile based on log probability
+    isplatykurtic,      # Is excess kurtosis > 0.0?
+    isleptokurtic,      # Is excess kurtosis < 0.0?
+    ismesokurtic,       # Is excess kurtosis = 0.0?
+    isprobvec,          # Is a probability vector?
     isupperbounded,  
     islowerbounded,
     isbounded,
     hasfinitesupport,
-    kde,           # Kernel density estimator (from Stats.jl)
-    kurtosis,      # kurtosis of the distribution
-    logccdf,       # ccdf returning log-probability
-    logcdf,        # cdf returning log-probability
-    loglikelihood, # log probability of array of IID draws
-    logpdf,        # log probability density
-    logpdf!,       # evaluate log pdf to provided storage
-    logpmf,        # log probability mass
-    logpmf!,       # evaluate log pmf to provided storage
-    posterior,        # get posterior distribution given prior and observed data
-    posterior_canon,  # get the canonical form of the posterior distribution
-    posterior_mode,  # get the mode of posterior distribution
-    posterior_rand,  # draw samples from the posterior distribution
+    kde,                # Kernel density estimator (from Stats.jl)
+    kurtosis,           # kurtosis of the distribution
+    logccdf,            # ccdf returning log-probability
+    logcdf,             # cdf returning log-probability
+    loglikelihood,      # log probability of array of IID draws
+    logpdf,             # log probability density
+    logpdf!,            # evaluate log pdf to provided storage
+    logpmf,             # log probability mass
+    logpmf!,            # evaluate log pmf to provided storage
+    posterior,          # get posterior distribution given prior and observed data
+    posterior_canon,    # get the canonical form of the posterior distribution
+    posterior_mode,     # get the mode of posterior distribution
+    posterior_rand,     # draw samples from the posterior distribution
     posterior_rand!, 
     posterior_randmodel,
-    scale,         # scale parameter of a distribution
-    invscale,      # invscale parameter of a distribution (see multivariate t-distribution)
-    rate,          # rate parameter of a distribution
-    sqmahal,       # squared Mahalanobis distance to Gaussian center
-    sqmahal!,      # inplace evaluation of sqmahal
-    mean,          # mean of distribution
-    median,        # median of distribution
-    mgf,           # moment generating function
-    mode,          # the mode of a unimodal distribution
-    modes,         # mode(s) of distribution as vector
-    moment,        # moments of distribution
-    nsamples,      # get the number of samples in a data array based on distribution types
-    pdf,           # probability density function (ContinuousDistribution)
-    pmf,           # probability mass function (DiscreteDistribution)
-    quantile,      # inverse of cdf (defined for p in (0,1))
-    qqbuild,       # build a paired quantiles data structure for qqplots
-    sampler,       # create a Sampler object for efficient samples
-    skewness,      # skewness of the distribution
-    sprand,        # random sampler for sparse matrices
-    std,           # standard deviation of distribution
-    suffstats,     # compute sufficient statistics
-    var,           # variance of distribution
-    expected_logdet, # expected logarithm of random matrix determinant
-    gradlogpdf     # gradient (or derivative) of logpdf(d,x) wrt x
+    scale,              # scale parameter of a distribution
+    invscale,           # invscale parameter of a distribution (see multivariate t-distribution)
+    rate,               # rate parameter of a distribution
+    sqmahal,            # squared Mahalanobis distance to Gaussian center
+    sqmahal!,           # inplace evaluation of sqmahal
+    mean,               # mean of distribution
+    median,             # median of distribution
+    mgf,                # moment generating function
+    mode,               # the mode of a unimodal distribution
+    modes,              # mode(s) of distribution as vector
+    moment,             # moments of distribution
+    nsamples,           # get the number of samples contained in an array
+    pdf,                # probability density function (ContinuousDistribution)
+    pmf,                # probability mass function (DiscreteDistribution)
+    quantile,           # inverse of cdf (defined for p in (0,1))
+    qqbuild,            # build a paired quantiles data structure for qqplots
+    sampler,            # create a Sampler object for efficient samples
+    skewness,           # skewness of the distribution
+    std,                # standard deviation of distribution
+    suffstats,          # compute sufficient statistics
+    var,                # variance of distribution
+    expected_logdet,    # expected logarithm of random matrix determinant
+    gradlogpdf,         # gradient (or derivative) of logpdf(d,x) wrt x
 
-import Base.Random
-import Base: show, scale, sum!, rand, rand!, sprand
-import Base: mean, median, maximum, minimum, quantile, std, var, cov, cor
-import Base: size, length
-import Base.LinAlg: Cholesky
-import StatsBase: kurtosis, skewness, entropy, mode, modes, randi, RandIntSampler, fit
-import PDMats: dim, PDMat, invquad
+    # reexport from StatsBase
+    sample, sample!,        # sample from a source array
+    wsample, wsample!      # weighted sampling from a source array
 
-
-#### Distribution type system
-
-abstract Distribution{F<:VariateForm,S<:ValueSupport} <: Sampleable{F,S}
-
-typealias UnivariateDistribution{S<:ValueSupport}   Distribution{Univariate,S}
-typealias MultivariateDistribution{S<:ValueSupport} Distribution{Multivariate,S}
-typealias MatrixDistribution{S<:ValueSupport}       Distribution{Matrixvariate,S}
-typealias NonMatrixDistribution Union(UnivariateDistribution, MultivariateDistribution)
-
-typealias DiscreteDistribution{F<:VariateForm}   Distribution{F,Discrete}
-typealias ContinuousDistribution{F<:VariateForm} Distribution{F,Continuous}
-
-typealias DiscreteUnivariateDistribution     Distribution{Univariate,    Discrete}
-typealias ContinuousUnivariateDistribution   Distribution{Univariate,    Continuous}
-typealias DiscreteMultivariateDistribution   Distribution{Multivariate,  Discrete}
-typealias ContinuousMultivariateDistribution Distribution{Multivariate,  Continuous}
-typealias DiscreteMatrixDistribution         Distribution{Matrixvariate, Discrete}
-typealias ContinuousMatrixDistribution       Distribution{Matrixvariate, Continuous}
-
-abstract SufficientStats
-abstract IncompleteDistribution
-
-typealias DistributionType{D<:Distribution} Type{D}
-typealias IncompleteFormulation Union(DistributionType,IncompleteDistribution)
-
-
-#### Include files
-
+include("common.jl")
 include("constants.jl")
-
 include("fallbacks.jl")
 include("rmath.jl")
 include("specialfuns.jl")
 include("tvpack.jl")
 include("utils.jl")
+include("samplers.jl")
+include("genericrand.jl")
 
 # Univariate distributions
 include(joinpath("univariate", "arcsine.jl"))

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,0 +1,61 @@
+## sample space/domain
+
+abstract ValueSupport
+type Discrete   <: ValueSupport end
+type Continuous <: ValueSupport end
+
+Base.eltype(::Type{Discrete}) = Int
+Base.eltype(::Type{Continuous}) = Float64
+
+abstract VariateForm
+type Univariate    <: VariateForm end
+type Multivariate  <: VariateForm end
+type Matrixvariate <: VariateForm end
+
+## Sampleable
+
+abstract Sampleable{F<:VariateForm,S<:ValueSupport}
+
+Base.length(::Sampleable{Univariate}) = 1
+Base.length(s::Sampleable{Multivariate}) = throw(MethodError(length, (s,)))
+Base.length(s::Sampleable) = prod(size(s))
+
+Base.size(s::Sampleable{Univariate}) = ()
+Base.size(s::Sampleable{Multivariate}) = (length(s),)
+
+nsamples{D<:Sampleable{Univariate}}(::Type{D}, x::AbstractArray) = length(x)
+nsamples{D<:Sampleable{Multivariate}}(::Type{D}, x::AbstractVector) = 1
+nsamples{D<:Sampleable{Multivariate}}(::Type{D}, x::AbstractMatrix) = size(x, 2)
+nsamples{D<:Sampleable{Matrixvariate},T}(::Type{D}, x::Array{Matrix{T}}) = length(x)
+
+## Distribution <: Sampleable
+
+abstract Distribution{F<:VariateForm,S<:ValueSupport} <: Sampleable{F,S}
+
+typealias UnivariateDistribution{S<:ValueSupport}   Distribution{Univariate,S}
+typealias MultivariateDistribution{S<:ValueSupport} Distribution{Multivariate,S}
+typealias MatrixDistribution{S<:ValueSupport}       Distribution{Matrixvariate,S}
+typealias NonMatrixDistribution Union(UnivariateDistribution, MultivariateDistribution)
+
+typealias DiscreteDistribution{F<:VariateForm}   Distribution{F,Discrete}
+typealias ContinuousDistribution{F<:VariateForm} Distribution{F,Continuous}
+
+typealias DiscreteUnivariateDistribution     Distribution{Univariate,    Discrete}
+typealias ContinuousUnivariateDistribution   Distribution{Univariate,    Continuous}
+typealias DiscreteMultivariateDistribution   Distribution{Multivariate,  Discrete}
+typealias ContinuousMultivariateDistribution Distribution{Multivariate,  Continuous}
+typealias DiscreteMatrixDistribution         Distribution{Matrixvariate, Discrete}
+typealias ContinuousMatrixDistribution       Distribution{Matrixvariate, Continuous}
+
+## TODO: replace dim with length in specialized methods
+Base.length(d::MultivariateDistribution) = dim(d)
+Base.size(d::MatrixDistribution) = (dim(d), dim(d)) # override if the matrix isn't square
+
+
+## TODO: the following types need to be improved
+abstract SufficientStats
+abstract IncompleteDistribution
+
+typealias DistributionType{D<:Distribution} Type{D}
+typealias IncompleteFormulation Union(DistributionType,IncompleteDistribution)
+

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -4,17 +4,6 @@
 #
 ##############################################################################
 
-# array-like characteristics
-
-# size(d::Distribution) = size(rand(d))
-size(d::UnivariateDistribution) = ()
-size(d::MultivariateDistribution) = (dim(d),)
-size(d::MatrixDistribution) = (dim(d), dim(d)) # override if the matrix isn't square
-
-length(d::UnivariateDistribution) = 1
-length(d::MultivariateDistribution) = dim(d)
-length(d::Distribution) = prod(size(d))
-
 # support handling
 
 isbounded(d::UnivariateDistribution) = isupperbounded(d) && islowerbounded(d)
@@ -58,12 +47,6 @@ function insupport!{D<:MatrixDistribution}(r::AbstractArray, d::Union(D,Type{D})
     r
 end
 insupport{D<:MatrixDistribution}(d::Union(D,Type{D}), X::AbstractArray) = insupport!(BitArray(size(X)[3:end]), d, X)
-
-# generic function to get number of samples
-
-nsamples{D<:UnivariateDistribution}(dt::Type{D}, x::Array) = length(x)
-nsamples{D<:MultivariateDistribution}(dt::Type{D}, x::Matrix) = size(x, 2)
-nsamples{D<:MatrixDistribution,T}(dt::Type{D}, x::Array{Matrix{T}}) = length(x)
 
 #### Statistics ####
 mean(d::Distribution) = throw(MethodError(mean,(d,)))
@@ -210,7 +193,7 @@ pmf(d::DiscreteDistribution, args::Any...) = pdf(d, args...)
 # default: inverse transform sampling
 rand(d::UnivariateDistribution) = quantile(d, rand())
 
-function sprand(m::Integer, n::Integer, density::Real, d::Distribution)
+function Base.sprand(m::Integer, n::Integer, density::Real, d::Distribution)
     return sprand(m, n, density, n -> rand(d, n))
 end
 

--- a/src/genericrand.jl
+++ b/src/genericrand.jl
@@ -1,0 +1,34 @@
+# Generic rand methods
+
+function rand!(s::Sampleable{Univariate}, A::AbstractArray)
+    for i in 1:length(A)
+        @inbounds A[i] = rand(s)
+    end
+    return A
+end
+
+rand{S<:ValueSupport}(s::Sampleable{Univariate,S}, shp::Union(Int,(Int...))) = 
+    rand!(s, Array(eltype(S), shp))
+
+function rand!(s::Sampleable{Multivariate}, A::DenseMatrix)
+    for i = 1:size(A,2)
+        rand!(s, view(A,:,i))
+    end
+    return A
+end
+
+rand{S<:ValueSupport}(s::Sampleable{Multivariate,S}) = 
+    rand!(s, Array(eltype(S), length(s)))
+
+rand{S<:ValueSupport}(s::Sampleable{Multivariate,S}, n::Int) = 
+    rand!(s, Array(eltype(S), length(s), n))
+
+function rand!{M<:Matrix}(s::Sampleable{Matrixvariate}, X::Array{M})
+    for i in 1:length(X)
+        X[i] = rand(s)
+    end
+    return X
+end
+
+rand{S<:ValueSupport}(s::Sampleable{Matrixvariate,S}, n::Int) =
+    rand!(s, Array(Matrix{eltype(S)}, n))

--- a/src/samplers.jl
+++ b/src/samplers.jl
@@ -1,5 +1,9 @@
 # delegation of samplers
 
-sampler(d::Binomial) = BinomialPolySampler(d.size, d.prob)
-sampler(d::Gamma) = GammaMTSampler(d.shape, d.scale)
-
+for fname in ["categorical.jl",
+              "binomial.jl",
+              "poisson.jl", 
+              "exponential.jl",
+              "gamma.jl"]
+    include(joinpath("samplers", fname))
+end

--- a/src/samplers/binomial.jl
+++ b/src/samplers/binomial.jl
@@ -1,0 +1,319 @@
+import Base.Math.@horner
+
+# BinomialRmathSampler is non-exported, which is mainly used
+# for benchmarking or testing purpose
+#
+immutable BinomialRmathSampler <: Sampleable{Univariate,Discrete}
+    n::Int
+    prob::Float64
+end
+
+rand(s::BinomialRmathSampler) = 
+    int(ccall((:rbinom, "libRmath-julia"), Float64, (Float64, Float64), s.n, s.prob))
+
+
+# compute probability vector of a Binomial distribution
+function binompvec(n::Int, p::Float64)
+    pv = Array(Float64, n+1)
+    if p == 0.0
+        fill!(pv, 0.0)
+        pv[1] = 1.0
+    elseif p == 1.0
+        fill!(pv, 0.0)
+        pv[n+1] = 1.0
+    else
+        q = 1.0 - p
+        a = p / q
+        @inbounds pv[1] = pk = q ^ n
+        for k = 1:n
+            @inbounds pv[k+1] = (pk *= ((n - k + 1) / k) * a)
+        end
+    end
+    return pv
+end
+
+
+# Remainder term after Stirling's approximation to the log-gamma function
+# lstirling(x) = lgamma(x) + x - (x-0.5)*log(x) - 0.5*log2π
+#              = 1/(12x) - 1/(360x^3) + 1/(1260x^5) + ...
+# Asymptotic expansion from:
+#   Temme, N. (1996) Special functions: An introduction to the classical
+#   functions of mathematical physics, Wiley, New York, ISBN: 0-471-11313-1,
+#   Chapter 3.6, pp 61-65.
+# Relative error of approximation is bounded by
+#   (174611/125400 x^-19) / (1/12 x^-1 - 1/360 x^-3)
+# which is < 1/2 ulp for x >= 10.0
+# total numeric error appears to be < 2 ulps
+#
+lstirling_asym(x::Integer) = lstirling_asym(float(x))
+
+function lstirling_asym(x::Float64)
+    t = 1.0/(x*x)
+    @horner(t,
+             8.33333333333333333e-2, #  1/12 x^-1
+            -2.77777777777777778e-3, # -1/360 x^-3
+             7.93650793650793651e-4, #  1/1260 x^-5
+            -5.95238095238095238e-4, # -1/1680 x^-7
+             8.41750841750841751e-4, #  1/1188 x^-9
+            -1.91752691752691753e-3, # -691/360360 x^-11
+             6.41025641025641026e-3, #  1/156 x^-13
+            -2.95506535947712418e-2, # -3617/122400 x^-15
+             1.79644372368830573e-1)/x #  43867/244188 x^-17
+end
+
+function lstirling_asym(x::Float32)
+    t = 1f0/(x*x)
+    @horner(t,
+             8.333333333333f-2, #  1/12 x^-1
+            -2.777777777777f-3, # -1/360 x^-3
+             7.936507936508f-4, #  1/1260 x^-5
+            -5.952380952381f-4, # -1/1680 x^-7
+             8.417508417508f-4)/x #  1/1188 x^-9
+end
+
+
+# Geometric method:
+#
+#   Devroye. L. 
+#   "Generating the maximum of independent identically  distributed random variables" 
+#   Computers and Marhemafics with Applicalions 6, 1960, 305-315.
+#
+immutable BinomialGeomSampler <: Sampleable{Univariate,Discrete}
+    comp::Bool
+    n::Int
+    scale::Float64
+end
+
+BinomialGeomSampler() = BinomialGeomSampler(false, 0, 0.0)
+
+function BinomialGeomSampler(n::Int, prob::Float64)
+    if prob <= 0.5
+        comp = false
+        scale = -1.0/log1p(-prob)
+    else
+        comp = true
+        scale = prob < 1.0 ? -1.0/log(prob) : Inf
+    end
+    BinomialGeomSampler(comp, n, scale)
+end
+
+function rand(s::BinomialGeomSampler)
+    y = 0
+    x = 0
+    n = s.n
+    while true
+        er = Base.Random.randmtzig_exprnd()
+        v = er * s.scale
+        if v > n  # in case when v is very large or infinity
+            break 
+        end
+        y += iceil(v)
+        if y > n
+            break
+        end
+        x += 1
+    end
+    (s.comp ? s.n - x : x)::Int
+end
+
+
+# BTPE algorithm from:
+#
+#   Kachitvichyanukul, V.; Schmeiser, B. W. 
+#   "Binomial random variate generation." 
+#   Comm. ACM 31 (1988), no. 2, 216–222. 
+#
+# Note: only use this sampler when n * min(p, 1-p) is large enough
+#       e.g., it is greater than 20.
+#
+immutable BinomialTPESampler <: Sampleable{Univariate,Discrete}
+    comp::Bool
+    n::Int
+    r::Float64
+    q::Float64
+    nrq::Float64
+    M::Float64
+    Mi::Int
+    p1::Float64
+    p2::Float64
+    p3::Float64
+    p4::Float64
+    xM::Float64
+    xL::Float64
+    xR::Float64
+    c::Float64
+    λL::Float64
+    λR::Float64
+end
+
+BinomialTPESampler() = 
+    BinomialTPESampler(false, 0, 0., 0., 0., 0., 0, 
+                       0., 0., 0., 0., 0., 0., 0., 0., 0., 0.)
+
+function BinomialTPESampler(n::Int, prob::Float64)
+    if prob <= 0.5
+        comp = false
+        r = prob
+        q = 1.0 - prob
+    else
+        comp = true
+        r = 1.0 - prob
+        q = prob
+    end
+
+    nrq = n*r*q
+    fM = (n+1)*r #
+    M = floor(fM)
+    Mi = integer(M)
+    p1 = floor(2.195*sqrt(nrq)-4.6*q) + 0.5
+    xM = M+0.5
+    xL = xM-p1
+    xR = xM+p1
+    c = 0.134 + 20.5/(15.3+M)
+    a = (fM-xL)/(fM-xL*r) #
+    λL = a*(1.0 + 0.5*a)
+    a = (xR-fM)/(xR*q) #
+    λR = a*(1.0 + 0.5*a)
+    p2 = p1*(1.0 + 2.0*c)
+    p3 = p2 + c/λL
+    p4 = p3 + c/λR
+    
+    BinomialTPESampler(comp,n,r,q,nrq,M,Mi,p1,p2,p3,p4,
+                        xM,xL,xR,c,λL,λR)
+end
+
+function rand(s::BinomialTPESampler)
+    y = 0
+    while true
+        # Step 1
+        u = s.p4*rand()
+        v = rand()
+        if u <= s.p1
+            y = ifloor(s.xM-s.p1*v+u)
+            # Goto 6
+            break
+        elseif u <= s.p2 # Step 2
+            x = s.xL + (u-s.p1)/s.c
+            v = v*s.c+1.0-abs(s.M-x+0.5)/s.p1
+            if v > 1
+                # Goto 1
+                continue
+            end
+            y = ifloor(x)
+            # Goto 5
+        elseif u <= s.p3 # Step 3
+            y = ifloor(s.xL + log(v)/s.λL)
+            if y < 0
+                # Goto 1
+                continue
+            end
+            v *= (u-s.p2)*s.λL
+            # Goto 5
+        else # Step 4
+            y = ifloor(s.xR-log(v)/s.λR)
+            if y > s.n
+                # Goto 1
+                continue
+            end
+            v *= (u-s.p3)*s.λR
+            # Goto 5
+        end
+        
+        # Step 5
+        # 5.0
+        k = abs(y-s.Mi)
+        if (k <= 20) || (k >= 0.5*s.nrq-1)
+            # 5.1
+            S = s.r/s.q
+            a = S*(s.n+1)
+            F = 1.0
+            if s.Mi < y
+                for i = (s.Mi+1):y
+                    F *= a/i-S
+                end
+            elseif s.Mi > y
+                for i = (y+1):s.Mi
+                    F /= a/i-S
+                end
+            end
+            if v > F
+                # Goto 1
+                continue
+            end
+            # Goto 6
+            break
+        else
+            # 5.2
+            ρ = (k/s.nrq)*((k*(k/3.0+0.625)+1.0/6.0)/s.nrq+0.5)
+            t = -k^2/(2.0*s.nrq)
+            A = log(v)
+            if A < t - ρ
+                # Goto 6
+                break
+            elseif A > t + ρ
+                # Goto 1
+                continue
+            end
+            
+            # 5.3
+            x1 = float64(y+1)
+            f1 = float64(s.Mi+1)
+            z = float64(s.n+1-s.Mi)
+            w = float64(s.n-y+1)
+
+            if A > (s.xM*log(f1/x1) + ((s.n-s.Mi)+0.5)*log(z/w) + (y-s.Mi)*log(w*s.r/(x1*s.q)) +
+                    lstirling_asym(f1) + lstirling_asym(z) + lstirling_asym(x1) + lstirling_asym(w))
+                # Goto 1
+                continue
+            end                
+            
+            # Goto 6
+            break
+        end
+    end
+    # 6
+    (s.comp ? s.n - y : y)::Int
+end
+
+
+# Constructing an alias table by directly computing the probability vector
+#
+immutable BinomialAliasSampler <: Sampleable{Univariate,Discrete}
+    table::AliasTable
+end
+
+BinomialAliasSampler(n::Int, p::Float64) = 
+    BinomialAliasSampler(make_alias_table!(binompvec(n, p)))
+
+rand(s::BinomialAliasSampler) = rand(s.table) - 1
+
+
+# Integrated Polyalgorithm sampler that automatically chooses the proper one
+#
+# It is important for type-stability
+#
+type BinomialPolySampler <: Sampleable{Univariate,Discrete}
+    use_btpe::Bool 
+    geom_sampler::BinomialGeomSampler
+    btpe_sampler::BinomialTPESampler
+end
+
+function BinomialPolySampler(n::Int, p::Float64)
+    q = 1.0 - p
+    if n * min(p, q) > 20
+        use_btpe = true
+        geom_sampler = BinomialGeomSampler()
+        btpe_sampler = BinomialTPESampler(n, p)
+    else
+        use_btpe = false
+        geom_sampler = BinomialGeomSampler(n, p)
+        btpe_sampler = BinomialTPESampler()
+    end
+    BinomialPolySampler(use_btpe, geom_sampler, btpe_sampler)
+end
+
+BinomialPolySampler(n::Real, p::Real) = BinomialPolySampler(int(n), float64(p))
+
+rand(s::BinomialPolySampler) = s.use_btpe ? rand(s.btpe_sampler) : rand(s.geom_sampler)
+
+

--- a/src/samplers/categorical.jl
+++ b/src/samplers/categorical.jl
@@ -1,0 +1,65 @@
+##### Alias Table #####
+
+immutable AliasTable <: Sampleable{Univariate,Discrete}
+    accept::Vector{Float64}
+    alias::Vector{Int}
+    isampler::RandIntSampler
+end
+numcategories(s::AliasTable) = length(s.accept)
+
+function make_alias_table!(a::AbstractVector{Float64})
+    # input probabilities via a, which is then
+    # overriden by acceptance probabilities
+    # and used internally by the AliasTable instance
+    #
+    n = length(a)
+    for i=1:n
+        @inbounds a[i] *= n
+    end
+    alias = Array(Int,n)
+    larges = Int[]
+    smalls = Int[]
+
+    for i = 1:n
+        acci = a[i] 
+        if acci > 1.0 
+            push!(larges,i)
+        elseif acci < 1.0
+            push!(smalls,i)
+        end
+    end
+
+    while !isempty(larges) && !isempty(smalls)
+        s = pop!(smalls)
+        l = pop!(larges)
+        @inbounds alias[s] = l
+        @inbounds a[l] = (a[l] - 1.0) + a[s]
+        if a[l] > 1
+            push!(larges,l)
+        else
+            push!(smalls,l)
+        end
+    end
+
+    # this loop should be redundant, except for rounding
+    for s in smalls
+        @inbounds a[s] = 1.0
+    end
+    AliasTable(a, alias, RandIntSampler(n))
+end
+
+function AliasTable{T<:Real}(probs::AbstractVector{T})
+    n = length(probs)
+    n > 0 || error("The input probability vector is empty.")
+    a = Array(Float64, n)
+    for i = 1:n
+        @inbounds a[i] = probs[i]
+    end
+    make_alias_table!(a)
+end
+
+rand(s::AliasTable) = 
+    (i = rand(s.isampler); u = rand(); @inbounds r = u < s.accept[i] ? i : s.alias[i]; r)
+
+show(io::IO, s::AliasTable) = @printf(io, "AliasTable with %d entries", numcategories(s))
+

--- a/src/samplers/exponential.jl
+++ b/src/samplers/exponential.jl
@@ -1,0 +1,9 @@
+
+randexp() = Base.Random.randmtzig_exprnd()
+
+immutable ExponentialSampler <: Sampleable{Univariate,Continuous}
+	scale::Float64
+end
+
+rand(s::ExponentialSampler) = s.scale * randexp()
+

--- a/src/samplers/gamma.jl
+++ b/src/samplers/gamma.jl
@@ -1,0 +1,99 @@
+
+#  A simple method for generating gamma variables - Marsaglia and Tsang (2000)
+#  http://www.cparity.com/projects/AcmClassification/samples/358414.pdf
+#  Page 369
+#  basic simulation loop for pre-computed d and c
+#
+
+immutable GammaMTSampler <: Sampleable{Univariate,Continuous}
+    iα::Float64
+    d::Float64
+    c::Float64
+    κ::Float64
+end
+
+function GammaMTSampler(α::Float64, scale::Float64)
+    if α >= 1.0
+        iα = 1.0
+        d = α - 1/3
+    else
+        iα = 1.0 / α
+        d = α + 2/3
+    end
+    c = 1.0 / sqrt(9.0 * d)
+    κ = d * scale
+    GammaMTSampler(iα, d, c, κ)
+end
+
+GammaMTSampler(α::Float64) = GammaMTSampler(α, 1.0)
+
+function rand(s::GammaMTSampler)
+    d = s.d
+    c = s.c
+    iα = s.iα
+
+    v = 0.0
+    while true
+        x = randn()
+        v = 1.0 + c * x
+        while v <= 0.0
+            x = randn()
+            v = 1.0 + c * x
+        end
+        v *= (v * v)
+        u = rand()
+        x2 = x * x
+        if u < 1.0 - 0.331 * abs2(x2)
+            break
+        end
+        if log(u) < 0.5 * x2 + d * (1.0 - v + log(v))
+            break
+        end
+    end
+    v *= s.κ
+    if iα > 1.0
+        v *= (rand() ^ iα)
+    end
+    return v
+end
+
+
+# function GammaMTSampler(g::Gamma)
+#     d = g.shape - 1.0/3.0
+#     GammaMTSampler(d, 1.0 / sqrt(9.0 * d), g.scale * d)
+# end
+
+# # for shape < 1.0: see note on page 371.
+# immutable GammaMTPowerSampler <: Sampler{Univariate,Continuous}
+#     gmt::GammaMTSampler
+#     iα::Float64
+# end
+
+# function GammaMTPowerSampler(g::Gamma)
+#     d = g.shape + 2.0/3.0
+#     GammaMTPowerSampler(GammaMTSampler(d, 1.0 / sqrt(9.0 * d), g.scale * d), 1.0/g.shape)
+# end
+    
+# function rand(s::GammaMTSampler)
+#     v = 0.0
+#     while true
+#         x = randn()
+#         v = 1.0 + s.c * x
+#         while v <= 0.0
+#             x = randn()
+#             v = 1.0 + s.c * x
+#         end
+#         v *= (v * v)
+#         u = rand()
+#         x2 = x^2
+#         if u < 1.0 - 0.331 * x2^2
+#             break
+#         end
+#         if log(u) < 0.5 * x2 + s.d * (1.0 - v + log(v))
+#             break
+#         end
+#     end
+#     v * s.scale
+# end
+
+# rand(s::GammaMTPowerSampler) = rand(s.gmt) * rand()^s.iα

--- a/src/samplers/obsoleted.jl
+++ b/src/samplers/obsoleted.jl
@@ -1,0 +1,157 @@
+# Obsoleted samplers
+
+# These samplers are not actually used by anyone, and they have not been properly tested.
+# The codes are still kept here in case we want to pick them up in future.
+#
+
+##### Draw Table #####
+
+# Store an alias table
+immutable DiscreteDistributionTable <: Sampler{Univariate,Discrete}
+    table::Vector{Vector{Int64}}
+    bounds::Vector{Int64}
+end
+
+# TODO: Test if bit operations can speed up Base64 mod's and fld's
+function DiscreteDistributionTable{T <: Real}(probs::Vector{T})
+    # Cache the cardinality of the outcome set
+    n = length(probs)
+
+    # Convert all Float64's into integers
+    vals = Array(Int64, n)
+    for i in 1:n
+        vals[i] = int(probs[i] * 64^9)
+    end
+
+    # Allocate digit table and digit sums as table bounds
+    table = Array(Vector{Int64}, 9)
+    bounds = zeros(Int64, 9)
+
+    # Special case for deterministic distributions
+    for i in 1:n
+        if vals[i] == 64^9
+            table[1] = Array(Int64, 64)
+            for j in 1:64
+                table[1][j] = i
+            end
+            bounds[1] = 64^9
+            for j in 2:9
+                table[j] = Array(Int64, 0)
+                bounds[j] = 64^9
+            end
+            return DiscreteDistributionTable(table, bounds)
+        end
+    end
+
+    # Fill tables
+    multiplier = 1
+    for index in 9:-1:1
+        counts = Array(Int64, 0)
+        for i in 1:n
+            digit = mod(vals[i], 64)
+            # vals[i] = fld(vals[i], 64)
+            vals[i] >>= 6
+            bounds[index] += digit
+            for itr in 1:digit
+                push!(counts, i)
+            end
+        end
+        bounds[index] *= multiplier
+        table[index] = counts
+        # multiplier *= 64
+        multiplier <<= 6
+    end
+
+    # Make bounds cumulative
+    bounds = cumsum(bounds)
+
+    return DiscreteDistributionTable(table, bounds)
+end
+
+function rand(table::DiscreteDistributionTable)
+    # 64^9 - 1 == 0x003fffffffffffff
+    i = rand(1:(64^9 - 1))
+    # if i == 64^9
+    #   return table.table[9][rand(1:length(table.table[9]))]
+    # end
+    bound = 1
+    while i > table.bounds[bound] && bound < 9
+        bound += 1
+    end
+    if bound > 1
+        index = fld(i - table.bounds[bound - 1] - 1, 64^(9 - bound)) + 1
+    else
+        index = fld(i - 1, 64^(9 - bound)) + 1
+    end
+    return table.table[bound][index]
+end
+
+Base.show(io::IO, table::DiscreteDistributionTable) = @printf io "DiscreteDistributionTable"
+
+
+##### Huffman Table ######
+
+abstract HuffmanNode{T} <: Sampler{Univariate,Discrete}
+
+immutable HuffmanLeaf{T} <: HuffmanNode{T}
+    value::T
+    weight::Uint64
+end
+
+immutable HuffmanBranch{T} <: HuffmanNode{T}
+    left::HuffmanNode{T}
+    right::HuffmanNode{T}
+    weight::Uint64
+end
+HuffmanBranch{T}(ha::HuffmanNode{T},hb::HuffmanNode{T}) = HuffmanBranch(ha, hb, ha.weight + hb.weight)
+
+Base.isless{T}(ha::HuffmanNode{T}, hb::HuffmanNode{T}) = isless(ha.weight,hb.weight)
+Base.show{T}(io::IO, t::HuffmanNode{T}) = show(io,typeof(t))
+
+function Base.getindex{T}(h::HuffmanBranch{T},u::Uint64) 
+    while isa(h,HuffmanBranch{T})
+        if u < h.left.weight
+            h = h.left
+        else 
+            u -= h.left.weight
+            h = h.right
+        end
+    end
+    h.value
+end
+
+# build the huffman tree
+# could be slightly more efficient using a Deque.
+function huffman{T}(values::AbstractVector{T},weights::AbstractVector{Uint64})
+    leafs = [HuffmanLeaf{T}(values[i],weights[i]) for i = 1:length(weights)]
+    sort!(leafs; rev=true)
+    
+    branches = Array(HuffmanBranch{T},0)
+        
+    while !isempty(leafs) || length(branches) > 1
+        left = isempty(branches) || (!isempty(leafs) && first(leafs) < first(branches)) ? pop!(leafs) : pop!(branches)
+        right = isempty(branches) || (!isempty(leafs) && first(leafs) < first(branches)) ? pop!(leafs) : pop!(branches)
+        unshift!(branches,HuffmanBranch(left,right))
+    end
+    
+    pop!(branches)    
+end
+
+function rand{T}(h::HuffmanNode{T})
+    w = h.weight
+    # generate uniform Uint64 objects on the range 0:(w-1)
+    # unfortunately we can't use Range objects, as they don't have sufficient length
+    u = rand(Uint64)
+    if (w & (w-1)) == 0
+        # power of 2
+        u = u & (w-1)
+    else
+        m = typemax(Uint64)
+        lim = m - (rem(m,w)+1)
+        while u > lim
+            u = rand(Uint64)
+        end
+        u = rem(u,w)
+    end
+    h[u]
+end

--- a/src/samplers/poisson.jl
+++ b/src/samplers/poisson.jl
@@ -1,0 +1,177 @@
+
+function poissonpvec(μ::Float64, n::Int)
+    # Poisson probabilities, from 0 to n
+    pv = Array(Float64, n+1)
+    @inbounds pv[1] = p = exp(-μ)
+    for i = 1:n
+        @inbounds pv[i+1] = (p *= (μ / i))
+    end
+    return pv
+end
+
+# Naive sampler by counting exp variables
+#
+# Suitable for small μ
+#
+immutable PoissonCountSampler <: Sampleable{Univariate,Discrete}
+    μ::Float64
+end
+
+function rand(s::PoissonCountSampler)
+    μ = s.μ
+    n = 0
+    c = randexp()
+    while c < μ
+        n += 1
+        c += randexp()
+    end 
+    return n
+end
+
+# Algorithm from:
+#
+#   J.H. Ahrens, U. Dieter (1982)
+#   "Computer Generation of Poisson Deviates from Modified Normal Distributions"
+#   ACM Transactions on Mathematical Software, 8(2):163-179
+#   
+#   For μ sufficiently large, (i.e. >= 10.0)
+#
+immutable PoissonADSampler <: Sampleable{Univariate,Discrete}
+    μ::Float64
+    s::Float64
+    d::Float64
+    L::Int
+end
+
+PoissonADSampler(μ::Float64) = 
+    PoissonADSampler(μ,sqrt(μ),6.0*μ^2,ifloor(μ-1.1484))
+
+function rand(s::PoissonADSampler)
+    # Step N
+    G = s.μ + s.s*randn()
+
+    if G >= 0.0
+        K = ifloor(G)
+        # Step I
+        if K >= s.L
+            return K
+        end
+
+        # Step S
+        U = rand()
+        if s.d*U >= (s.μ-K)^3
+            return K
+        end
+
+        # Step P
+        px,py,fx,fy = procf(s.μ,K,s.s)
+
+        # Step Q
+        if fy*(1-U) <= py*exp(px-fx)
+            return K
+        end
+    end
+
+    while true
+        # Step E
+        E = randexp()
+        U = 2.0*rand()-1.0
+        T = 1.8+copysign(E,U)
+        if T <= -0.6744
+            continue
+        end
+
+        K = ifloor(s.μ + s.s*T)
+        px,py,fx,fy = procf(s.μ,K,s.s)
+        c = 0.1069/s.μ
+
+        # Step H
+        if c*abs(U) <= py*exp(px+E)-fy*exp(fx+E)
+            return K
+        end
+    end
+end
+
+# log(1+x)-x
+# accurate ~2ulps for -0.227 < x < 0.315
+function log1pmx_kernel(x::Float64)
+    r = x/(x+2.0)
+    t = r*r
+    w = @horner(t,
+                6.66666666666666667e-1, # 2/3
+                4.00000000000000000e-1, # 2/5
+                2.85714285714285714e-1, # 2/7
+                2.22222222222222222e-1, # 2/9
+                1.81818181818181818e-1, # 2/11
+                1.53846153846153846e-1, # 2/13
+                1.33333333333333333e-1, # 2/15
+                1.17647058823529412e-1) # 2/17
+    hxsq = 0.5*x*x
+    r*(hxsq+w*t)-hxsq
+end
+
+# use naive calculation or range reduction outside kernel range.
+# accurate ~2ulps for all x
+function log1pmx(x::Float64)
+    if !(-0.7 < x < 0.9)
+        return log1p(x) - x
+    elseif x > 0.315
+        u = (x-0.5)/1.5
+        return log1pmx_kernel(u) - 9.45348918918356180e-2 - 0.5*u
+    elseif x > -0.227
+        return log1pmx_kernel(x)
+    elseif x > -0.4
+        u = (x+0.25)/0.75
+        return log1pmx_kernel(u) - 3.76820724517809274e-2 + 0.25*u
+    elseif x > -0.6
+        u = (x+0.5)*2.0
+        return log1pmx_kernel(u) - 1.93147180559945309e-1 + 0.5*u
+    else
+        u = (x+0.625)/0.375
+        return log1pmx_kernel(u) - 3.55829253011726237e-1 + 0.625*u
+    end
+end
+
+# log(x) - x + 1
+function logmxp1(x::Float64)
+    if x <= 0.3
+        return (log(x) + 1.0) - x
+    elseif x <= 0.4
+        u = (x-0.375)/0.375
+        return log1pmx_kernel(u) - 3.55829253011726237e-1 + 0.625*u
+    elseif x <= 0.6
+        u = 2.0*(x-0.5)
+        return log1pmx_kernel(u) - 1.93147180559945309e-1 + 0.5*u
+    else
+        return log1pmx(x-1.0)
+    end
+end
+
+# Procedure F                    
+function procf(μ::Float64, K::Int, s::Float64)
+    # can be pre-computed, but does not seem to affect performance
+    ω = 0.3989422804014327/s
+    b1 = 0.041666666666666664/μ
+    b2 = 0.3*b1*b1
+    c3 = 0.14285714285714285*b1*b2
+    c2 = b2 - 15.0*c3
+    c1 = b1 - 6.0*b2 + 45.0*c3
+    c0 = 1.0 - b1 + 3.0*b2 - 15.0*c3
+
+    if K < 10
+        px = -μ
+        py = μ^K/factorial(K)
+    else
+        δ = 0.08333333333333333/K
+        δ -= 4.8*δ^3
+        V = (μ-K)/K
+        px = K*log1pmx(V) - δ # avoids need for table
+        py = 0.3989422804014327/sqrt(K)
+
+    end
+    X = (K-μ+0.5)/s
+    X2 = X^2
+    fx = -0.5*X2 # missing negation in pseudo-algorithm, but appears in fortran code.
+    fy = ω*(((c3*X2+c2)*X2+c1)*X2+c0)
+    return px,py,fx,fy
+end


### PR DESCRIPTION
The whole business of moving out core samplers to Sampling.jl does not turn out to make things better. Samplers are closely related to distributions, and separating them into two packages just gets in the way ...

Now the samplers are moved back here, which also comes with a refactored API around `Sampleable` (some basic methods are now defined on `Sampleable` level, such as `size`, `length`, `rand`, and `nsamples`).
