### PR TITLE
Remove subtype constraints in support methods

### DIFF
--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -11,15 +11,15 @@ minimum(r::RealInterval) = r.lb
 maximum(r::RealInterval) = r.ub
 @compat in(x::Real, r::RealInterval) = (r.lb <= Float64(x) <= r.ub)
 
-isbounded{D<:UnivariateDistribution}(d::Union(D,Type{D})) = isupperbounded(d) && islowerbounded(d)
+isbounded(d::Union(UnivariateDistribution,Type{UnivariateDistribution})) = isupperbounded(d) && islowerbounded(d)
 
-islowerbounded{D<:UnivariateDistribution}(d::Union(D,Type{D})) = minimum(d) > -Inf
-isupperbounded{D<:UnivariateDistribution}(d::Union(D,Type{D})) = maximum(d) < +Inf
+islowerbounded(d::Union(UnivariateDistribution,Type{UnivariateDistribution})) = minimum(d) > -Inf
+isupperbounded(d::Union(UnivariateDistribution,Type{UnivariateDistribution})) = maximum(d) < +Inf
 
 hasfinitesupport(d::DiscreteUnivariateDistribution) = isbounded(d)
 hasfinitesupport(d::ContinuousUnivariateDistribution) = false
 
-function insupport!{D<:UnivariateDistribution}(r::AbstractArray, d::Union(D,Type{D}), X::AbstractArray)
+function insupport!(r::AbstractArray, d::Union(UnivariateDistribution,Type{UnivariateDistribution}), X::AbstractArray)
     length(r) == length(X) ||
         throw(DimensionMismatch("Inconsistent array dimensions."))
     for i in 1 : length(X)
@@ -28,14 +28,18 @@ function insupport!{D<:UnivariateDistribution}(r::AbstractArray, d::Union(D,Type
     return r
 end
 
-insupport{D<:UnivariateDistribution}(d::Union(D,Type{D}), X::AbstractArray) =
+insupport(d::Union(UnivariateDistribution,Type{UnivariateDistribution}), X::AbstractArray) =
      insupport!(BitArray(size(X)), d, X)
 
-insupport{D<:ContinuousUnivariateDistribution}(d::Union(D,Type{D}),x::Real) = minimum(d) <= x <= maximum(d)
-insupport{D<:DiscreteUnivariateDistribution}(d::Union(D,Type{D}),x::Real) = isinteger(x) && minimum(d) <= x <= maximum(d)
+insupport(d::Union(ContinuousUnivariateDistribution,Type{ContinuousUnivariateDistribution}),x::Real) =
+  minimum(d) <= x <= maximum(d)
+insupport(d::Union(DiscreteUnivariateDistribution,Type{DiscreteUnivariateDistribution}),x::Real) =
+  isinteger(x) && minimum(d) <= x <= maximum(d)
 
-support{D<:ContinuousUnivariateDistribution}(d::Union(D,Type{D})) = RealInterval(minimum(d), maximum(d))
-support{D<:DiscreteUnivariateDistribution}(d::Union(D,Type{D})) = round(Int, minimum(d)):round(Int, maximum(d))
+support(d::Union(ContinuousUnivariateDistribution,Type{ContinuousUnivariateDistribution})) =
+  RealInterval(minimum(d), maximum(d))
+support(d::Union(DiscreteUnivariateDistribution,Type{DiscreteUnivariateDistribution})) =
+  round(Int, minimum(d)):round(Int, maximum(d))
 
 ## macros to declare support
 


### PR DESCRIPTION
The subtype constraints on the new fallback support methods may not be needed.  If not, the changes in this pull will get rid of the current warnings about ambiguous method definitions (shown below).

P.S.  Do you even need the Type{*} parts of the Unions?

```julia
Warning: New definition
    insupport(Truncated{D<:Distribution{Univariate,S<:ValueSupport},S<:ValueSupp
ort},Real) at C:\Users\bjsmith\.julia\v0.3\Distributions\src\truncate.jl:33
is ambiguous with:
    insupport(Union(D<:Distribution{Univariate,Continuous},Type{D<:Distribution{
Univariate,Continuous}}),Real) at C:\Users\bjsmith\.julia\v0.3\Distributions\src
\univariates.jl:34.
To fix, define
    insupport(_<:Truncated{D<:Distribution{Univariate,S<:ValueSupport},Continuou
s},Real)
before the new definition.
Warning: New definition
    insupport(Truncated{D<:Distribution{Univariate,S<:ValueSupport},S<:ValueSupp
ort},Real) at C:\Users\bjsmith\.julia\v0.3\Distributions\src\truncate.jl:33
is ambiguous with:
    insupport(Union(Type{D<:Distribution{Univariate,Discrete}},D<:Distribution{U
nivariate,Discrete}),Real) at C:\Users\bjsmith\.julia\v0.3\Distributions\src\uni
variates.jl:35.
To fix, define
    insupport(_<:Truncated{D<:Distribution{Univariate,S<:ValueSupport},Discrete}
,Real)
before the new definition.
```