### PR TITLE
don't automatically promote to Float64 for ContinuousUnivariateDistributions

### DIFF
--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -95,8 +95,7 @@ pdf(d::DiscreteUnivariateDistribution, x::Int) = throw(MethodError(pdf, (d, x)))
 pdf(d::DiscreteUnivariateDistribution, x::Integer) = pdf(d, round(Int, x))
 pdf(d::DiscreteUnivariateDistribution, x::Real) = isinteger(x) ? pdf(d, round(Int, x)) : 0.0
 
-pdf(d::ContinuousUnivariateDistribution, x::Float64) = throw(MethodError(pdf, (d, x)))
-@compat pdf(d::ContinuousUnivariateDistribution, x::Real) = pdf(d, Float64(x))
+pdf(d::ContinuousUnivariateDistribution, x::Number) = throw(MethodError(pdf, (d, x)))
 
 # logpdf
 
@@ -104,8 +103,7 @@ logpdf(d::DiscreteUnivariateDistribution, x::Int) = log(pdf(d, x))
 logpdf(d::DiscreteUnivariateDistribution, x::Integer) = logpdf(d, round( Int, x))
 logpdf(d::DiscreteUnivariateDistribution, x::Real) = isinteger(x) ? logpdf(d, round(Int, x)) : -Inf
 
-logpdf(d::ContinuousUnivariateDistribution, x::Float64) = log(pdf(d, x))
-@compat logpdf(d::ContinuousUnivariateDistribution, x::Real) = logpdf(d, Float64(x))
+logpdf(d::ContinuousUnivariateDistribution, x::Number) = log(pdf(d, x))
 
 # cdf
 
@@ -119,54 +117,45 @@ end
 
 cdf(d::DiscreteUnivariateDistribution, x::Real) = cdf(d, floor(Int,x))
 
-cdf(d::ContinuousUnivariateDistribution, x::Float64) = throw(MethodError(cdf, (d, x)))
-@compat cdf(d::ContinuousUnivariateDistribution, x::Real) = cdf(d, Float64(x))
+cdf(d::ContinuousUnivariateDistribution, x::Number) = throw(MethodError(cdf, (d, x)))
 
 # ccdf
 
 ccdf(d::DiscreteUnivariateDistribution, x::Int) = 1.0 - cdf(d, x)
 ccdf(d::DiscreteUnivariateDistribution, x::Real) = ccdf(d, floor(Int,x))
-ccdf(d::ContinuousUnivariateDistribution, x::Float64) = 1.0 - cdf(d, x)
-@compat ccdf(d::ContinuousUnivariateDistribution, x::Real) = ccdf(d, Float64(x))
+ccdf(d::ContinuousUnivariateDistribution, x::Number) = 1.0 - cdf(d, x)
 
 # logcdf
 
 logcdf(d::DiscreteUnivariateDistribution, x::Int) = log(cdf(d, x))
 logcdf(d::DiscreteUnivariateDistribution, x::Real) = logcdf(d, floor(Int,x))
-logcdf(d::ContinuousUnivariateDistribution, x::Float64) = log(cdf(d, x))
-@compat logcdf(d::ContinuousUnivariateDistribution, x::Real) = logcdf(d, Float64(x))
+logcdf(d::ContinuousUnivariateDistribution, x::Number) = log(cdf(d, x))
 
 # logccdf
 
 logccdf(d::DiscreteUnivariateDistribution, x::Int) = log(ccdf(d, x))
 logccdf(d::DiscreteUnivariateDistribution, x::Real) = logccdf(d, floor(Int,x))
-logccdf(d::ContinuousUnivariateDistribution, x::Float64) = log(ccdf(d, x))
-@compat logccdf(d::ContinuousUnivariateDistribution, x::Real) = logccdf(d, Float64(x))
+logccdf(d::ContinuousUnivariateDistribution, x::Number) = log(ccdf(d, x))
 
 # quantile
 
-quantile(d::UnivariateDistribution, p::Float64) = throw(MethodError(quantile, (d, p)))
-@compat quantile(d::UnivariateDistribution, p::Real) = quantile(d, Float64(p))
+quantile(d::UnivariateDistribution, p::Number) = throw(MethodError(quantile, (d, p)))
 
 # cquantile
 
-cquantile(d::UnivariateDistribution, p::Float64) = quantile(d, 1.0 - p)
-@compat cquantile(d::UnivariateDistribution, p::Real) = cquantile(d, Float64(p))
+cquantile(d::UnivariateDistribution, p::Number) = quantile(d, 1.0 - p)
 
 # invlogcdf
 
-invlogcdf(d::UnivariateDistribution, lp::Float64) = quantile(d, exp(lp))
-@compat invlogcdf(d::UnivariateDistribution, lp::Real) = invlogcdf(d, Float64(lp))
+invlogcdf(d::UnivariateDistribution, lp::Number) = quantile(d, exp(lp))
 
 # invlogccdf
 
-invlogccdf(d::UnivariateDistribution, lp::Float64) = quantile(d, -expm1(lp))
-@compat invlogccdf(d::UnivariateDistribution, lp::Real) = invlogccdf(d, Float64(lp))
+invlogccdf(d::UnivariateDistribution, lp::Number) = quantile(d, -expm1(lp))
 
 # gradlogpdf
 
-gradlogpdf(d::ContinuousUnivariateDistribution, x::Float64) = throw(MethodError(gradlogpdf, (d, x)))
-@compat gradlogpdf(d::ContinuousUnivariateDistribution, x::Real) = gradlogpdf(d, Float64(x))
+gradlogpdf(d::ContinuousUnivariateDistribution, x::Number) = throw(MethodError(gradlogpdf, (d, x)))
 
 
 # vectorized versions
@@ -290,7 +279,7 @@ loglikelihood(d::UnivariateDistribution, X::AbstractArray) =
 
 macro _delegate_statsfuns(D, fpre, psyms...)
     dt = eval(D)
-    T = dt <: DiscreteUnivariateDistribution ? :Int : :Float64
+    T = dt <: DiscreteUnivariateDistribution ? :Int : :Number
 
     # function names from StatsFuns
     fpdf = symbol(string(fpre, "pdf"))

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 JSON 0.4.0
+DualNumbers

--- a/test/continuous.jl
+++ b/test/continuous.jl
@@ -74,3 +74,8 @@ end
 #     println("    testing $(distr)")
 #     test_samples(distr, n_tsamples)
 # end
+
+# Test for non-Float64 input
+using DualNumbers
+@test string(logpdf(Normal(0,1),big(1))) == "-1.418938533204672741780329736405617639861397473637783412817151540482765695927251"
+@test_approx_eq epsilon(logpdf(Normal(1.0,0.15), Dual(2.5,1.0))) -66.66666666666667


### PR DESCRIPTION
Combined with https://github.com/JuliaStats/StatsFuns.jl/pull/5, closes #427. I think the automatic promotion was out of place anyway, since some of the implementations in StatsFuns already supported non-Float64 types. This now works:
```
julia> logpdf(Normal(0,1),big(1))
-1.418938533204672741780329736405617639861397473637783412817151540482765695927251

julia> using ForwardDiff

julia> f(x::Number) = logpdf(Normal(1., 0.15), x);

julia> derivative(f, 2.5)
-66.66666666666667
```

Added a couple unit tests, not sure if they're in the right format or the right place. (The tests will fail until https://github.com/JuliaStats/StatsFuns.jl/pull/5 is merged and tagged.)

CC @scidom @jrevels