### PR TITLE
Fix label in "Type Hierarchy" documentation

### DIFF
--- a/doc/source/types.rst
+++ b/doc/source/types.rst
@@ -34,7 +34,7 @@ It has two type parameters that define the kind of samples that can be drawn the
        **Type**           **Element type**           **Descriptions**
     ------------------ ------------------------- --------------------------------------
      ``Discrete``         ``Int``                   Samples take discrete values
-     ``Discrete``         ``Float64``               Samples take continuous real values
+     ``Continuous``       ``Float64``               Samples take continuous real values
     ================== ========================= ======================================
 
 Multiple samples are often organized into an array, depending on the variate form.


### PR DESCRIPTION
The `Discrete` type was listed for both Discrete and Continuous samplers
variables in the documentation. This commit changes the Continuous case
to `Continuous`.
