### PR TITLE
New Shifted distribution type

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -120,6 +120,7 @@ export
     PoissonBinomial,
     QQPair,
     Rayleigh,
+    Shifted,
     Skellam,
     SymTriangularDist,
     TDist,
@@ -274,6 +275,7 @@ include("samplers.jl")
 
 # others
 include("truncate.jl")
+include("shifted.jl")
 include("conversion.jl")
 include("qq.jl")
 include("estimators.jl")

--- a/src/shifted.jl
+++ b/src/shifted.jl
@@ -1,0 +1,67 @@
+immutable Shifted{D<:UnivariateDistribution, S<:ValueSupport, T} <: UnivariateDistribution{S}
+    unshifted::D        # the original distribution (unshifted)
+    offset::T           # the shift offset
+end
+
+### Constructors
+
+function Shifted(d::UnivariateDistribution, offset::Real)
+    Shifted{typeof(d),value_support(typeof(d)), typeof(offset)}(d, offset)
+end
+
+### range and support
+
+islowerbounded(d::Shifted) = islowerbounded(d.unshifted)
+isupperbounded(d::Shifted) = isupperbounded(d.unshifted)
+
+minimum(d::Shifted) = minimum(d.unshifted)+d.offset
+maximum(d::Shifted) = maximum(d.unshifted)+d.offset
+
+@compat insupport{D<:UnivariateDistribution}(d::Shifted{D,Union{Discrete,Continuous}}, x::Real) = insupport(d.unshifted, x-d.offset)
+
+
+### evaluation
+
+pdf(d::Shifted, x::Float64) = pdf(d.unshifted, x-d.offset)
+
+logpdf(d::Shifted, x::Float64) = logpdf(d.unshifted, x-d.offset)
+
+cdf(d::Shifted, x::Float64) = cdf(d.unshifted, x-d.offset)
+
+logcdf(d::Shifted, x::Float64) = logcdf(d.unshifted, x-d.offset)
+
+ccdf(d::Shifted, x::Float64) = ccdf(d.unshifted, x-d.offset)
+
+logccdf(d::Shifted, x::Float64) = logccdf(d.unshifted, x-d.offset)
+
+
+quantile(d::Shifted, p::Float64) = quantile(d.unshifted, p) + s
+
+pdf(d::Shifted, x::Int) = pdf(d.unshifted, x-d.offset)
+
+logpdf(d::Shifted, x::Int) = logpdf(d.unshifted, x-d.offset)
+
+cdf(d::Shifted, x::Int) = cdf(d.unshifted, x-d.offset)
+
+logcdf(d::Shifted, x::Int) = logcdf(d.unshifted, x-d.offset)
+
+ccdf(d::Shifted, x::Int) = ccdf(d.unshifted, x-d.offset)
+
+logccdf(d::Shifted, x::Int) = logccdf(d.unshifted, x-d.offset)
+
+rand(d::Shifted) = rand(d.unshifted) + d.offset
+
+
+## show
+
+function show(io::IO, d::Shifted)
+    print(io, "Shifted(")
+    d0 = d.unshifted
+    uml, namevals = _use_multline_show(d0)
+    uml ? show_multline(io, d0, namevals) :
+          show_oneline(io, d0, namevals)
+    print(io, ", offset=$(d.offset))")
+    uml && println(io)
+end
+
+_use_multline_show(d::Shifted) = _use_multline_show(d.unshifted)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,8 @@ tests = [
     "conversion",
     "mixture",
     "gradlogpdf",
-    "truncate"]
+    "truncate",
+    "shifted"]
 
 print_with_color(:blue, "Running tests:\n")
 

--- a/test/shifted.jl
+++ b/test/shifted.jl
@@ -1,0 +1,108 @@
+# Testing discrete univariate distributions
+
+using Distributions
+import JSON
+using Base.Test
+using Compat
+
+
+function verify_and_test_drive(jsonfile, selected, n_tsamples::Int, offset::Int)
+    R = JSON.parsefile(jsonfile)
+
+    for (ex, dct) in R
+        dsym = symbol(dct["dtype"])
+        dname = string(dsym)
+
+        dsymt = symbol("Shifted($(dct["dtype"]),$offset")
+        dnamet = string(dsym)
+
+        # test whether it is included in the selected list
+        # or all are selected (when selected is empty)
+        if !isempty(selected) && !(dname in selected)
+            continue
+        end
+
+        # perform testing
+        println("    testing Shifted($(ex),$offset)")
+        dtype = eval(dsym)
+        dtypet = Shifted
+        d = Shifted(eval(parse(ex)),offset)
+        @test isa(d, dtypet)
+        #@assert isa(dtype, Type) && dtype <: UnivariateDistribution # fails for TruncatedNormal for some reason
+
+        # verification and testing
+        verify_and_test(d, dct, n_tsamples)
+    end
+end
+
+
+@compat _parse_x(d::DiscreteUnivariateDistribution, x) = round(Int, x)
+@compat _parse_x(d::ContinuousUnivariateDistribution, x) = Float64(x)
+
+_json_value(x::Number) = x
+
+_json_value(x::AbstractString) =
+    x == "inf" ? Inf :
+    x == "-inf" ? -Inf :
+    x == "nan" ? NaN :
+    error("Invalid numerical value: $x")
+
+function verify_and_test(d::UnivariateDistribution, dct::Dict, n_tsamples::Int)
+    # verify parameters
+    pdct = dct["params"]
+    for (fname, val) in pdct
+        f = eval(symbol(fname))
+        @assert isa(f, Function)
+        Base.Test.test_approx_eq(f(d.unshifted), val, "$fname(d.unshifted)", "val")
+    end
+
+    # verify stats
+    @test_approx_eq minimum(d) _json_value(dct["minimum"]) + d.offset
+    @test_approx_eq maximum(d) _json_value(dct["maximum"]) + d.offset
+
+    # verify logpdf and cdf at certain points
+    pts = dct["points"]
+    for pt in pts
+        x = _parse_x(d, pt["x"])
+        @Base.Test.test_approx_eq_eps(logpdf(d, x + d.offset), Float64(pt["logpdf"]), sqrt(eps()))
+        @Base.Test.test_approx_eq_eps(cdf(d, x + d.offset), Float64(pt["cdf"]), sqrt(eps()))
+    end
+
+    rand(d) # makes sure this runs
+
+    try
+        m = mgf(d,0.0)
+        @test m == 1.0
+    catch e
+        isa(e, MethodError) || throw(e)
+    end
+    try
+        c = cf(d,0.0)
+        @test c == 1.0
+        # test some extra values: should all be well-defined
+        for t in (0.1,-0.1,1.0,-1.0)
+            @test !isnan(cf(d,t))
+        end
+    catch e
+        isa(e, MethodError) || throw(e)
+    end
+
+    # generic testing
+    if isa(d, Cosine)
+        n_tsamples = floor(Int, n_tsamples / 10)
+    end
+end
+
+
+## main
+
+for c in ["discrete",
+          "continuous"]
+
+    title = string(uppercase(c[1]), c[2:end])
+    println("    [$title]")
+    println("    ------------")
+    jsonfile = joinpath(dirname(@__FILE__), "$(c)_test.json")
+    verify_and_test_drive(jsonfile, ARGS, 10^6, 3)
+    println()
+end


### PR DESCRIPTION
I ran into the need for this when working with mixture distributions. Sometimes a shifted distribution is needed when creating mixture distributions. For example:

``` julia
# model where 10% of the time a constant is added to a Poisson
MixtureModel([Poisson(4), Shifted(Poisson(4), 2)], [0.9,0.1])
```
