### PR TITLE
RFC: Specialize cdf for discrete distributions with finite support

### DIFF
--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -70,19 +70,3 @@ mode(d::BetaBinomial) = indmax(pdf(d)) - 1
 modes(d::BetaBinomial) = [x - 1 for x in modes(Categorical(pdf(d)))]
 
 quantile(d::BetaBinomial, p::Float64) = quantile(Categorical(pdf(d)), p) - 1
-
-function cdf(d::BetaBinomial, x::Int)
-  c = 0.0
-  for y = minimum(d):min(floor(Int,x), maximum(d))
-    c += pdf(d, y)
-  end
-
-  # TODO: remove when https://github.com/JuliaLang/julia/issues/14620 is resolved
-  # this is needed due to the fact that pdf(d, y) can return values that are imprecise at higher decimal places (due to https://github.com/JuliaLang/julia/issues/14620)
-  # and so due to the impl above we can end up with cdf values that are basically 1 but are either slightly greater or smaller
-  if abs(c - 1.0) < 1.0e-10
-    c = 1.0
-  end
-
-  return c
-end


### PR DESCRIPTION
* For discrete functions with finite support, calculate
  `cdf` from right if we're in the right half of that support
* Remove cdf specialized on `BetaBinomial` (handled by
  `DiscreteUnivariateDistribution` version)
* ~~Remove extraneous definitions of `*cdf` functions which simply
  convert values to `Int` or `Float64`, where these conversions will
  happen in a call to `cdf(...)`~~ See #428