### PR TITLE
Moments of MixtureModel no longer includes components with 0 probability

### DIFF
--- a/src/mixturemodel.jl
+++ b/src/mixturemodel.jl
@@ -40,7 +40,9 @@ dim(d::MixtureModel{Multivariate}) = dim(d.components[1])
 function mean(d::MixtureModel)
     m = 0.0
     for i in 1:length(d.components)
-        m += mean(d.components[i]) * d.probs[i]
+        if d.probs[i] > 0.
+            m += mean(d.components[i]) * d.probs[i]
+        end
     end
     return m
 end
@@ -75,7 +77,9 @@ function var(d::MixtureModel)
     m = 0.0
     squared_mean_mixture = mean(d).^2
     for i in 1:length(d.components)
-        m += (var(d.components[i]) .- squared_mean_mixture .+ mean(d.components[i]).^2) * d.probs[i]
+        if d.probs[i] > 0.
+            m += (var(d.components[i]) .- squared_mean_mixture .+ mean(d.components[i]).^2) * d.probs[i]
+        end
     end
     return m
 end


### PR DESCRIPTION
If, some mixture components have 0 probability, but moments that are Inf or NaN, e.g.

``` julia
Truncated(Normal(), 10, Inf)
```

then this can cause the mixture moments to be Inf or NaN, even when they finite.

Here, we fix this, by not incorporating mixture components with 0 probability in the moment computation.
