### PR TITLE
Use square root of variance when creating instance of Normal

### DIFF
--- a/src/conjugates/normalgamma.jl
+++ b/src/conjugates/normalgamma.jl
@@ -40,7 +40,7 @@ function rand(d::NormalGamma)
     if tau2 <= zero(Float64)
         tau2 = eps(Float64)
     end
-    mu = rand(Normal(d.mu, 1./(tau2*d.nu)))
+    mu = rand(Normal(d.mu, sqrt(1./(tau2*d.nu))))
     return mu, tau2
 end
 

--- a/src/conjugates/normalinversegamma.jl
+++ b/src/conjugates/normalinversegamma.jl
@@ -48,6 +48,6 @@ function rand(d::NormalInverseGamma)
     if sig2 <= zero(Float64)
         sig2 = eps(Float64)
     end
-    mu = rand(Normal(d.mu, sig2*d.v0))
+    mu = rand(Normal(d.mu, sqrt(sig2*d.v0)))
     return mu, sig2
 end


### PR DESCRIPTION
For `NormalGamma` and `NormalInverseGamma`, the current `rand()` code initializes an instance of `Normal` using the variance instead of standard deviation. This gives an incorrect `mu` variate. This pull request fixes this issue.
