### PR TITLE
Statistical tests for NormalGamma and NormalInverseGamma

### DIFF
--- a/src/conjugates/normalgamma.jl
+++ b/src/conjugates/normalgamma.jl
@@ -44,3 +44,10 @@ function rand(d::NormalGamma)
     return mu, tau2
 end
 
+mean(d::NormalGamma) = (d.mu, d.shape/d.rate)
+
+function var(d::NormalGamma)
+    varmu   = d.rate/(d.nu*(d.shape-1.0))
+    vartau2 = d.shape/(d.rate^2)
+    varmu, vartau2
+end

--- a/src/conjugates/normalinversegamma.jl
+++ b/src/conjugates/normalinversegamma.jl
@@ -51,3 +51,15 @@ function rand(d::NormalInverseGamma)
     mu = rand(Normal(d.mu, sqrt(sig2*d.v0)))
     return mu, sig2
 end
+
+function mean(d::NormalInverseGamma)
+    d.shape > 1.0 || throw(ArgumentError("Mean of NormalInverseGamma only defined for shape > 1"))
+    d.mu, d.scale/(d.shape-1.0)
+end
+
+function var(d::NormalInverseGamma)
+    d.shape > 2.0 || throw(ArgumentError("Variance of NormalInverseGamma only defined for shape > 2"))
+    varmu   = d.v0*d.scale/(d.shape-1.0)
+    varsig2 = (d.scale/(d.shape-1))^2/(d.shape-2)
+    varmu, varsig2
+end

--- a/test/conjugate_stats.jl
+++ b/test/conjugate_stats.jl
@@ -1,0 +1,36 @@
+using Distributions
+using Base.Test
+
+const n_samples = 5_000_001
+
+for d in [
+	NormalGamma(-1.0, 1.0, 3.0, 1.0),
+	NormalGamma( 0.0, 1.0, 3.0, 1.0),
+    NormalGamma( 0.0, 5.0, 3.0, 1.0),
+    NormalGamma( 0.0, 5.0, 4.0, 1.0),
+    NormalGamma( 0.0,10.0, 4.0, 2.0),
+    NormalInverseGamma(-2.0, 1.0, 3.0, 1.0),
+    NormalInverseGamma( 0.0, 1.0, 3.0, 1.0),
+    NormalInverseGamma( 0.0, 0.2, 3.0, 1.0),
+    NormalInverseGamma( 0.0, 0.2, 4.0, 1.0),
+    NormalInverseGamma( 0.0, 0.1, 4.0, 2.0)]
+
+	println(d)
+	dmean = mean(d)
+	dvar = var(d)
+
+	xmu   = Array(Float64, n_samples)
+	xv2 = Array(Float64, n_samples)
+	for i = 1 : n_samples
+		xmu[i], xv2[i] = rand(d)
+	end
+	mumean = mean(xmu)
+	v2mean = mean(xv2)
+	muvar  = var(xmu)
+	v2var  = var(xv2)
+
+	@test_approx_eq_eps mumean dmean[1]  0.01
+	@test_approx_eq_eps v2mean dmean[2]  0.01
+	@test_approx_eq_eps muvar  dvar[1]   0.02
+	@test_approx_eq_eps v2var  dvar[2]   0.02
+end


### PR DESCRIPTION
This pull request adds `mean` and `var` for `NormalGamma` and `NormalInverseGamma`. In addition, it uses those moments to verify that `rand` is working correctly for those distributions.
