### PR TITLE
Use `ifelse` for faster `rand(Laplace())`

### DIFF
--- a/src/univariate/continuous/laplace.jl
+++ b/src/univariate/continuous/laplace.jl
@@ -74,10 +74,7 @@ end
 
 #### Sampling
 
-function rand(d::Laplace) 
-    z = randexp()
-    rand(Bool) ? d.μ + d.β * z : d.μ - d.β * z 
-end
+rand(d::Laplace) = d.μ + d.β*randexp()*ifelse(rand(Bool), 1, -1)
 
 
 #### Fitting


### PR DESCRIPTION
Elapsed times for 400 trials of 2,000,000 iterations:

![p](https://cloud.githubusercontent.com/assets/876546/7252628/b387dea0-e871-11e4-8bcf-d7d1d18d282c.png)

```julia
import Distributions


function go(r, n)
    for _ in 1:n
        rand(r)
    end
end


function main()
    r = Distributions.Laplace()
    n = 2000000
    rand(r)
    for _ in 1:400
        @time go(r, n)
    end
end

main()
```