### PR TITLE
Update _invwishart_c0 to accept all df <: Real

### DIFF
--- a/src/matrix/inversewishart.jl
+++ b/src/matrix/inversewishart.jl
@@ -21,7 +21,7 @@ InverseWishart(df::Real, Ψ::Matrix{Float64}) = InverseWishart(df, PDMat(Ψ))
 
 InverseWishart(df::Real, Ψ::Cholesky) = InverseWishart(df, PDMat(Ψ))
 
-function _invwishart_c0(df::Float64, Ψ::AbstractPDMat)
+function _invwishart_c0(df::Real, Ψ::AbstractPDMat)
     h_df = df / 2
     p = dim(Ψ)
     h_df * (p * logtwo - logdet(Ψ)) + lpgamma(p, h_df)


### PR DESCRIPTION
We were only accepting df <: Float64.

This was more restrictive than the constructors for InverseWishart.

Found this problem when I tried to pass df as an Int64.
