### PR TITLE
removing undefined function names from export list

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -72,8 +72,6 @@ export
     FullNormal,
     FullNormalCanon,
     Gamma,
-    GenericMvNormal,
-    GenericMvNormalCanon,
     Geometric,
     Gumbel,
     Hypergeometric,


### PR DESCRIPTION
GenericMvNormal and GenericMvNormalCanon were removed/renamed during a previous refactoring. However, the names are still exported despite being undefined. This pull requests fixes this.