### PR TITLE
A multivariate lognormal using MvNormal internally.

### DIFF
--- a/doc/source/multivariate.rst
+++ b/doc/source/multivariate.rst
@@ -47,7 +47,7 @@ Computation of statistics
 
 .. function:: entropy(d)
 
-    Return the entropy of distribution ``d``. 
+    Return the entropy of distribution ``d``.
 
 
 Probability evaluation
@@ -55,30 +55,30 @@ Probability evaluation
 
 .. function:: insupport(d, x)
 
-    If ``x`` is a vector, it returns whether x is within the support of ``d``. 
-    If ``x`` is a matrix, it returns whether every column in ``x`` is within the support of ``d``. 
+    If ``x`` is a vector, it returns whether x is within the support of ``d``.
+    If ``x`` is a matrix, it returns whether every column in ``x`` is within the support of ``d``.
 
 .. function:: pdf(d, x)
 
     Return the probability density of distribution ``d`` evaluated at ``x``.
 
-    - If ``x`` is a vector, it returns the result as a scalar. 
+    - If ``x`` is a vector, it returns the result as a scalar.
     - If ``x`` is a matrix with n columns, it returns a vector ``r`` of length n, where ``r[i]`` corresponds to ``x[:,i]`` (i.e. treating each column as a sample).
 
 .. function:: pdf!(r, d, x)
 
-    Evaluate the probability densities at columns of x, and write the results to a pre-allocated array r. 
+    Evaluate the probability densities at columns of x, and write the results to a pre-allocated array r.
 
 .. function:: logpdf(d, x)
 
     Return the logarithm of probability density evaluated at ``x``.
 
-    - If ``x`` is a vector, it returns the result as a scalar. 
+    - If ``x`` is a vector, it returns the result as a scalar.
     - If ``x`` is a matrix with n columns, it returns a vector ``r`` of length n, where ``r[i]`` corresponds to ``x[:,i]``.
 
 .. function:: logpdf!(r, d, x)
 
-    Evaluate the logarithm of probability densities at columns of x, and write the results to a pre-allocated array r. 
+    Evaluate the logarithm of probability densities at columns of x, and write the results to a pre-allocated array r.
 
 .. function:: loglikelihood(d, x)
 
@@ -100,7 +100,7 @@ Sampling
 
 .. function:: rand!(d, x)
 
-    Draw samples and output them to a pre-allocated array x. Here, x can be either a vector of length ``dim(d)`` or a matrix with ``dim(d)`` rows.     
+    Draw samples and output them to a pre-allocated array x. Here, x can be either a vector of length ``dim(d)`` or a matrix with ``dim(d)`` rows.
 
 
 **Node:** In addition to these common methods, each multivariate distribution has its own special methods, as introduced below.
@@ -117,14 +117,14 @@ The probability mass function is given by
 
 .. math::
 
-    f(x; n, p) = \frac{n!}{x_1! \cdots x_k!} \prod_{i=1}^k p_i^{x_i}, 
+    f(x; n, p) = \frac{n!}{x_1! \cdots x_k!} \prod_{i=1}^k p_i^{x_i},
     \quad x_1 + \cdots + x_k = n
 
 .. code-block:: julia
 
     Multinomial(n, p)   # Multinomial distribution for n trials with probability vector p
 
-    Multinomial(n, k)   # Multinomial distribution for n trials with equal probabilities 
+    Multinomial(n, k)   # Multinomial distribution for n trials with equal probabilities
                         # over 1:k
 
 
@@ -133,7 +133,7 @@ The probability mass function is given by
 Multivariate Normal Distribution
 ----------------------------------
 
-The `Multivariate normal distribution <http://en.wikipedia.org/wiki/Multivariate_normal_distribution>`_ is a multidimensional generalization of the *normal distribution*. The probability density function of a d-dimensional multivariate normal distribution with mean vector :math:`\boldsymbol{\mu}` and covariance matrix :math:`\boldsymbol{\Sigma}` is 
+The `Multivariate normal distribution <http://en.wikipedia.org/wiki/Multivariate_normal_distribution>`_ is a multidimensional generalization of the *normal distribution*. The probability density function of a d-dimensional multivariate normal distribution with mean vector :math:`\boldsymbol{\mu}` and covariance matrix :math:`\boldsymbol{\Sigma}` is
 
 .. math::
 
@@ -231,7 +231,7 @@ Multivariate normal distribution is an `exponential family distribution <http://
 
 .. math::
 
-    \mathbf{h} = \boldsymbol{\Sigma}^{-1} \boldsymbol{\mu}, \quad \text{ and } \quad \mathbf{J} = \boldsymbol{\Sigma}^{-1} 
+    \mathbf{h} = \boldsymbol{\Sigma}^{-1} \boldsymbol{\mu}, \quad \text{ and } \quad \mathbf{J} = \boldsymbol{\Sigma}^{-1}
 
 The canonical parameterization is widely used in Bayesian analysis. We provide a type ``MvNormalCanon``, which is also a subtype of ``AbstractMvNormal`` to represent a multivariate normal distribution using canonical parameters. Particularly, ``MvNormalCanon`` is defined as:
 
@@ -247,12 +247,12 @@ We also define aliases for common specializations of this parametric type:
 
 .. code:: julia
 
-    typealias FullNormalCanon MvNormalCanon{PDMat,    Vector{Float64}} 
-    typealias DiagNormalCanon MvNormalCanon{PDiagMat, Vector{Float64}} 
+    typealias FullNormalCanon MvNormalCanon{PDMat,    Vector{Float64}}
+    typealias DiagNormalCanon MvNormalCanon{PDiagMat, Vector{Float64}}
     typealias IsoNormalCanon  MvNormalCanon{ScalMat,  Vector{Float64}}
 
-    typealias ZeroMeanFullNormalCanon MvNormalCanon{PDMat,    ZeroVector{Float64}} 
-    typealias ZeroMeanDiagNormalCanon MvNormalCanon{PDiagMat, ZeroVector{Float64}} 
+    typealias ZeroMeanFullNormalCanon MvNormalCanon{PDMat,    ZeroVector{Float64}}
+    typealias ZeroMeanDiagNormalCanon MvNormalCanon{PDiagMat, ZeroVector{Float64}}
     typealias ZeroMeanIsoNormalCanon  MvNormalCanon{ScalMat,  ZeroVector{Float64}}
 
 A multivariate distribution with canonical parameterization can be constructed using a common constructor ``MvNormalCanon`` as:
@@ -286,6 +286,85 @@ A multivariate distribution with canonical parameterization can be constructed u
 
 **Note:** ``MvNormalCanon`` share the same set of methods as ``MvNormal``.
 
+.. _multivariatelognormal:
+
+Multivariate Lognormal Distribution
+-----------------------------------
+
+The `Multivariate lognormal distribution <http://en.wikipedia.org/wiki/Log-normal_distribution>`_ is a multidimensional generalization of the *lognormal distribution*.
+
+If :math:`\boldsymbol X \sim \mathcal{N}(\boldsymbol\mu,\,\boldsymbol\Sigma)` has a multivariate normal distribution then :math:`\boldsymbol Y=\exp(\boldsymbol X)` has a multivariate lognormal distribution.
+
+Mean vector :math:`\boldsymbol{\mu}` and covariance matrix :math:`\boldsymbol{\Sigma}` of the underlying normal distribution are known as the *location* and *scale* parameters of the corresponding lognormal distribution.
+
+The package provides an implementation, ``MvLogNormal``, which wraps around ``MvNormal``:
+
+.. code-block:: julia
+
+    immutable MvLogNormal <: AbstractMvLogNormal
+      normal::MvNormal
+    end
+
+Construction
+~~~~~~~~~~~~
+
+``MvLogNormal`` provides the same constructors as ``MvNormal``. See above for details.
+
+Additional Methods
+~~~~~~~~~~~~~~~~~~
+
+In addition to the methods listed in the common interface above, we also provide the following methods:
+
+.. function:: location(d)
+
+    Return the location vector of the distribution (the mean of the underlying normal distribution).
+
+.. function:: scale(d)
+
+    Return the scale matrix of the distribution (the covariance matrix of the underlying normal distribution).
+
+.. function:: median(d)
+
+    Return the median vector of the lognormal distribution. which is strictly smaller than the mean.
+
+.. function:: mode(d)
+
+    Return the mode vector of the lognormal distribution, which is strictly smaller than the mean and median.
+
+Conversion Methods
+~~~~~~~~~~~~~~~~~~
+
+It can be necessary to calculate the parameters of the lognormal (location vector and scale matrix) from a given covariance and mean, median or mode. To that end, the following functions are provided.
+
+.. function:: location{D<:AbstractMvLogNormal}(::Type{D},s::Symbol,m::AbstractVector,S::AbstractMatrix)
+
+    Calculate the location vector (the mean of the underlying normal distribution).
+
+    If ``s == :meancov``, then m is taken as the mean, and S the covariance matrix of a lognormal distribution.
+
+    If ``s == :mean | :median | :mode``, then m is taken as the mean, median or mode of the lognormal respectively, and S is interpreted as the scale matrix (the covariance of the underlying normal distribution).
+
+    It is not possible to analytically calculate the location vector from e.g., median + covariance, or from mode + covariance.
+
+.. function:: location!{D<:AbstractMvLogNormal}(::Type{D},s::Symbol,m::AbstractVector,S::AbstractMatrix,μ::AbstractVector)
+
+    Calculate the location vector (as above) and store the result in ``μ``
+
+.. function:: scale{D<:AbstractMvLogNormal}(::Type{D},s::Symbol,m::AbstractVector,S::AbstractMatrix)
+
+    Calculate the scale parameter, as defined for the location parameter above.
+
+.. function:: scale!{D<:AbstractMvLogNormal}(::Type{D},s::Symbol,m::AbstractVector,S::AbstractMatrix,Σ::AbstractMatrix)
+
+    Calculate the scale parameter, as defined for the location parameter above and store the result in ``Σ``.
+
+.. function:: params{D<:AbstractMvLogNormal}(::Type{D},m::AbstractVector,S::AbstractMatrix)
+
+    Return (scale,location) for a given mean and covariance
+
+.. function:: params!{D<:AbstractMvLogNormal}(::Type{D},m::AbstractVector,S::AbstractMatrix,μ::AbstractVector,Σ::AbstractMatrix)
+
+    Calculate (scale,location) for a given mean and covariance, and store the results in ``μ`` and ``Σ``
 
 
 .. _dirichlet:
@@ -298,7 +377,7 @@ The `Dirichlet distribution <http://en.wikipedia.org/wiki/Dirichlet_distribution
 .. math::
 
     f(x; \alpha) = \frac{1}{B(\alpha)} \prod_{i=1}^k x_i^{\alpha_i - 1}, \quad \text{ with }
-    B(\alpha) = \frac{\prod_{i=1}^k \Gamma(\alpha_i)}{\Gamma \left( \sum_{i=1}^k \alpha_i \right)}, 
+    B(\alpha) = \frac{\prod_{i=1}^k \Gamma(\alpha_i)}{\Gamma \left( \sum_{i=1}^k \alpha_i \right)},
     \quad x_1 + \cdots + x_k = 1
 
 
@@ -308,7 +387,7 @@ The `Dirichlet distribution <http://en.wikipedia.org/wiki/Dirichlet_distribution
     Dirichlet(alpha)         # Dirichlet distribution with parameter vector alpha
 
     # Let a be a positive scalar
-    Dirichlet(k, a)          # Dirichlet distribution with parameter a * ones(k)  
+    Dirichlet(k, a)          # Dirichlet distribution with parameter a * ones(k)
 
 
 

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -9,7 +9,7 @@ using StatsBase
 using Compat
 
 import Base.Random
-import Base: size, eltype, length, full, convert, show, getindex, scale, rand, rand!
+import Base: size, eltype, length, full, convert, show, getindex, scale, scale!, rand, rand!
 import Base: sum, mean, median, maximum, minimum, quantile, std, var, cov, cor
 import Base: +, -, .+, .-
 import Base.Math.@horner
@@ -99,6 +99,7 @@ export
     MixtureModel,
     Multinomial,
     MultivariateNormal,
+    MvLogNormal,
     MvNormal,
     MvNormalCanon,
     MvNormalKnownCov,
@@ -207,6 +208,7 @@ export
     sqmahal,            # squared Mahalanobis distance to Gaussian center
     sqmahal!,           # inplace evaluation of sqmahal
     location,           # get the location parameter
+    location!,          # provide storage for the location parameter (used in multivariate distribution mvlognormal)
     mean,               # mean of distribution
     meandir,            # mean direction (of a spherical distribution)
     meanform,           # convert a normal distribution from canonical form to mean form
@@ -221,6 +223,7 @@ export
     ncomponents,        # the number of components in a mixture model
     ntrials,            # the number of trials being performed in the experiment
     params,             # get the tuple of parameters
+    params!,            # provide storage space to calculate the tuple of parameters for a multivariate distribution like mvlognormal
     pdf,                # probability density function (ContinuousDistribution)
     pmf,                # probability mass function (DiscreteDistribution)
     probs,              # Get the vector of probabilities
@@ -230,6 +233,7 @@ export
     rate,               # get the rate parameter
     sampler,            # create a Sampler object for efficient samples
     scale,              # get the scale parameter
+    scale!,             # provide storage for the scale parameter (used in multivariate distribution mvlognormal)
     shape,              # get the shape parameter
     skewness,           # skewness of the distribution
     span,               # the span of the support, e.g. maximum(d) - minimum(d)

--- a/src/multivariate/mvlognormal.jl
+++ b/src/multivariate/mvlognormal.jl
@@ -1,0 +1,149 @@
+# Multivariate LogNormal distribution
+
+###########################################################
+#
+#   Abstract base class for multivariate lognormal
+#
+#   Each subtype should provide the following methods:
+#
+#   - length(d)         vector dimension
+#   - params(d)         Get the parameters from the underlying Normal distribution
+#   - location(d)       Location parameter
+#   - scale(d)          Scale parameter
+#   - _rand!(d, x)      Sample random vector(s)
+#   - _logpdf(d,x)      Evaluate logarithm of pdf
+#   - _pdf(d,x)         Evaluate the pdf
+#   - mean(d)           Mean of the distribution
+#   - median(d)         Median of the distribution
+#   - mode(d)           Mode of the distribution
+#   - var(d)            Vector of element-wise variance
+#   - cov(d)            Covariance matrix
+#   - entropy(d)        Compute the entropy
+#
+#
+###########################################################
+
+abstract AbstractMvLogNormal <: ContinuousMultivariateDistribution
+
+function insupport{T<:Real,D<:AbstractMvLogNormal}(::Type{D},x::AbstractVector{T})
+    for i=1:length(x)
+      @inbounds 0.0<x[i]<Inf?continue:(return false)
+    end
+    true
+end
+insupport{T<:Real}(l::AbstractMvLogNormal,x::AbstractVector{T}) = insupport(typeof(l),x)
+assertinsupport{D<:AbstractMvLogNormal}(::Type{D},m::AbstractVector) = @assert insupport(D,m) "Mean of LogNormal distribution should be strictly positive"
+
+###Internal functions to calculate scale and location for a desired average and covariance
+function _location!{D<:AbstractMvLogNormal}(::Type{D},::Type{Val{:meancov}},mn::AbstractVector,S::AbstractMatrix,μ::AbstractVector)
+    @simd for i=1:length(mn)
+      @inbounds μ[i] = log(mn[i]/sqrt(1+S[i,i]/mn[i]/mn[i]))
+    end
+    μ
+end
+
+function _scale!{D<:AbstractMvLogNormal}(::Type{D},::Type{Val{:meancov}},mn::AbstractVector,S::AbstractMatrix,Σ::AbstractMatrix)
+    for j=1:length(mn)
+      @simd for i=j:length(mn)
+        @inbounds Σ[i,j] = Σ[j,i] = log(1 + S[j,i]/mn[i]/mn[j])
+      end
+    end
+    Σ
+end
+
+function _location!{D<:AbstractMvLogNormal}(::Type{D},::Type{Val{:mean}},mn::AbstractVector,S::AbstractMatrix,μ::AbstractVector)
+    @simd for i=1:length(mn)
+      @inbounds μ[i] = log(mn[i]) - S[i,i]/2
+    end
+    μ
+end
+
+function _location!{D<:AbstractMvLogNormal}(::Type{D},::Type{Val{:median}},md::AbstractVector,S::AbstractMatrix,μ::AbstractVector)
+    @simd for i=1:length(md)
+      @inbounds μ[i] = log(md[i])
+    end
+    μ
+end
+
+function _location!{D<:AbstractMvLogNormal}(::Type{D},::Type{Val{:mode}},mo::AbstractVector,S::AbstractMatrix,μ::AbstractVector)
+    @simd for i=1:length(mo)
+      @inbounds μ[i] = log(mo[i]) + S[i,i]
+    end
+    μ
+end
+
+###Functions to calculate location and scale for a distribution with desired :mean, :median or :mode and covariance
+function location!{D<:AbstractMvLogNormal}(::Type{D},s::Symbol,m::AbstractVector,S::AbstractMatrix,μ::AbstractVector)
+  @assert size(S) == (length(m),length(m)) && length(m) == length(μ)
+  assertinsupport(D,m)
+  _location!(D,Val{s},m,S,μ)
+end
+
+function location{D<:AbstractMvLogNormal}(::Type{D},s::Symbol,m::AbstractVector,S::AbstractMatrix)
+    @assert size(S) == (length(m),length(m))
+    assertinsupport(D,m)
+    _location!(D,Val{s},m,S,similar(m))
+end
+
+function scale!{D<:AbstractMvLogNormal}(::Type{D},s::Symbol,m::AbstractVector,S::AbstractMatrix,Σ::AbstractMatrix)
+    @assert size(S) == size(Σ) == (length(m),length(m))
+    assertinsupport(D,m)
+    _scale!(D,Val{s},m,S,Σ)
+end
+
+function scale{D<:AbstractMvLogNormal}(::Type{D},s::Symbol,m::AbstractVector,S::AbstractMatrix)
+    @assert size(S) == (length(m),length(m))
+    assertinsupport(D,m)
+    _scale!(D,Val{s},m,S,similar(S))
+end
+
+params!{D<:AbstractMvLogNormal}(::Type{D},m::AbstractVector,S::AbstractMatrix,μ::AbstractVector,Σ::AbstractMatrix) = location!(D,:meancov,m,S,μ),scale!(D,:meancov,m,S,Σ)
+params{D<:AbstractMvLogNormal}(::Type{D},m::AbstractVector,S::AbstractMatrix) = params!(D,m,S,similar(m),similar(S))
+
+#########################################################
+#
+#   MvLogNormal
+#
+#   Multivariate lognormal distribution based on MvNormal
+#
+#########################################################
+immutable MvLogNormal <: AbstractMvLogNormal
+    normal::MvNormal
+end
+
+#Constructors mirror the ones for MvNormmal
+@compat MvLogNormal(μ::Union{Vector,ZeroVector},Σ::AbstractPDMat) = MvLogNormal(MvNormal(μ,Σ))
+MvLogNormal(Σ::AbstractPDMat) = MvLogNormal(MvNormal(ZeroVector(Float64,dim(Σ)),Σ))
+MvLogNormal(μ::Vector,Σ::Matrix) = MvLogNormal(MvNormal(μ,Σ))
+MvLogNormal(μ::Vector,σ::Vector) = MvLogNormal(MvNormal(μ,σ))
+MvLogNormal(μ::Vector,s::Real) = MvLogNormal(MvNormal(μ,s))
+MvLogNormal(Σ::Matrix) = MvLogNormal(MvNormal(Σ))
+MvLogNormal(σ::Vector) = MvLogNormal(MvNormal(σ))
+MvLogNormal(d::Int,s::Real) = MvLogNormal(MvNormal(d,s))
+
+length(d::MvLogNormal) = length(d.normal)
+params(d::MvLogNormal) = params(d.normal)
+location(d::MvLogNormal) = mean(d.normal)
+scale(d::MvLogNormal) = cov(d.normal)
+
+#See https://en.wikipedia.org/wiki/Log-normal_distribution
+mean(d::MvLogNormal) = exp(mean(d.normal) + var(d.normal)/2)
+median(d::MvLogNormal) = exp(mean(d.normal))
+mode(d::MvLogNormal) = exp(mean(d.normal) - var(d.normal))
+cov(d::MvLogNormal) = (m = mean(d) ; m*m'.*(exp(cov(d.normal))-1))
+var(d::MvLogNormal) = diag(cov(d))
+
+#see Zografos & Nadarajah (2005) Stat. Prob. Let 71(1) pp71-84 DOI: 10.1016/j.spl.2004.10.023
+entropy(d::MvLogNormal) = length(d)*(1+log2π)/2 + logdetcov(d.normal)/2 + sum(mean(d.normal))
+
+#See https://en.wikipedia.org/wiki/Log-normal_distribution
+_rand!{T<:Real}(d::MvLogNormal,x::AbstractVector{T}) = exp!(_rand!(d.normal,x))
+_logpdf{T<:Real}(d::MvLogNormal,x::AbstractVector{T}) = insupport(d,x)?(_logpdf(d.normal,log(x))-sum(log(x))):-Inf
+_pdf{T<:Real}(d::MvLogNormal,x::AbstractVector{T}) = insupport(d,x)?_pdf(d.normal,log(x))/prod(x):0.0
+
+Base.show(io::IO,d::MvLogNormal) = show_multline(io,d,[(:dim,length(d)),(:μ,mean(d.normal)),(:Σ,cov(d.normal))])
+
+
+
+
+

--- a/src/multivariates.jl
+++ b/src/multivariates.jl
@@ -51,7 +51,7 @@ function cor(d::MultivariateDistribution)
             @inbounds R[i, j] = C[i, j] / sqrt(C[i, i] * C[j, j])
         end
     end
-    
+
     return R
 end
 
@@ -60,13 +60,13 @@ end
 _pdf(d::MultivariateDistribution, X::AbstractVector) = exp(_logpdf(d, X))
 
 function logpdf(d::MultivariateDistribution, X::AbstractVector)
-    length(X) == length(d) || 
+    length(X) == length(d) ||
         throw(DimensionMismatch("Inconsistent array dimensions."))
     _logpdf(d, X)
 end
 
 function pdf(d::MultivariateDistribution, X::AbstractVector)
-    length(X) == length(d) || 
+    length(X) == length(d) ||
         throw(DimensionMismatch("Inconsistent array dimensions."))
     _pdf(d, X)
 end
@@ -130,8 +130,9 @@ end
 
 for fname in ["dirichlet.jl",
               "multinomial.jl",
-              "mvnormal.jl", 
+              "mvnormal.jl",
               "mvnormalcanon.jl",
+              "mvlognormal.jl",
               "mvtdist.jl",
               "vonmisesfisher.jl"]
     include(joinpath("multivariate", fname))

--- a/test/mvlognormal.jl
+++ b/test/mvlognormal.jl
@@ -1,0 +1,122 @@
+# Tests on Multivariate LogNormal distributions
+
+using Distributions
+using Base.Test
+
+
+####### Core testing procedure
+
+function test_mvlognormal(g::MvLogNormal, n_tsamples::Int=10^6)
+    d = length(g)
+    mn = mean(g)
+    md = median(g)
+    mo = mode(g)
+    S = cov(g)
+    s = var(g)
+    e = entropy(g)
+    @test isa(mn, Vector{Float64})
+    @test isa(md, Vector{Float64})
+    @test isa(mo, Vector{Float64})
+    @test isa(s, Vector{Float64})
+    @test isa(S, Matrix{Float64})
+    @test length(mn) == d
+    @test length(md) == d
+    @test length(mo) == d
+    @test length(s) == d
+    @test size(S) == (d, d)
+    @test_approx_eq s diag(S)
+    @test_approx_eq md exp(mean(g.normal))
+    @test_approx_eq mn exp(mean(g.normal) + var(g.normal)/2)
+    @test_approx_eq mo exp(mean(g.normal) - var(g.normal))
+    @test_approx_eq entropy(g) d*(1 + Distributions.log2π)/2 + logdetcov(g.normal)/2 + sum(mean(g.normal))
+    @test g == typeof(g)(params(g)...)
+    @test insupport(g,ones(d))
+    @test !insupport(g,zeros(d))
+    @test !insupport(g,-ones(d))
+
+    # sampling
+    X = rand(g, n_tsamples)
+    emp_mn = vec(mean(X, 2))
+    emp_md = vec(median(X, 2))
+    Z = X .- emp_mn
+    emp_cov = A_mul_Bt(Z, Z) * (1.0 / n_tsamples)
+    for i = 1:d
+        @test_approx_eq_eps emp_mn[i] mn[i] (sqrt(s[i] / n_tsamples) * 8.0)
+    end
+    for i = 1:d
+        @test_approx_eq_eps emp_md[i] md[i] (sqrt(s[i] / n_tsamples) * 8.0)
+    end
+    for i = 1:d, j = 1:d
+        @test_approx_eq_eps emp_cov[i,j] S[i,j] (sqrt(s[i] * s[j]) * 20.0) / sqrt(n_tsamples)
+    end
+
+    # evaluation of logpdf and pdf
+    for i = 1:min(100, n_tsamples)
+        @test_approx_eq logpdf(g, X[:,i]) log(pdf(g, X[:,i]))
+    end
+    @test_approx_eq logpdf(g, X) log(pdf(g, X))
+    @test isequal(logpdf(g, zeros(d)),-Inf)
+    @test isequal(logpdf(g, -mn),-Inf)
+    @test isequal(pdf(g, zeros(d)),0.0)
+    @test isequal(pdf(g, -mn),0.0)
+
+    # test the location and scale functions
+    @test_approx_eq_eps location(g) location(MvLogNormal,:meancov,mean(g),cov(g)) 1e-8
+    @test_approx_eq_eps location(g) location(MvLogNormal,:mean,mean(g),scale(g)) 1e-8
+    @test_approx_eq_eps location(g) location(MvLogNormal,:median,median(g),scale(g)) 1e-8
+    @test_approx_eq_eps location(g) location(MvLogNormal,:mode,mode(g),scale(g)) 1e-8
+    @test_approx_eq_eps scale(g) scale(MvLogNormal,:meancov,mean(g),cov(g)) 1e-8
+
+    @test_approx_eq_eps location(g) location!(MvLogNormal,:meancov,mean(g),cov(g),zeros(mn)) 1e-8
+    @test_approx_eq_eps location(g) location!(MvLogNormal,:mean,mean(g),scale(g),zeros(mn)) 1e-8
+    @test_approx_eq_eps location(g) location!(MvLogNormal,:median,median(g),scale(g),zeros(mn)) 1e-8
+    @test_approx_eq_eps location(g) location!(MvLogNormal,:mode,mode(g),scale(g),zeros(mn)) 1e-8
+    @test_approx_eq_eps scale(g) scale!(MvLogNormal,:meancov,mean(g),cov(g),zeros(S)) 1e-8
+
+    lc1,sc1 = params(MvLogNormal,mean(g),cov(g))
+    lc2,sc2 = params!(MvLogNormal,mean(g),cov(g),similar(mn),similar(S))
+    @test_approx_eq_eps location(g) lc1  1e-8
+    @test_approx_eq_eps location(g) lc2  1e-8
+    @test_approx_eq_eps scale(g) sc1  1e-8
+    @test_approx_eq_eps scale(g) sc2  1e-8
+end
+
+####### Validate results for a single-dimension MvLogNormal by comparing with univariate LogNormal
+println("    comparing results from MvLogNormal with univariate LogNormal")
+l1 = LogNormal(0.1,0.4)
+l2 = MvLogNormal(0.1*ones(1),0.4)
+@test_approx_eq [mean(l1)] mean(l2)
+@test_approx_eq [median(l1)] median(l2)
+@test_approx_eq [mode(l1)] mode(l2)
+@test_approx_eq [var(l1)] var(l2)
+@test_approx_eq [entropy(l1)] entropy(l2)
+@test_approx_eq logpdf(l1,5.0) logpdf(l2,[5.0])
+@test_approx_eq pdf(l1,5.0) pdf(l2,[5.0])
+@test (srand(78393) ; [rand(l1)]) == (srand(78393) ; rand(l2))
+
+###### General Testing
+
+mu = [0.1, 0.2, 0.3]
+va = [0.16, 0.25, 0.36]
+C = [0.4 -0.2 -0.1; -0.2 0.5 -0.1; -0.1 -0.1 0.6]
+
+for (g, μ, Σ) in [
+    (MvLogNormal(mu,PDMats.PDMat(C)), mu, C),
+    (MvLogNormal(PDMats.PDiagMat(sqrt(va))), zeros(3), diagm(va)),
+    (MvLogNormal(mu, sqrt(0.2)), mu, 0.2 * eye(3)),
+    (MvLogNormal(3, sqrt(0.2)), zeros(3), 0.2 * eye(3)),
+    (MvLogNormal(mu, sqrt(va)), mu, diagm(va)),
+    (MvLogNormal(sqrt(va)), zeros(3), diagm(va)),
+    (MvLogNormal(mu, C), mu, C),
+    (MvLogNormal(C), zeros(3), C) ]
+
+    println("    testing $(typeof(g)) with normal distribution $(Distributions.distrname(g.normal))")
+
+    m,s = params(g)
+    @test_approx_eq full(m) μ
+    test_mvlognormal(g)
+end
+
+
+
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ tests = [
     "poissonbinomial",
     "dirichlet",
     "mvnormal",
+    "mvlognormal",
     "mvtdist",
     "normalinversegaussian",
     "kolmogorov",


### PR DESCRIPTION
A port of my private MvLogNormal class to the Distributions package. Implemented the minimum interface described in the documentation and tested using similar tests as MvNormal.

Implements the same constructors as MvNormal.

No changes to the existing code from the Distributions package (other than includes and exports).