### PR TITLE
Use Cholesky when inverting random Wishart matrices. Fixes #393

### DIFF
--- a/src/matrix/inversewishart.jl
+++ b/src/matrix/inversewishart.jl
@@ -79,7 +79,7 @@ rand(d::InverseWishart) = inv(rand(Wishart(d.df, inv(d.Ψ))))
 function _rand!{M<:Matrix}(d::InverseWishart, X::AbstractArray{M})
     wd = Wishart(d.df, inv(d.Ψ))
     for i in 1:length(X)
-        X[i] = inv(rand(wd))
+        X[i] = inv(cholfact!(rand(wd)))
     end
     return X
 end


### PR DESCRIPTION
The present version didn't assume anything about the Wishart matrix so the inverse was calculated with the LU factorization and consequently it was numerically unsymmetric.