### PR TITLE
Hypergeometric: allow `n` to take 0 and ns+nf values

### DIFF
--- a/src/univariate/discrete/hypergeometric.jl
+++ b/src/univariate/discrete/hypergeometric.jl
@@ -13,7 +13,7 @@ immutable Hypergeometric <: DiscreteUnivariateDistribution
 
     function Hypergeometric(ns::Real, nf::Real, n::Real)
         @check_args(Hypergeometric, ns >= zero(ns) && nf >= zero(nf))
-        @check_args(Hypergeometric, zero(n) < n < ns + nf)
+        @check_args(Hypergeometric, zero(n) <= n <= ns + nf)
         new(ns, nf, n)
     end
 end

--- a/test/discrete_test.json
+++ b/test/discrete_test.json
@@ -1009,6 +1009,56 @@
     }
   ], 
   [
+    "Hypergeometric(3, 2, 0)",
+    {
+      "dtype": "Hypergeometric",
+      "entropy": 0.0,
+      "minimum": 0,
+      "maximum": 0,
+      "mean": 0,
+      "median": 0.0,
+      "params": {},
+      "points": [
+        {
+          "cdf": 1.0,
+          "logpdf": 0.0,
+          "x": 0
+        }
+      ],
+      "q10": 0.0,
+      "q25": 0.0,
+      "q50": 0.0,
+      "q75": 0.0,
+      "q90": 0.0,
+      "var": 0.0
+    }
+  ],
+  [
+    "Hypergeometric(3, 2, 5)",
+    {
+      "dtype": "Hypergeometric",
+      "entropy": 0.0,
+      "minimum": 3,
+      "maximum": 3,
+      "mean": 3.0,
+      "median": 3.0,
+      "params": {},
+      "points": [
+        {
+          "cdf": 1.0,
+          "logpdf": 0.0,
+          "x": 3
+        }
+      ],
+      "q10": 3.0,
+      "q25": 3.0,
+      "q50": 3.0,
+      "q75": 3.0,
+      "q90": 3.0,
+      "var": 0.0
+    }
+  ],
+  [
     "Hypergeometric(4, 5, 6)", 
     {
       "dtype": "Hypergeometric", 

--- a/test/discrete_test.lst
+++ b/test/discrete_test.lst
@@ -27,6 +27,8 @@ Geometric(0.9)
 
 Hypergeometric(2, 2, 2)
 Hypergeometric(3, 2, 2)
+Hypergeometric(3, 2, 0)
+Hypergeometric(3, 2, 5)
 Hypergeometric(4, 5, 6)
 Hypergeometric(60, 80, 100)
 


### PR DESCRIPTION
When `n=0` or `n=ns+nf`, the distribution is degenerated, but still defined.
Improves corner cases support in `FisherExactTest`.