### PR TITLE
fix instantiation of DimensionMismatch

### DIFF
--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -78,7 +78,7 @@ typealias ZeroMeanFullNormal MvNormal{PDMat,ZeroVector{Float64}}
 ### Construction
 
 function MvNormal{Cov<:AbstractPDMat}(μ::Vector{Float64}, Σ::Cov)
-    dim(Σ) == length(μ) || throw(DimensionMismatch("The dimensions of μ and Σ are inconsistent."))
+    dim(Σ) == length(μ) || throw(DimensionMismatch("The dimensions of mu and Sigma are inconsistent."))
     MvNormal{Cov,Vector{Float64}}(μ, Σ)
 end
 


### PR DESCRIPTION
An instantiation of DimensionMismatch used the unicode characters for mu and Sigma. Alas, DimensionMismatch can only receive an ASCII string as message.
