### PR TITLE
Allow precompiling Distributions

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -1,3 +1,5 @@
+VERSION >= v"0.4.0-dev+6521" && __precompile__(true)
+
 module Distributions
 
 using ArrayViews


### PR DESCRIPTION
Title says it all.

This implies precompiling the dependencies for Distributions. We should probably explicit flag all of them as safe for precompilation.