### PR TITLE
Change randbool to rand(Bool) in vonmises sampler

### DIFF
--- a/src/samplers/vonmises.jl
+++ b/src/samplers/vonmises.jl
@@ -40,7 +40,7 @@ function rand(s::VonMisesSampler)
             end
         end
         acf = acos(f)
-        x = s.μ + (randbool() ? acf : -acf)
+        x = s.μ + (rand(Bool) ? acf : -acf)
     end
     return x
 end


### PR DESCRIPTION
As per JuliaLang/julia#9569, `randbool()` has been deprecated in favor of `rand(Bool)`.