### PR TITLE
Fix for Issue #384 (pdf of Binomial)

### DIFF
--- a/test/binomial.jl
+++ b/test/binomial.jl
@@ -1,0 +1,23 @@
+using Distributions
+using Base.Test
+
+# Test the consistency between the recursive and nonrecursive computation of the pdf 
+# of the Binomial distribution
+srand(1234)
+for (p, n) in [(0.6, 10), (0.8, 6), (0.5, 40), (0.04, 20), (1., 100), (0., 10), (0.999999, 1000), (1e-7, 1000)]
+    
+    d = Binomial(n, p)
+   
+    a = pdf(d, 0:n)
+    for t=0:n
+        @test_approx_eq pdf(d, t) a[1+t]
+    end
+   
+    li = rand(0:n, 2)
+    rng = minimum(li):maximum(li)
+    b = pdf(d, rng)
+    for t in rng
+        @test_approx_eq pdf(d, t) b[t - first(rng) + 1]
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ tests = [
     "continuous",
     "fit",
     "multinomial",
+    "binomial",
     "poissonbinomial",
     "dirichlet",
     "mvnormal",


### PR DESCRIPTION
This patch should fix issue #384  and adds a quick test case to check consistency of `pdf(Binomial(n,p))` and `pdf(Binomial(n,p), x)`. It also removes a bit of duplicate code in `univariates.jl` by moving it in a helper function `_pdf_fill_outside!`.