### PR TITLE
Fix the upper dependency of PDMats

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.3
 ArrayViews 0.4.12
-PDMats 0.3.2
+PDMats 0.3.2 0.4
 StatsFuns 0.1.1
 StatsBase 0.7.0
 Compat 0.4.0


### PR DESCRIPTION
PR https://github.com/JuliaStats/PDMats.jl/pull/37 would need a small change to some typealiases in MvNormal.jl. Therefore fixing upper boundary of PDMats to upcoming version of PDMats (0.4)

The corresponding PR for the same changes in METADATA is https://github.com/JuliaLang/METADATA.jl/pull/4506