### PR TITLE
fix type restriction on params function

### DIFF
--- a/src/univariate/discrete/geometric.jl
+++ b/src/univariate/discrete/geometric.jl
@@ -15,7 +15,7 @@ end
 
 succprob(d::Geometric) = d.p
 failprob(d::Geometric) = 1.0 - d.p
-params(d) = (d.p,)
+params(d::Geometric) = (d.p,)
 
 
 ### Statistics


### PR DESCRIPTION
`params` was untyped for geometric, resulting in fallback for other distributions for which params weren't defined. So something like

```
d = Dirichlet(5, 1)
params(d)
```
resulted in a call here rather than method not found.