### PR TITLE
Fixing Boundary parameter handling #283 for Poisson(0)

### DIFF
--- a/src/univariate/discrete/poisson.jl
+++ b/src/univariate/discrete/poisson.jl
@@ -2,7 +2,7 @@ immutable Poisson <: DiscreteUnivariateDistribution
     λ::Float64
 
     function Poisson(λ::Float64)
-        λ > 0.0 || error("λ must be positive.")
+        λ >= 0.0 || error("λ must be non-negative.")
         new(λ)
     end
 
@@ -10,7 +10,7 @@ immutable Poisson <: DiscreteUnivariateDistribution
     Poisson() = new(1.0)
 end
 
-@distr_support Poisson 0 Inf
+@distr_support Poisson 0 (d.λ == 0.0 ? 0 : Inf)
 
 
 ### Parameters
@@ -39,7 +39,9 @@ kurtosis(d::Poisson) = 1.0 / d.λ
 
 function entropy(d::Poisson)
     λ = rate(d)
-    if λ < 50.0
+    if λ == 0.0
+        return 0.0
+    elseif λ < 50.0
         s = 0.0
         λk = 1.0
         for k = 1:100

--- a/test/discrete_test.json
+++ b/test/discrete_test.json
@@ -1376,6 +1376,33 @@
     }
   ], 
   [
+    "Poisson(0.0)", 
+    {
+      "dtype": "Poisson", 
+        "entropy": 0.0,
+      "maximum": 0, 
+      "mean": 0.0, 
+      "median": 0.0, 
+      "minimum": 0, 
+      "params": {
+        "rate": 0.0
+      }, 
+      "points": [
+        {
+          "cdf": 1.0, 
+          "logpdf": 0.0, 
+          "x": 0
+        }
+      ], 
+      "q10": 0.0, 
+      "q25": 0.0, 
+      "q50": 0.0, 
+      "q75": 0.0, 
+      "q90": 0.0, 
+      "var": 0.0
+    }
+  ], 
+  [
     "Poisson(0.5)", 
     {
       "dtype": "Poisson", 


### PR DESCRIPTION
As spaceLem, I need a rate of 0 for the Poisson distribution. So I've gone through the distribution code and test scripts, and added in support (and tests) for a rate of 0. This has a v0.9 milestone, and has been sitting around unfixed for almost a year. I hope it's useful to just provide it, otherwise it seems like it may hang around for ever.

Cheers,

Richard.