### PR TITLE
generalizing multivariates dependent on PDMats

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.4
-PDMats 0.4 0.5
+PDMats 0.4.1 0.5
 StatsFuns 0.1.1
 StatsBase 0.7.0

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -59,8 +59,7 @@ _pdf!{T<:Real}(r::AbstractArray, d::AbstractMvNormal, x::AbstractMatrix{T}) = ex
 #   Multivariate normal distribution with mean parameters
 #
 ###########################################################
-
-immutable MvNormal{Cov<:AbstractPDMat,Mean<:Union{Vector{Float64},ZeroVector{Float64}}} <: AbstractMvNormal
+immutable MvNormal{Cov<:AbstractPDMat,Mean<:Union{Vector, ZeroVector}} <: AbstractMvNormal
     μ::Mean
     Σ::Cov
 end
@@ -77,19 +76,19 @@ typealias ZeroMeanFullNormal MvNormal{PDMat{Float64,Matrix{Float64}},ZeroVector{
 
 ### Construction
 
-function MvNormal{Cov<:AbstractPDMat}(μ::Vector{Float64}, Σ::Cov)
+function MvNormal{Cov<:AbstractPDMat, T<:Real}(μ::Vector{T}, Σ::Cov)
     dim(Σ) == length(μ) || throw(DimensionMismatch("The dimensions of mu and Sigma are inconsistent."))
-    MvNormal{Cov,Vector{Float64}}(μ, Σ)
+    MvNormal{Cov,Vector{T}}(μ, Σ)
 end
 
 MvNormal{Cov<:AbstractPDMat}(Σ::Cov) = MvNormal{Cov,ZeroVector{Float64}}(ZeroVector(Float64, dim(Σ)), Σ)
 
-MvNormal(μ::Vector{Float64}, Σ::Matrix{Float64}) = MvNormal(μ, PDMat(Σ))
-MvNormal(μ::Vector{Float64}, σ::Vector{Float64}) = MvNormal(μ, PDiagMat(abs2(σ)))
-MvNormal(μ::Vector{Float64}, σ::Real) = MvNormal(μ, ScalMat(length(μ), abs2(Float64(σ))))
+MvNormal{T<:Real,S<:Real}(μ::Vector{T}, Σ::Matrix{S}) = MvNormal(μ, PDMat(Σ))
+MvNormal{T<:Real,S<:Real}(μ::Vector{T}, σ::Vector{S}) = MvNormal(μ, PDiagMat(abs2(σ)))
+MvNormal{T<:Real}(μ::Vector{T}, σ::Real) = MvNormal(μ, ScalMat(length(μ), abs2(Float64(σ))))
 
-MvNormal(Σ::Matrix{Float64}) = MvNormal(PDMat(Σ))
-MvNormal(σ::Vector{Float64}) = MvNormal(PDiagMat(abs2(σ)))
+MvNormal{T<:Real}(Σ::Matrix{T}) = MvNormal(PDMat(Σ))
+MvNormal{T<:Real}(σ::Vector{T}) = MvNormal(PDiagMat(abs2(σ)))
 MvNormal(d::Int, σ::Real) = MvNormal(ScalMat(d, abs2(Float64(σ))))
 
 ### Show

--- a/src/multivariate/mvtdist.jl
+++ b/src/multivariate/mvtdist.jl
@@ -4,45 +4,43 @@
 
 abstract AbstractMvTDist <: ContinuousMultivariateDistribution
 
-immutable GenericMvTDist{Cov<:AbstractPDMat} <: AbstractMvTDist
-    df::Float64 # non-integer degrees of freedom allowed
+immutable GenericMvTDist{Cov<:AbstractPDMat, T<:Real} <: AbstractMvTDist
+    df::T # non-integer degrees of freedom allowed
     dim::Int
     zeromean::Bool
-    μ::Vector{Float64}
+    μ::Vector{T}
     Σ::Cov
 
-    function GenericMvTDist{Cov}(df::Float64, dim::Int, zmean::Bool, μ::Vector{Float64}, Σ::Cov)
+    function GenericMvTDist{Cov, T}(df::T, dim::Int, zmean::Bool, μ::Vector{T}, Σ::Cov)
       df > zero(df) || error("df must be positive")
-      new(Float64(df), dim, zmean, μ, Σ)
+      new(df, dim, zmean, μ, Σ)
     end
 end
 
-function GenericMvTDist{Cov<:AbstractPDMat}(df::Float64, μ::Vector{Float64}, Σ::Cov, zmean::Bool)
-    d = length(μ)
-    dim(Σ) == d || throw(ArgumentError("The dimensions of μ and Σ are inconsistent."))
-    GenericMvTDist{Cov}(df, d, zmean, μ, Σ)
+function GenericMvTDist{Cov<:AbstractPDMat, T<:Real, S<:Real}(df::T, μ::Vector{S}, Σ::Cov, zmean::Bool)
+    R = promote_type(T, S)
+    GenericMvTDist(R(df), convert(Vector{R}, μ), Σ, zmean)
 end
 
-function GenericMvTDist{Cov<:AbstractPDMat}(df::Float64, μ::Vector{Float64}, Σ::Cov)
+function GenericMvTDist{Cov<:AbstractPDMat, T<:Real}(df::T, μ::Vector{T}, Σ::Cov, zmean::Bool)
     d = length(μ)
     dim(Σ) == d || throw(ArgumentError("The dimensions of μ and Σ are inconsistent."))
-    GenericMvTDist{Cov}(df, d, allzeros(μ), μ, Σ)
+    GenericMvTDist{Cov, T}(df, d, zmean, μ, Σ)
 end
 
-function GenericMvTDist{Cov<:AbstractPDMat}(df::Float64, Σ::Cov)
-    d = dim(Σ)
-    GenericMvTDist{Cov}(df, d, true, zeros(d), Σ)
-end
+GenericMvTDist{Cov<:AbstractPDMat, T<:Real, S<:Real}(df::T, μ::Vector{S}, Σ::Cov) = GenericMvTDist(df, μ, Σ, allzeros(μ))
+
+GenericMvTDist{Cov<:AbstractPDMat, T<:Real}(df::T, Σ::Cov) = GenericMvTDist(df, zeros(d), Σ, true)
 
 ## Construction of multivariate normal with specific covariance type
 
-typealias IsoTDist  GenericMvTDist{ScalMat{Float64}}
-typealias DiagTDist GenericMvTDist{PDiagMat{Float64,Vector{Float64}}}
-typealias MvTDist GenericMvTDist{PDMat{Float64,Matrix{Float64}}}
+typealias IsoTDist  GenericMvTDist{ScalMat{Float64}, Float64}
+typealias DiagTDist GenericMvTDist{PDiagMat{Float64,Vector{Float64}}, Float64}
+typealias MvTDist GenericMvTDist{PDMat{Float64,Matrix{Float64}}, Float64}
 
-MvTDist(df::Float64, μ::Vector{Float64}, C::PDMat) = GenericMvTDist(df, μ, C)
-MvTDist(df::Float64, C::PDMat) = GenericMvTDist(df, C)
-MvTDist(df::Float64, μ::Vector{Float64}, Σ::Matrix{Float64}) = GenericMvTDist(df, μ, PDMat(Σ))
+MvTDist(df::Real, μ::Vector{Float64}, C::PDMat) = GenericMvTDist(df, μ, C)
+MvTDist(df::Real, C::PDMat) = GenericMvTDist(df, C)
+MvTDist(df::Real, μ::Vector{Float64}, Σ::Matrix{Float64}) = GenericMvTDist(df, μ, PDMat(Σ))
 MvTDist(df::Float64, Σ::Matrix{Float64}) = GenericMvTDist(df, PDMat(Σ))
 
 DiagTDist(df::Float64, μ::Vector{Float64}, C::PDiagMat) = GenericMvTDist(df, μ, C)
@@ -56,8 +54,14 @@ IsoTDist(df::Float64, d::Int, σ::Real) = GenericMvTDist(df, ScalMat(d, abs2(Flo
 
 ## convenient function to construct distributions of proper type based on arguments
 
-mvtdist(df::Float64, μ::Vector{Float64}, C::AbstractPDMat) = GenericMvTDist(df, μ, C)
-mvtdist(df::Float64, C::AbstractPDMat) = GenericMvTDist(df, C)
+mvtdist(df::Real, μ::Vector, C::AbstractPDMat) = GenericMvTDist(df, μ, C)
+mvtdist(df::Real, C::AbstractPDMat) = GenericMvTDist(df, C)
+
+mvtdist(df::Real, μ::Vector, σ::Real) = GenericMvTDist(df, μ, ScalMat(length(μ), abs2(σ)))
+mvtdist(df::Real, d::Int, σ::Real) = GenericMvTDist(df, μ, ScalMat(d, abs2(σ)))
+mvtdist(df::Real, μ::Vector, σ::Vector) = GenericMvTDist(df, μ, PDiagMat(abs2(σ)))
+mvtdist(df::Real, μ::Vector, Σ::Matrix) = GenericMvTDist(df, μ, PDMat(Σ))
+mvtdist(df::Real, Σ::Matrix) = GenericMvTDist(df, PDMat(Σ))
 
 mvtdist(df::Float64, μ::Vector{Float64}, σ::Real) = IsoTDist(df, μ, Float64(σ))
 mvtdist(df::Float64, d::Int, σ::Float64) = IsoTDist(d, σ)
@@ -95,16 +99,16 @@ insupport{T<:Real}(d::AbstractMvTDist, x::AbstractVector{T}) =
   length(d) == length(x) && allfinite(x)
 
 function sqmahal{T<:Real}(d::GenericMvTDist, x::AbstractVector{T})
-    z::Vector{Float64} = d.zeromean ? x : x - d.μ
+    z = d.zeromean ? x : x - d.μ
     invquad(d.Σ, z)
 end
 
 function sqmahal!{T<:Real}(r::AbstractArray, d::GenericMvTDist, x::AbstractMatrix{T})
-    z::Matrix{Float64} = d.zeromean ? x : x .- d.μ
+    z = d.zeromean ? x : x .- d.μ
     invquad!(r, d.Σ, z)
 end
 
-sqmahal{T<:Real}(d::AbstractMvTDist, x::AbstractMatrix{T}) = sqmahal!(Array(Float64, size(x, 2)), d, x)
+sqmahal{T<:Real}(d::AbstractMvTDist, x::AbstractMatrix{T}) = sqmahal!(Array(T, size(x, 2)), d, x)
 
 
 function mvtdist_consts(d::AbstractMvTDist)
@@ -132,7 +136,7 @@ end
 _pdf!{T<:Real}(r::AbstractArray, d::AbstractMvNormal, x::AbstractMatrix{T}) = exp!(_logpdf!(r, d, x))
 
 function gradlogpdf{T<:Real}(d::GenericMvTDist, x::AbstractVector{T})
-    z::Vector{Float64} = d.zeromean ? x : x - d.μ
+    z::Vector{T} = d.zeromean ? x : x - d.μ
     prz = invscale(d)*z
     -((d.df + d.dim) / (d.df + dot(z, prz))) * prz
 end
@@ -153,7 +157,7 @@ end
 function _rand!{T<:Real}(d::GenericMvTDist, x::AbstractMatrix{T})
     cols = size(x,2)
     chisqd = Chisq(d.df)
-    y = Array(Float64, 1, cols)
+    y = Array(T, 1, cols)
     unwhiten!(d.Σ, randn!(x))
     rand!(chisqd, y)
     y = sqrt(y/(d.df))


### PR DESCRIPTION
This PR generalizes multivariate distributions dependent on a recent update (JuliaStats/PDMats.jl#41) to PDMats to work with ForwardDiff.jl. 

For `Wishart` and `InverseWishart`, this also depends on (JuliaStats/StatsFuns.jl#6).

Integration tests for desired autodiff behavior are available [here](https://github.com/jmxpearson/distribution_diff_tests).