### PR TITLE
Permanently add Poisson(0.0) to test suite updating #398

### DIFF
--- a/test/discrete_test.lst
+++ b/test/discrete_test.lst
@@ -36,6 +36,7 @@ NegativeBinomial(1, 0.5)
 NegativeBinomial(5, 0.6)
 
 Poisson()
+Poisson(0.0)
 Poisson(0.5)
 Poisson(2.0)
 Poisson(10.0)


### PR DESCRIPTION
Merged pull request #398 only added Poisson(0.0) test to json file as I didn't understand how the test suite worked. I've now added it to the right place - thanks @lindahua - and fixed the python code to handle Poisson(0.0) correctly.