### PR TITLE
Fix to ensure consistency between insupport() and logpdf() for Inverse/Wishart

### DIFF
--- a/src/matrix/inversewishart.jl
+++ b/src/matrix/inversewishart.jl
@@ -27,8 +27,7 @@ function InverseWishart(nu::Real, Psi::Matrix{Float64})
 end
 
 function insupport(IW::InverseWishart, X::Matrix{Float64})
-    return size(X) == size(IW.Psichol) && isApproxSymmmetric(X) &&
-           hasCholesky(X)
+    return size(X) == size(IW) && isApproxSymmmetric(X) && hasCholesky(X)
 end
 # This just checks if X could come from any Inverse-Wishart
 function insupport(::Type{InverseWishart}, X::Matrix{Float64})
@@ -45,17 +44,18 @@ function mean(IW::InverseWishart)
 end
 
 function _logpdf{T<:Real}(IW::InverseWishart, X::DenseMatrix{T})
-    if !insupport(IW, X)
-        return -Inf
-    else
+    Xchol = trycholfact(X)
+    if size(X) == size(IW) && isApproxSymmmetric(X) && isa(Xchol, Cholesky)
         p = size(X, 1)
         logd::Float64 = IW.nu * p / 2.0 * log(2.0)
         logd += lpgamma(p, IW.nu / 2.0)
         logd -= IW.nu / 2.0 * logdet(IW.Psichol)
         logd = -logd
-        logd -= 0.5 * (IW.nu + p + 1.0) * logdet(X)
-        logd -= 0.5 * trace(X \ (IW.Psichol[:U]' * IW.Psichol[:U]))
+        logd -= 0.5 * (IW.nu + p + 1.0) * logdet(Xchol)
+        logd -= 0.5 * trace(inv(Xchol) * (IW.Psichol[:U]' * IW.Psichol[:U]))
         return logd
+    else
+        return -Inf
     end
 end
 

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -27,7 +27,7 @@ dim(W::Wishart) = size(W.Schol, 1)
 size(W::Wishart) = size(W.Schol)
 
 function insupport(W::Wishart, X::Matrix{Float64})
-    return size(X) == size(W.Schol) && isApproxSymmmetric(X) && hasCholesky(X)
+    return size(X) == size(W) && isApproxSymmmetric(X) && hasCholesky(X)
 end
 # This just checks if X could come from any Wishart
 function insupport(::Type{Wishart}, X::Matrix{Float64})
@@ -56,14 +56,15 @@ function lognorm(W::Wishart)
 end
 
 function _logpdf{T<:Real}(W::Wishart, X::DenseMatrix{T})
-    if !insupport(W, X)
-        return -Inf
-    else
+    Xchol = trycholfact(X)
+    if size(X) == size(W) && isApproxSymmmetric(X) && isa(Xchol, Cholesky)
         d = dim(W)
         logd = -lognorm(W)
-        logd += 0.5 * (W.nu - d - 1.0) * logdet(X)
+        logd += 0.5 * (W.nu - d - 1.0) * logdet(Xchol)
         logd -= 0.5 * trace(W.Schol \ X)
         return logd
+    else
+        return -Inf
     end
 end
 


### PR DESCRIPTION
This pull request is meant to fix inconsistencies that can occur between `insupport()` results and `logpdf()` calculations for Wishart and InverseWishart distributions.

The issue:
- Let `D` denote a Wishart or InverseWishart distribution object, and `X` a real matrix to evaluate.
- `logpdf(D, X)` is intended to return `-Inf` if `X` is not in the support of `D`, and a numeric value otherwise.
- Support is tested with `insupport(D, X)`.
- `insupport()` uses the Cholesky factorization of `X`, and `logpdf()` calculations involving `X` are non-Cholesky based.
- If `X` is close to being singular, Cholesky-based calculations of determinants, inverses, etc. can differ from non-Cholesky-based ones.
- This can lead to situations where `insupport()` returns true, but `logpdf()` calculations throw errors (e.g. the non-Cholesky-based inverse cannot be calculated, even though the Cholesky factorization can).
- In a nutshell, `logpdf()` can result in a terminal error instead of a numeric value or `-Inf`, as intended.

The solution proposed in this pull:
- Use Cholesky-based methods to compute  the determinant and inverse of `X` in `logpdf()` - `logdet(cholfact(X))` and `inv(cholfact(X))` are the log-determinant and inverse of `X`, respectively.
- Note that `trycholfact()` is added and `hasCholesky()` modified a bit to allow the Cholesky factorization to be computed only once in a call to `logpdf()`.  Determinants and inverses are then computed from that one factorization.
- Currently, a call to `logpdf()` can result in unrelated Cholesky factorization, determinant, and inverse calculations.
- Having them all be based on the factorization should  make calculations consistent, faster, and more precise.

Feel free to let me know if there are any questions about or suggestions for the pull.
