### PR TITLE
Fix #364

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -35,8 +35,9 @@ function _use_multline_show(d::Distribution, pnames)
         pv = d.(p)
         if !(isa(pv, Number) || isa(pv, NTuple) || isa(pv, AbstractVector))
             multline = true
+        else
+            tlen += length(pv)
         end
-        tlen += length(pv)
         push!(namevals, (p, pv))
     end
     if tlen > 8


### PR DESCRIPTION
_use_multline_show now tallies the number of numeric entries _only_ for
scalars, tuples of scalars, or vector fields. If any other type of field
is encountered, defaults to multiline show layout.

This change in logic avoids problems with types like
EmpiricalUnivariateDistribution which contain nonnumeric fields.