### PR TITLE
Fix ambiguous Truncated insupport method for julia 0.4

### DIFF
--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -30,7 +30,7 @@ isupperbounded(d::Truncated) = isupperbounded(d.untruncated) || isfinite(d.upper
 minimum(d::Truncated) = max(minimum(d.untruncated), d.lower)
 maximum(d::Truncated) = min(maximum(d.untruncated), d.upper)
 
-insupport{D<:UnivariateDistribution,S<:ValueSupport}(d::Truncated{D,S}, x::Real) =
+insupport{D<:UnivariateDistribution}(d::Truncated{D,Union(Discrete,Continuous)}, x::Real) =
     d.lower <= x <= d.upper && insupport(d.untruncated, x)
 
 


### PR DESCRIPTION
This is a fix to eliminate the ambiguous definition warnings for the Truncated insupport method, noted in #391 to be occurring now in julia 0.4.

The warnings started with pull #374 and were fixed for julia 0.3 with pull #382. Apparently, that previous fix is not working for julia 0.4, and so this one is being proposed to finish the job.  It has been tested on julia 0.3 and 0.4 and seems to eliminate the ambiguous warnings on both.