### PR TITLE
Small grammatical doc change

### DIFF
--- a/doc/source/types.rst
+++ b/doc/source/types.rst
@@ -16,7 +16,7 @@ The root of this type hierarchy is ``Sampleable``. The abstract type ``Sampleabl
 
 It has two type parameters that define the kind of samples that can be drawn therefrom. 
 
-- ``F <: VariateForm`` specifies the form of the variate, which can be either of the following:
+- ``F <: VariateForm`` specifies the form of the variate, which can be one of the following:
 
     ================== ========================= ======================================
        **Type**           **A single sample**       **Multiple samples**


### PR DESCRIPTION
Either is typically used for two options. More than two is informal, and sometimes confusing.

Sorry if this is tediously small, it just tripped me up a bit.