### PR TITLE
Fix fit(::Cauchy, x)

### DIFF
--- a/src/univariate/continuous/cauchy.jl
+++ b/src/univariate/continuous/cauchy.jl
@@ -69,7 +69,7 @@ cf(d::Cauchy, t::Real) = exp(im * (t * d.μ) - d.β * abs(t))
 #### Fitting
 
 # Note: this is not a Maximum Likelihood estimator
-function fit{T <: Real}(::Type{Cauchy}, x::Array{T})
-    l, u = iqr(x)
-    Cauchy(median(x), (u - l) / 2.0)
+function fit{T<:Real}(::Type{Cauchy}, x::AbstractArray{T})
+    l, m, u = quantile(x, [0.25, 0.5, 0.75])
+    Cauchy(m, (u - l) / 2.0)
 end

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -47,7 +47,7 @@ p = countnz(x) / n0
 d = fit(Bernoulli, x, w)
 p = sum(w[x .== 1]) / sum(w)
 @test isa(d, Bernoulli)
-@test_approx_eq mean(d) p 
+@test_approx_eq mean(d) p
 
 d = fit(Bernoulli, rand(Bernoulli(0.7), N))
 @test isa(d, Bernoulli)
@@ -129,6 +129,11 @@ d = fit(Categorical, suffstats(Categorical, 3, x, w))
 d = fit(Categorical, rand(Categorical(p), N))
 @test isa(d, Categorical)
 @test_approx_eq_eps probs(d) p 0.01
+
+
+# Cauchy
+
+@test fit(Cauchy, collect(-4.0:4.0)) === Cauchy(0.0, 2.0)
 
 
 # Exponential


### PR DESCRIPTION
Due to an apparent change in the output of iqr(x), this fit method has
been broken for awhile and threw a BoundsError because it expected iqr()
to return two numbers.

This PR restores the functionality of fit(::Cauchy, x), by calling the
quantile function directly. Doing so has the added benefit of getting
the median in the same computation. I've also generalized this fit
method to accept as input x::AbstractArray, not just x::Array.
Finally, I've also added a simple test for this fit method.