### PR TITLE
fixed bug in betaprim constructor for single argument

### DIFF
--- a/src/univariate/continuous/betaprime.jl
+++ b/src/univariate/continuous/betaprime.jl
@@ -32,7 +32,7 @@ immutable BetaPrime <: ContinuousUnivariateDistribution
         @check_args(BetaPrime, α > zero(α) && β > zero(β))
         new(α, β)
     end
-    BetaPrime(α::Real) = BetaPrime(α)
+    BetaPrime(α::Real) = BetaPrime(α,α)
     BetaPrime() = new(1.0, 1.0)
 end
 


### PR DESCRIPTION
Fixing bug

```
julia> BetaPrime(3)
ERROR: StackOverflowError:
 in call at /Users/jonalm/.julia/v0.4/Distributions/src/univariate/continuous/betaprime.jl:9 (repeats 80000 times)
```