### PR TITLE
Fix typo in mode function for truncated normal distributions

### DIFF
--- a/src/truncated/normal.jl
+++ b/src/truncated/normal.jl
@@ -14,8 +14,8 @@ maximum(d::Truncated{Normal}) = d.upper
 
 function mode(d::Truncated{Normal})
     μ = mean(d.untruncated)
-    d.upper < mu ? d.upper :
-    d.lower > mu ? d.lower : μ
+    d.upper < μ ? d.upper :
+    d.lower > μ ? d.lower : μ
 end
 
 modes(d::Truncated{Normal}) = [mode(d)]


### PR DESCRIPTION
There really also should be a unit test that should have caught this error, but I don't understand the structure of the package well enough right now to add that.
