### PR TITLE
Gamma distribution should compute mode for shape=1

### DIFF
--- a/src/univariate/continuous/gamma.jl
+++ b/src/univariate/continuous/gamma.jl
@@ -37,7 +37,7 @@ kurtosis(d::Gamma) = 6.0 / d.α
 
 function mode(d::Gamma)
     (α, β) = params(d)
-    α > 1.0 ? β * (α - 1.0) : error("Gamma has no mode when shape < 1.0")
+    α >= 1.0 ? β * (α - 1.0) : error("Gamma has no mode when shape < 1.0")
 end
 
 function entropy(d::Gamma)


### PR DESCRIPTION
I think, at least I don't see any reason why it would not.
