### PR TITLE
[WIP] Fix mean(NoncentralT) when df is Inf

### DIFF
--- a/src/univariate/continuous/noncentralt.jl
+++ b/src/univariate/continuous/noncentralt.jl
@@ -11,7 +11,18 @@ end
 
 @distr_support NoncentralT -Inf Inf
 
-mean(d::NoncentralT) = d.df > 1.0 ? sqrt(0.5*d.df)*d.ncp*gamma(0.5*(d.df-1))/gamma(0.5*d.df) : NaN
+function mean(d::NoncentralT)
+    if d.df > 1.0
+        if isinf(d.df)
+            d.ncp
+        else
+            sqrt(0.5*d.df)*d.ncp*gamma(0.5*(d.df-1))/gamma(0.5*d.df)
+        end
+    else
+        NaN
+    end
+end
+
 var(d::NoncentralT) = d.df > 2.0 ? d.df*(1+d.ncp^2)/(d.df-2.0) - mean(d)^2 : NaN
 
 function rand(d::NoncentralT)


### PR DESCRIPTION
This changes the definition of mean(NoncentralT) so that a non-central T distribution with zero non-centrality parameter produces the same mean as the central T distribution would.

In practice, this reduces to changing the code to pass the following tests:

```
using Distributions
using Base.Test

@test mean(TDist(Inf)) == 0.0

@test mean(NoncentralT(Inf, 0)) == 0.0
```
