### PR TITLE
logpdfs handle mixed eltype inputs

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 0.4
-PDMats 0.4.1 0.5
+PDMats 0.4.2 0.5
 StatsFuns 0.1.1
+Calculus
 StatsBase 0.7.0
-Compat 0.2.17
+Compat 0.8.4

--- a/doc/source/multivariate.rst
+++ b/doc/source/multivariate.rst
@@ -144,12 +144,12 @@ We realize that the mean vector and the covariance often have special forms in p
 
 .. code-block:: julia
 
-    immutable MvNormal{Cov<:AbstractPDMat,Mean<:Union{Vector{Float64},ZeroVector{Float64}}} <: AbstractMvNormal
+    immutable MvNormal{Cov<:AbstractPDMat,Mean<:Union{Vector,ZeroVector}} <: AbstractMvNormal
         μ::Mean
         Σ::Cov
     end
 
-Here, the mean vector can be an instance of either ``Vector{Float64}`` or ``ZeroVector{Float64}``, where the latter is simply an empty type indicating a vector filled with zeros. The covariance can be of any subtype of ``AbstractPDMat``. Particularly, one can use ``PDMat`` for full covariance, ``PDiagMat`` for diagonal covariance, and ``ScalMat`` for the isotropic covariance -- those in the form of :math:`\sigma \mathbf{I}`. (See the Julia package `PDMats <https://github.com/lindahua/PDMats.jl>`_ for details).
+Here, the mean vector can be an instance of either ``Vector`` or ``ZeroVector``, where the latter is simply an empty type indicating a vector filled with zeros. The covariance can be of any subtype of ``AbstractPDMat``. Particularly, one can use ``PDMat`` for full covariance, ``PDiagMat`` for diagonal covariance, and ``ScalMat`` for the isotropic covariance -- those in the form of :math:`\sigma \mathbf{I}`. (See the Julia package `PDMats <https://github.com/lindahua/PDMats.jl>`_ for details).
 
 We also define a set of alias for the types using different combinations of mean vectors and covariance:
 
@@ -173,23 +173,23 @@ Generally, users don't have to worry about these internal details. We provide a 
 
     Construct a multivariate normal distribution with mean ``mu`` and covariance represented by ``sig``.
 
-    :param mu:      The mean vector, of type ``Vector{Float64}``.
-    :param sig:     The covariance, which can in of either of the following forms:
+    :param mu:      The mean vector, of type ``Vector{T}``, with ``T<:Real``.
+    :param sig:     The covariance, which can in of either of the following forms (with ``T<:Real``):
 
                     - an instance of a subtype of ``AbstractPDMat``
-                    - a symmetric matrix of type ``Matrix{Float64}``
-                    - a vector of type ``Vector{Float64}``: indicating a diagonal covariance as ``diagm(abs2(sig))``.
+                    - a symmetric matrix of type ``Matrix{T}``
+                    - a vector of type ``Vector{T}``: indicating a diagonal covariance as ``diagm(abs2(sig))``.
                     - a real-valued number: indicating an isotropic covariance as ``abs2(sig) * eye(d)``.
 
 .. function:: MvNormal(sig)
 
     Construct a multivariate normal distribution with zero mean and covariance represented by ``sig``.
 
-    Here, ``sig`` can be in either of the following forms:
+    Here, ``sig`` can be in either of the following forms (with ``T<:Real``):
 
     - an instance of a subtype of ``AbstractPDMat``
-    - a symmetric matrix of type ``Matrix{Float64}``
-    - a vector of type ``Vector{Float64}``: indicating a diagonal covariance as ``diagm(abs2(sig))``.
+    - a symmetric matrix of type ``Matrix{T}``
+    - a vector of type ``Vector{T}``: indicating a diagonal covariance as ``diagm(abs2(sig))``.
 
 
 .. function:: MvNormal(d, sig)
@@ -237,7 +237,7 @@ The canonical parameterization is widely used in Bayesian analysis. We provide a
 
 .. code:: julia
 
-    immutable MvNormalCanon{P<:AbstractPDMat,V<:Union{Vector{Float64},ZeroVector{Float64}}} <: AbstractMvNormal
+    immutable MvNormalCanon{P<:AbstractPDMat,V<:Union{Vector,ZeroVector}} <: AbstractMvNormal
         μ::V    # the mean vector
         h::V    # potential vector, i.e. inv(Σ) * μ
         J::P    # precision matrix, i.e. inv(Σ)
@@ -261,23 +261,23 @@ A multivariate distribution with canonical parameterization can be constructed u
 
     Construct a multivariate normal distribution with potential vector ``h`` and precision matrix represented by ``J``.
 
-    :param h:   the potential vector, of type ``Vector{Float64}``.
-    :param J:   the representation of the precision matrix, which can be in either of the following forms:
+    :param h:   the potential vector, of type ``Vector{T}`` with ``T<:Real``.
+    :param J:   the representation of the precision matrix, which can be in either of the following forms (``T<:Real``):
 
                 - an instance of a subtype of ``AbstractPDMat``
-                - a square matrix of type ``Matrix{Float64}``
-                - a vector of type ``Vector{Float64}``: indicating a diagonal precision matrix as ``diagm(J)``.
+                - a square matrix of type ``Matrix{T}``
+                - a vector of type ``Vector{T}``: indicating a diagonal precision matrix as ``diagm(J)``.
                 - a real number: indicating an isotropic precision matrix as ``J * eye(d)``.
 
 .. function:: MvNormalCanon(J)
 
     Construct a multivariate normal distribution with zero mean (thus zero potential vector) and precision matrix represented by ``J``.
 
-    Here, ``J`` represents the precision matrix, which can be in either of the following forms:
+    Here, ``J`` represents the precision matrix, which can be in either of the following forms (``T<:Real``):
 
     - an instance of a subtype of ``AbstractPDMat``
-    - a square matrix of type ``Matrix{Float64}``
-    - a vector of type ``Vector{Float64}``: indicating a diagonal precision matrix as ``diagm(J)``.
+    - a square matrix of type ``Matrix{T}``
+    - a vector of type ``Vector{T}``: indicating a diagonal precision matrix as ``diagm(J)``.
 
 
 .. function:: MvNormalCanon(d, v)
@@ -388,9 +388,3 @@ The `Dirichlet distribution <http://en.wikipedia.org/wiki/Dirichlet_distribution
 
     # Let a be a positive scalar
     Dirichlet(k, a)          # Dirichlet distribution with parameter a * ones(k)
-
-
-
-
-
-

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -7,8 +7,14 @@ using StatsFuns
 using StatsBase
 using Compat
 
+import Compat.view
 import Base.Random
 import Base: size, eltype, length, full, convert, show, getindex, scale, scale!, rand, rand!
+if VERSION < v"0.5.0-"
+    export shape
+else
+    import Base.shape
+end
 import Base: sum, mean, median, maximum, minimum, quantile, std, var, cov, cor
 import Base: +, -, .+, .-
 import Base.Math.@horner
@@ -234,7 +240,6 @@ export
     sampler,            # create a Sampler object for efficient samples
     scale,              # get the scale parameter
     scale!,             # provide storage for the scale parameter (used in multivariate distribution mvlognormal)
-    shape,              # get the shape parameter
     skewness,           # skewness of the distribution
     span,               # the span of the support, e.g. maximum(d) - minimum(d)
     std,                # standard deviation of distribution

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -230,6 +230,7 @@ export
     ntrials,            # the number of trials being performed in the experiment
     params,             # get the tuple of parameters
     params!,            # provide storage space to calculate the tuple of parameters for a multivariate distribution like mvlognormal
+    partype,            # returns a type large enough to hold all of a distribution's parameters' element types
     pdf,                # probability density function (ContinuousDistribution)
     pmf,                # probability mass function (DiscreteDistribution)
     probs,              # Get the vector of probabilities

--- a/src/genericrand.jl
+++ b/src/genericrand.jl
@@ -21,7 +21,7 @@ rand(s::Sampleable{Univariate}, dims::Int...) =
 
 function _rand!(s::Sampleable{Multivariate}, A::AbstractMatrix)
     for i = 1:size(A,2)
-        _rand!(s, slice(A,:,i))
+        _rand!(s, view(A,:,i))
     end
     return A
 end

--- a/src/matrixvariates.jl
+++ b/src/matrixvariates.jl
@@ -10,49 +10,53 @@ rand(d::MatrixDistribution, n::Int) = _rand!(sampler(d), Array(Matrix{eltype(d)}
 
 _pdf{T<:Real}(d::MatrixDistribution, x::AbstractMatrix{T}) = exp(_logpdf(d, x))
 
-function logpdf{T<:Real}(d::MatrixDistribution, x::AbstractMatrix{T}) 
+function logpdf{T<:Real}(d::MatrixDistribution, x::AbstractMatrix{T})
     size(x) == size(d) ||
         throw(DimensionMismatch("Inconsistent array dimensions."))
     _logpdf(d, x)
 end
 
-function pdf{T<:Real}(d::MatrixDistribution, x::AbstractMatrix{T}) 
+function pdf{T<:Real}(d::MatrixDistribution, x::AbstractMatrix{T})
     size(x) == size(d) ||
         throw(DimensionMismatch("Inconsistent array dimensions."))
     _pdf(d, x)
 end
 
-function _logpdf!{M<:Matrix}(r::AbstractArray, d::MatrixDistribution, X::AbstractArray{M}) 
+function _logpdf!{M<:Matrix}(r::AbstractArray, d::MatrixDistribution, X::AbstractArray{M})
     for i = 1:length(X)
         r[i] = logpdf(r, X[i])
     end
     return r
 end
 
-function _pdf!{M<:Matrix}(r::AbstractArray, d::MatrixDistribution, X::AbstractArray{M}) 
+function _pdf!{M<:Matrix}(r::AbstractArray, d::MatrixDistribution, X::AbstractArray{M})
     for i = 1:length(X)
         r[i] = pdf(r, X[i])
     end
     return r
 end
 
-function logpdf!{M<:Matrix}(r::AbstractArray, d::MatrixDistribution, X::AbstractArray{M}) 
+function logpdf!{M<:Matrix}(r::AbstractArray, d::MatrixDistribution, X::AbstractArray{M})
     length(X) == length(r) ||
         throw(DimensionMismatch("Inconsistent array dimensions."))
     _logpdf!(r, d, X)
 end
 
-function pdf!{M<:Matrix}(r::AbstractArray, d::MatrixDistribution, X::AbstractArray{M}) 
+function pdf!{M<:Matrix}(r::AbstractArray, d::MatrixDistribution, X::AbstractArray{M})
     length(X) == length(r) ||
         throw(DimensionMismatch("Inconsistent array dimensions."))
     _pdf!(r, d, X)
 end
 
-logpdf{M<:Matrix}(d::MatrixDistribution, X::AbstractArray{M}) = 
-    _logpdf!(Array(Float64, size(X)), d, X)
+function logpdf{M<:Matrix}(d::MatrixDistribution, X::AbstractArray{M})
+    T = promote_type(partype(d), eltype(M))
+    _logpdf!(Array(T, size(X)), d, X)
+end
 
-pdf{M<:Matrix}(d::MatrixDistribution, X::AbstractArray{M}) = 
-    _pdf!(Array(Float64, size(X)), d, X)
+function pdf{M<:Matrix}(d::MatrixDistribution, X::AbstractArray{M})
+    T = promote_type(partype(d), eltype(M))
+    _pdf!(Array(T, size(X)), d, X)
+end
 
 
 ##### Specific distributions #####
@@ -60,4 +64,3 @@ pdf{M<:Matrix}(d::MatrixDistribution, X::AbstractArray{M}) =
 for fname in ["wishart.jl", "inversewishart.jl"]
     include(joinpath("matrix", fname))
 end
-

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -271,7 +271,7 @@ function _mixlogpdf!(r::AbstractArray, d::AbstractMixtureModel, x)
         @inbounds pi = p[i]
         if pi > 0.0
             lpri = log(pi)
-            lp_i = slice(Lp, :, i)
+            lp_i = view(Lp, :, i)
             # compute logpdf in batch and store
             logpdf!(lp_i, component(d, i), x)
 
@@ -289,7 +289,7 @@ function _mixlogpdf!(r::AbstractArray, d::AbstractMixtureModel, x)
     fill!(r, 0.0)
     @inbounds for i = 1:K
         if p[i] > 0.0
-            lp_i = slice(Lp, :, i)
+            lp_i = view(Lp, :, i)
             for j = 1:n
                 r[j] += exp(lp_i[j] - m[j])
             end
@@ -342,7 +342,7 @@ function _cwise_pdf!(r::AbstractMatrix, d::AbstractMixtureModel, X)
     n = size(X, ndims(X))
     size(r) == (n, K) || error("The size of r is incorrect.")
     for i = 1:K
-        pdf!(slice(r,:,i), component(d, i), X)
+        pdf!(view(r,:,i), component(d, i), X)
     end
     r
 end
@@ -352,7 +352,7 @@ function _cwise_logpdf!(r::AbstractMatrix, d::AbstractMixtureModel, X)
     n = size(X, ndims(X))
     size(r) == (n, K) || error("The size of r is incorrect.")
     for i = 1:K
-        logpdf!(slice(r,:,i), component(d, i), X)
+        logpdf!(view(r,:,i), component(d, i), X)
     end
     r
 end

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -70,6 +70,7 @@ component(d::MixtureModel, k::Int) = d.components[k]
 
 probs(d::MixtureModel) = probs(d.prior)
 params(d::MixtureModel) = ([params(c) for c in d.components], params(d.prior)[1])
+partype(d::MixtureModel) = promote_type(partype(d.prior), map(partype, d.components)...)
 
 function mean(d::UnivariateMixture)
     K = ncomponents(d)

--- a/src/multivariate/mvlognormal.jl
+++ b/src/multivariate/mvlognormal.jl
@@ -137,13 +137,8 @@ var(d::MvLogNormal) = diag(cov(d))
 entropy(d::MvLogNormal) = length(d)*(1+log2π)/2 + logdetcov(d.normal)/2 + sum(mean(d.normal))
 
 #See https://en.wikipedia.org/wiki/Log-normal_distribution
-_rand!{T<:Real}(d::MvLogNormal,x::AbstractVector{T}) = exp!(_rand!(d.normal,x))
-_logpdf{T<:Real}(d::MvLogNormal,x::AbstractVector{T}) = insupport(d,x)?(_logpdf(d.normal,log(x))-sum(log(x))):-Inf
-_pdf{T<:Real}(d::MvLogNormal,x::AbstractVector{T}) = insupport(d,x)?_pdf(d.normal,log(x))/prod(x):0.0
+_rand!{T<:Real}(d::MvLogNormal,x::AbstractVecOrMat{T}) = exp!(_rand!(d.normal,x))
+_logpdf{T<:Real}(d::MvLogNormal,x::AbstractVecOrMat{T}) = insupport(d,x)?(_logpdf(d.normal,log(x))-sum(log(x))):-Inf
+_pdf{T<:Real}(d::MvLogNormal,x::AbstractVecOrMat{T}) = insupport(d,x)?_pdf(d.normal,log(x))/prod(x):0.0
 
 Base.show(io::IO,d::MvLogNormal) = show_multline(io,d,[(:dim,length(d)),(:μ,mean(d.normal)),(:Σ,cov(d.normal))])
-
-
-
-
-

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -227,8 +227,8 @@ function suffstats(D::Type{MvNormal}, x::AbstractMatrix{Float64}, w::Array{Float
     m = s * inv(tw)
     z = similar(x)
     for j = 1:n
-        xj = slice(x,:,j)
-        zj = slice(z,:,j)
+        xj = view(x,:,j)
+        zj = view(z,:,j)
         swj = sqrt(w[j])
         for i = 1:d
             @inbounds zj[i] = swj * (xj[i] - m[i])

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -122,7 +122,7 @@ sqmahal(d::MvNormal, x::AbstractVector) = invquad(d.Σ, x - d.μ)
 sqmahal!(r::AbstractVector, d::MvNormal, x::AbstractMatrix) =
     invquad!(r, d.Σ, x .- d.μ)
 
-gradlogpdf(d::MvNormal, x::Vector{Float64}) = -(d.Σ \ (x - d.μ))
+gradlogpdf(d::MvNormal, x::Vector) = -(d.Σ \ (x - d.μ))
 
 # Sampling (for GenericMvNormal)
 

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -26,7 +26,7 @@ abstract AbstractMvNormal <: ContinuousMultivariateDistribution
 
 ### Generic methods (for all AbstractMvNormal subtypes)
 
-insupport{T<:Real}(d::AbstractMvNormal, x::AbstractVector{T}) =
+insupport(d::AbstractMvNormal, x::AbstractVector) =
     length(d) == length(x) && allfinite(x)
 
 mode(d::AbstractMvNormal) = mean(d)
@@ -36,20 +36,20 @@ entropy(d::AbstractMvNormal) = 0.5 * (length(d) * (Float64(log2π) + 1.0) + logd
 
 mvnormal_c0(g::AbstractMvNormal) = -0.5 * (length(g) * Float64(log2π) + logdetcov(g))
 
-sqmahal{T<:Real}(d::AbstractMvNormal, x::AbstractMatrix{T}) = sqmahal!(Array(Float64, size(x, 2)), d, x)
+sqmahal(d::AbstractMvNormal, x::AbstractMatrix) = sqmahal!(Array(Float64, size(x, 2)), d, x)
 
-_logpdf{T<:Real}(d::AbstractMvNormal, x::AbstractVector{T}) = mvnormal_c0(d) - 0.5 * sqmahal(d, x)
+_logpdf(d::AbstractMvNormal, x::AbstractVector) = mvnormal_c0(d) - 0.5 * sqmahal(d, x)
 
-function _logpdf!{T<:Real}(r::AbstractArray, d::AbstractMvNormal, x::AbstractMatrix{T})
+function _logpdf!(r::AbstractArray, d::AbstractMvNormal, x::AbstractMatrix)
     sqmahal!(r, d, x)
-    c0::Float64 = mvnormal_c0(d)
+    c0 = mvnormal_c0(d)
     for i = 1:size(x, 2)
         @inbounds r[i] = c0 - 0.5 * r[i]
     end
     r
 end
 
-_pdf!{T<:Real}(r::AbstractArray, d::AbstractMvNormal, x::AbstractMatrix{T}) = exp!(_logpdf!(r, d, x))
+_pdf!(r::AbstractArray, d::AbstractMvNormal, x::AbstractMatrix) = exp!(_logpdf!(r, d, x))
 
 
 ###########################################################
@@ -117,9 +117,9 @@ logdetcov(d::MvNormal) = logdet(d.Σ)
 
 ### Evaluation
 
-sqmahal{T<:Real}(d::MvNormal, x::AbstractVector{T}) = invquad(d.Σ, x - d.μ)
+sqmahal(d::MvNormal, x::AbstractVector) = invquad(d.Σ, x - d.μ)
 
-sqmahal!{T<:Real}(r::AbstractVector, d::MvNormal, x::AbstractMatrix{T}) =
+sqmahal!(r::AbstractVector, d::MvNormal, x::AbstractMatrix) =
     invquad!(r, d.Σ, x .- d.μ)
 
 gradlogpdf(d::MvNormal, x::Vector{Float64}) = -(d.Σ \ (x - d.μ))

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -126,10 +126,10 @@ gradlogpdf(d::MvNormal, x::Vector) = -(d.Σ \ (x - d.μ))
 
 # Sampling (for GenericMvNormal)
 
-_rand!(d::MvNormal, x::VecOrMat{Float64}) = add!(unwhiten!(d.Σ, randn!(x)), d.μ)
+_rand!(d::MvNormal, x::VecOrMat) = add!(unwhiten!(d.Σ, randn!(x)), d.μ)
 
 # Workaround: randn! only works for Array, but not generally for AbstractArray
-function _rand!(d::MvNormal, x::AbstractVecOrMat{Float64})
+function _rand!(d::MvNormal, x::AbstractVecOrMat)
     for i = 1:length(x)
         @inbounds x[i] = randn()
     end

--- a/src/multivariate/mvnormalcanon.jl
+++ b/src/multivariate/mvnormalcanon.jl
@@ -2,41 +2,45 @@
 
 ### Generic types
 
-immutable MvNormalCanon{P<:AbstractPDMat,V<:Union{Vector,ZeroVector}} <: AbstractMvNormal
+immutable MvNormalCanon{T<:Real,P<:AbstractPDMat,V<:Union{Vector,ZeroVector}} <: AbstractMvNormal
     μ::V    # the mean vector
     h::V    # potential vector, i.e. inv(Σ) * μ
     J::P    # precision matrix, i.e. inv(Σ)
 end
 
-typealias FullNormalCanon MvNormalCanon{PDMat{Float64,Matrix{Float64}},Vector{Float64}}
-typealias DiagNormalCanon MvNormalCanon{PDiagMat{Float64,Vector{Float64}},Vector{Float64}}
-typealias IsoNormalCanon  MvNormalCanon{ScalMat{Float64},Vector{Float64}}
+typealias FullNormalCanon MvNormalCanon{Float64, PDMat{Float64,Matrix{Float64}},Vector{Float64}}
+typealias DiagNormalCanon MvNormalCanon{Float64,PDiagMat{Float64,Vector{Float64}},Vector{Float64}}
+typealias IsoNormalCanon  MvNormalCanon{Float64,ScalMat{Float64},Vector{Float64}}
 
-typealias ZeroMeanFullNormalCanon MvNormalCanon{PDMat{Float64,Matrix{Float64}},ZeroVector{Float64}}
-typealias ZeroMeanDiagNormalCanon MvNormalCanon{PDiagMat{Float64,Vector{Float64}},ZeroVector{Float64}}
-typealias ZeroMeanIsoNormalCanon  MvNormalCanon{ScalMat{Float64},ZeroVector{Float64}}
+typealias ZeroMeanFullNormalCanon MvNormalCanon{Float64,PDMat{Float64,Matrix{Float64}},ZeroVector{Float64}}
+typealias ZeroMeanDiagNormalCanon MvNormalCanon{Float64,PDiagMat{Float64,Vector{Float64}},ZeroVector{Float64}}
+typealias ZeroMeanIsoNormalCanon  MvNormalCanon{Float64,ScalMat{Float64},ZeroVector{Float64}}
 
 
 ### Constructors
 
-function MvNormalCanon{P<:AbstractPDMat, T<:Real}(μ::Vector{T}, h::Vector{T}, J::P)
+function MvNormalCanon{T<:Real, P<:AbstractPDMat}(μ::Vector{T}, h::Vector{T}, J::P)
     length(μ) == length(h) == dim(J) || throw(DimensionMismatch("Inconsistent argument dimensions"))
-    MvNormalCanon{P,Vector{T}}(μ, h, J)
+    MvNormalCanon{T,P,Vector{T}}(μ, promote_eltype(h, J)...)
 end
 
 function MvNormalCanon{P<:AbstractPDMat}(J::P)
-    z = ZeroVector(Float64, dim(J))
-    MvNormalCanon{P,ZeroVector{Float64}}(z, z, J)
+    z = ZeroVector(eltype(J), dim(J))
+    MvNormalCanon{eltype(J),P,ZeroVector{eltype(J)}}(z, z, J)
 end
 
-function MvNormalCanon{P<:AbstractPDMat, T<:Real}(h::Vector{T}, J::P)
+function MvNormalCanon{T<:Real, P<:AbstractPDMat}(h::Vector{T}, J::P)
     length(h) == dim(J) || throw(DimensionMismatch("Inconsistent argument dimensions"))
-    MvNormalCanon{P,Vector{T}}(J \ h, h, J)
+    hh, JJ = promote_eltype(h, J)
+    MvNormalCanon{T,P,Vector{T}}(JJ \ hh, hh, JJ)
 end
 
-MvNormalCanon{T<:Real}(h::Vector{T}, J::Matrix) = MvNormalCanon(h, PDMat(J))
-MvNormalCanon{T<:Real}(h::Vector{T}, prec::Vector) = MvNormalCanon(h, PDiagMat(prec))
-MvNormalCanon{T<:Real}(h::Vector{T}, prec) = MvNormalCanon(h, ScalMat(length(h), prec))
+MvNormalCanon{T<:Real}(h::Vector{T}, J::Matrix{T}) = MvNormalCanon(h, PDMat(J))
+MvNormalCanon{T<:Real}(h::Vector{T}, prec::Vector{T}) = MvNormalCanon(h, PDiagMat(prec))
+MvNormalCanon{T<:Real}(h::Vector{T}, prec::T) = MvNormalCanon(h, ScalMat(length(h), prec))
+
+MvNormalCanon{T<:Real, S<:Real}(h::Vector{T}, J::VecOrMat{S}) = MvNormalCanon(promote_eltype(h, J)...)
+MvNormalCanon{T<:Real, S<:Real}(h::Vector{T}, prec::S) = MvNormalCanon(promote_eltype(h, prec)...)
 
 MvNormalCanon(J::Matrix) = MvNormalCanon(PDMat(J))
 MvNormalCanon(prec::Vector) = MvNormalCanon(PDiagMat(prec))
@@ -55,11 +59,12 @@ distrname(d::ZeroMeanFullNormalCanon) = "ZeroMeanFullNormalCanon"
 
 ### conversion between conventional form and canonical form
 
-meanform{C,V}(d::MvNormalCanon{C,V}) = MvNormal{C,V}(d.μ, inv(d.J))
+meanform(d::MvNormalCanon) = MvNormal(d.μ, inv(d.J))
+# meanform{C, T<:Real}(d::MvNormalCanon{T,C,Vector{T}}) = MvNormal(d.μ, inv(d.J))
+# meanform{C, T<:Real}(d::MvNormalCanon{T,C,ZeroVector{T}}) = MvNormal(inv(d.J))
 
-canonform{C, T<:Real}(d::MvNormal{C,Vector{T}}) = (J = inv(d.Σ); MvNormalCanon(d.μ, J * d.μ, J))
-canonform{C, T<:Real}(d::MvNormal{C,ZeroVector{T}}) = MvNormalCanon(inv(d.Σ))
-
+canonform{C, T<:Real}(d::MvNormal{T,C,Vector{T}}) = (J = inv(d.Σ); MvNormalCanon(d.μ, J * d.μ, J))
+canonform{C, T<:Real}(d::MvNormal{T,C,ZeroVector{T}}) = MvNormalCanon(inv(d.Σ))
 
 ### Basic statistics
 

--- a/src/multivariates.jl
+++ b/src/multivariates.jl
@@ -24,7 +24,7 @@ function insupport!{D<:MultivariateDistribution}(r::AbstractArray, d::Union{D,Ty
     size(X) == (length(d),n) ||
         throw(DimensionMismatch("Inconsistent array dimensions."))
     for i in 1:n
-        @inbounds r[i] = insupport(d, slice(X, :, i))
+        @inbounds r[i] = insupport(d, view(X, :, i))
     end
     return r
 end
@@ -73,14 +73,14 @@ end
 
 function _logpdf!(r::AbstractArray, d::MultivariateDistribution, X::AbstractMatrix)
     for i in 1 : size(X,2)
-        @inbounds r[i] = logpdf(d, slice(X,:,i))
+        @inbounds r[i] = logpdf(d, view(X,:,i))
     end
     return r
 end
 
 function _pdf!(r::AbstractArray, d::MultivariateDistribution, X::AbstractMatrix)
     for i in 1 : size(X,2)
-        @inbounds r[i] = pdf(d, slice(X,:,i))
+        @inbounds r[i] = pdf(d, view(X,:,i))
     end
     return r
 end
@@ -114,7 +114,7 @@ end
 function _loglikelihood(d::MultivariateDistribution, X::AbstractMatrix)
     ll = 0.0
     for i in 1:size(X, 2)
-        ll += _logpdf(d, slice(X,:,i))
+        ll += _logpdf(d, view(X,:,i))
     end
     return ll
 end

--- a/src/multivariates.jl
+++ b/src/multivariates.jl
@@ -40,7 +40,7 @@ function cor(d::MultivariateDistribution)
     C = cov(d)
     n = size(C, 1)
     @assert size(C, 2) == n
-    R = Array(Float64, n, n)
+    R = Array(eltype(C), n, n)
 
     for j = 1:n
         for i = 1:j-1
@@ -100,13 +100,15 @@ end
 function logpdf(d::MultivariateDistribution, X::AbstractMatrix)
     size(X, 1) == length(d) ||
         throw(DimensionMismatch("Inconsistent array dimensions."))
-    _logpdf!(Array(Float64, size(X,2)), d, X)
+    T = promote_type(partype(d), eltype(X))
+    _logpdf!(Array(T, size(X,2)), d, X)
 end
 
 function pdf(d::MultivariateDistribution, X::AbstractMatrix)
     size(X, 1) == length(d) ||
         throw(DimensionMismatch("Inconsistent array dimensions."))
-    _pdf!(Array(Float64, size(X,2)), d, X)
+    T = promote_type(partype(d), eltype(X))
+    _pdf!(Array(T, size(X,2)), d, X)
 end
 
 ## log likelihood

--- a/src/samplers/vonmisesfisher.jl
+++ b/src/samplers/vonmisesfisher.jl
@@ -44,7 +44,7 @@ _rand!(spl::VonMisesFisherSampler, x::AbstractVector) = _rand!(spl, x, Array(Flo
 function _rand!(spl::VonMisesFisherSampler, x::AbstractMatrix)
     t = Array(Float64, size(x, 1))
     for j = 1:size(x, 2)
-        _rand!(spl, slice(x,:,j), t)
+        _rand!(spl, view(x,:,j), t)
     end
     return x
 end
@@ -78,13 +78,13 @@ function _vmf_rotmat(u::Vector{Float64})
     # s.t. Q * [1,0,...,0]^T --> u
     #
     # Strategy: construct a full-rank matrix
-    # with first column being u, and then 
+    # with first column being u, and then
     # perform QR factorization
     #
 
     p = length(u)
     A = zeros(p, p)
-    copy!(slice(A,:,1), u)
+    copy!(view(A,:,1), u)
 
     # let k the be index of entry with max abs
     k = 1
@@ -98,7 +98,7 @@ function _vmf_rotmat(u::Vector{Float64})
     end
 
     # other columns of A will be filled with
-    # indicator vectors, except the one 
+    # indicator vectors, except the one
     # that activates the k-th entry
     i = 1
     for j = 2:p
@@ -110,11 +110,10 @@ function _vmf_rotmat(u::Vector{Float64})
 
     # perform QR factorization
     Q = full(qrfact!(A)[:Q])
-    if dot(slice(Q,:,1), u) < 0.0  # the first column was negated
+    if dot(view(Q,:,1), u) < 0.0  # the first column was negated
         for i = 1:p
             @inbounds Q[i,1] = -Q[i,1]
         end
     end
     return Q
 end
-

--- a/src/testutils.jl
+++ b/src/testutils.jl
@@ -68,7 +68,7 @@ end
 function test_samples(s::Sampleable{Univariate, Discrete},      # the sampleable instance
                       distr::DiscreteUnivariateDistribution,    # corresponding distribution
                       n::Int;                                   # number of samples to generate
-                      q::Float64=1.0e-6,                        # confidence interval, 1 - q as confidence
+                      q::Float64=1.0e-7,                        # confidence interval, 1 - q as confidence
                       verbose::Bool=false)                      # show intermediate info (for debugging)
 
     # The basic idea

--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -21,6 +21,7 @@ end
 
 Truncated(d::UnivariateDistribution, l::Real, u::Real) = Truncated(d, Float64(l), Float64(u))
 
+params(d::Truncated) = tuple(params(d.untruncated)..., d.lower, d.upper)
 ### range and support
 
 islowerbounded(d::Truncated) = islowerbounded(d.untruncated) || isfinite(d.lower)
@@ -39,7 +40,7 @@ pdf(d::Truncated, x::Float64) = d.lower <= x <= d.upper ? pdf(d.untruncated, x) 
 
 logpdf(d::Truncated, x::Float64) = d.lower <= x <= d.upper ? logpdf(d.untruncated, x) - d.logtp : -Inf
 
-cdf(d::Truncated, x::Float64) = x <= d.lower ? 0.0 : 
+cdf(d::Truncated, x::Float64) = x <= d.lower ? 0.0 :
                              x >= d.upper ? 1.0 :
                              (cdf(d.untruncated, x) - d.lcdf) / d.tp
 
@@ -47,13 +48,13 @@ logcdf(d::Truncated, x::Float64) = x <= d.lower ? -Inf :
                                 x >= d.upper ? 0.0 :
                                 log(cdf(d.untruncated, x) - d.lcdf) - d.logtp
 
-ccdf(d::Truncated, x::Float64) = x <= d.lower ? 1.0 : 
+ccdf(d::Truncated, x::Float64) = x <= d.lower ? 1.0 :
                               x >= d.upper ? 0.0 :
                               (d.ucdf - cdf(d.untruncated, x)) / d.tp
 
 logccdf(d::Truncated, x::Float64) = x <= d.lower ? 0.0 :
                                  x >= d.upper ? -Inf :
-                                 log(d.ucdf - cdf(d.untruncated, x)) - d.logtp 
+                                 log(d.ucdf - cdf(d.untruncated, x)) - d.logtp
 
 
 quantile(d::Truncated, p::Float64) = quantile(d.untruncated, d.lcdf + p * d.tp)
@@ -62,7 +63,7 @@ pdf(d::Truncated, x::Int) = d.lower <= x <= d.upper ? pdf(d.untruncated, x) / d.
 
 logpdf(d::Truncated, x::Int) = d.lower <= x <= d.upper ? logpdf(d.untruncated, x) - d.logtp : -Inf
 
-cdf(d::Truncated, x::Int) = x <= d.lower ? 0.0 : 
+cdf(d::Truncated, x::Int) = x <= d.lower ? 0.0 :
                              x >= d.upper ? 1.0 :
                              (cdf(d.untruncated, x) - d.lcdf) / d.tp
 
@@ -70,13 +71,13 @@ logcdf(d::Truncated, x::Int) = x <= d.lower ? -Inf :
                                 x >= d.upper ? 0.0 :
                                 log(cdf(d.untruncated, x) - d.lcdf) - d.logtp
 
-ccdf(d::Truncated, x::Int) = x <= d.lower ? 1.0 : 
+ccdf(d::Truncated, x::Int) = x <= d.lower ? 1.0 :
                               x >= d.upper ? 0.0 :
                               (d.ucdf - cdf(d.untruncated, x)) / d.tp
 
 logccdf(d::Truncated, x::Int) = x <= d.lower ? 0.0 :
                                  x >= d.upper ? -Inf :
-                                 log(d.ucdf - cdf(d.untruncated, x)) - d.logtp 
+                                 log(d.ucdf - cdf(d.untruncated, x)) - d.logtp
 
 ## random number generation
 
@@ -113,7 +114,3 @@ _use_multline_show(d::Truncated) = _use_multline_show(d.untruncated)
 ### specialized truncated distributions
 
 include(joinpath("truncated", "normal.jl"))
-
-
-
-

--- a/src/univariate/discrete/discreteuniform.jl
+++ b/src/univariate/discrete/discreteuniform.jl
@@ -40,6 +40,8 @@ span(d::DiscreteUniform) = d.b - d.a + 1
 probval(d::DiscreteUniform) = d.pv
 params(d::DiscreteUniform) = (d.a, d.b)
 
+# this is a hack to get pdf, etc. to allocate the correct storage type
+partype(d::DiscreteUniform) = Float64
 
 ### Show
 

--- a/src/univariate/discrete/hypergeometric.jl
+++ b/src/univariate/discrete/hypergeometric.jl
@@ -36,6 +36,9 @@ end
 
 params(d::Hypergeometric) = (d.ns, d.nf, d.n)
 
+# this is a hack to get pdf, etc. to allocate the correct storage type
+partype(d::Hypergeometric) = Float64
+
 
 ### Statistics
 

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -203,7 +203,7 @@ for fun in [:pdf, :logpdf,
         end
 
         ($fun)(d::UnivariateDistribution, X::AbstractArray) =
-            $(_fun!)(Array(Float64, size(X)), d, X)
+            $(_fun!)(Array(promote_type(partype(d), eltype(X)), size(X)), d, X)
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -95,6 +95,8 @@ function exp!(x::AbstractArray)
     x
 end
 
+# get a type capable of representing computations using a distribution's paramters
+@inline partype(d::Distribution) = promote_type(map(eltype, params(d))...)
 
 # for checking the input range of quantile functions
 # comparison with NaN is always false, so no explicit check is required

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -129,3 +129,18 @@ function trycholfact(a::Matrix{Float64})
         return e
     end
 end
+
+# for when container inputs need to be promoted to the same eltype
+function promote_eltype{T, S}(A::Array{T}, B::Array{S})
+    R = promote_type(T, S)
+    (convert(Array{R}, A), convert(Array{R}, B))
+end
+function promote_eltype{T}(A::Array{T}, B::Real)
+    R = promote_type(T, typeof(B))
+    (convert(Array{R}, A), convert(R, B))
+end
+function promote_eltype{T, S}(A::Array{T}, B::AbstractPDMat{S})
+    R = promote_type(T, S)
+    (convert(Array{R}, A), convert(typeof(B).name.primary{R}, B))
+end
+promote_eltype{T, S}(A::ZeroVector{T}, B::AbstractPDMat{S}) = (ZeroVector{S}(A.len), B)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -96,7 +96,8 @@ function exp!(x::AbstractArray)
 end
 
 # get a type capable of representing computations using a distribution's paramters
-@inline partype(d::Distribution) = promote_type(map(eltype, params(d))...)
+@inline partype(d::Distribution) = promote_type(map(_partype, params(d))...)
+@inline _partype(x) = isa(x, Real) ? typeof(x) : eltype(x)
 
 # for checking the input range of quantile functions
 # comparison with NaN is always false, so no explicit check is required

--- a/test/continuous.jl
+++ b/test/continuous.jl
@@ -2,6 +2,7 @@
 
 using Distributions
 using Base.Test
+using Calculus.derivative
 
 ### load reference data
 #

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -24,7 +24,17 @@ v = 3.0
 @test_approx_eq_eps pdf(Wishart(v,inv(S)),S) 0.0148086 1e-8
 @test_approx_eq_eps pdf(Wishart(v,inv(S)),inv(S)) 0.01901462 1e-8
 
+@test_approx_eq logpdf(Wishart(v,S), S) log(pdf(Wishart(v,S), S))
+@test_approx_eq logpdf(Wishart(v,S), inv(S)) log(pdf(Wishart(v,S), inv(S)))
+@test_approx_eq logpdf(Wishart(v,inv(S)), S) log(pdf(Wishart(v,inv(S)), S))
+@test_approx_eq logpdf(Wishart(v,inv(S)), inv(S)) log(pdf(Wishart(v,inv(S)), inv(S)))
+
 @test_approx_eq_eps pdf(InverseWishart(v,S), S) 0.04507168 1e-8
 @test_approx_eq_eps pdf(InverseWishart(v,S), inv(S)) 0.006247377 1e-8
 @test_approx_eq_eps pdf(InverseWishart(v,inv(S)),S)  0.03147137 1e-8
 @test_approx_eq_eps pdf(InverseWishart(v,inv(S)),inv(S)) 0.01901462 1e-8
+
+@test_approx_eq logpdf(InverseWishart(v,S), S) log(pdf(InverseWishart(v,S), S))
+@test_approx_eq logpdf(InverseWishart(v,S), inv(S)) log(pdf(InverseWishart(v,S), inv(S)))
+@test_approx_eq logpdf(InverseWishart(v,inv(S)), S) log(pdf(InverseWishart(v,inv(S)), S))
+@test_approx_eq logpdf(InverseWishart(v,inv(S)), inv(S)) log(pdf(InverseWishart(v,inv(S)), inv(S)))

--- a/test/mvlognormal.jl
+++ b/test/mvlognormal.jl
@@ -29,7 +29,9 @@ function test_mvlognormal(g::MvLogNormal, n_tsamples::Int=10^6)
     @test_approx_eq mn exp(mean(g.normal) + var(g.normal)/2)
     @test_approx_eq mo exp(mean(g.normal) - var(g.normal))
     @test_approx_eq entropy(g) d*(1 + Distributions.log2π)/2 + logdetcov(g.normal)/2 + sum(mean(g.normal))
-    @test g == typeof(g)(params(g)...)
+    gg = typeof(g)(params(g)...)
+    @test full(g.normal.μ) == full(gg.normal.μ)
+    @test full(g.normal.Σ) == full(gg.normal.Σ)
     @test insupport(g,ones(d))
     @test !insupport(g,zeros(d))
     @test !insupport(g,-ones(d))
@@ -116,7 +118,3 @@ for (g, μ, Σ) in [
     @test_approx_eq full(m) μ
     test_mvlognormal(g)
 end
-
-
-
-

--- a/test/mvtdist.jl
+++ b/test/mvtdist.jl
@@ -23,5 +23,8 @@ df = [1., 2, 3, 5, 10]
 for i = 1:length(df)
   d = MvTDist(df[i], mu, Sigma)
   @test_approx_eq_eps logpdf(d, [-2., 3]) rvalues[i] 1.0e-8
-  @test d == typeof(d)(params(d)...)
+  dd = typeof(d)(params(d)...)
+  @test d.df == dd.df
+  @test full(d.μ) == full(dd.μ)
+  @test full(d.Σ) == full(dd.Σ)
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -8,4 +8,15 @@ r = RealInterval(1.5, 4.0)
 
 @test partype(Gamma(1, 2)) == Int64
 @test partype(Gamma(1.1, 2)) == Float64
-@test partype(MvNormal(rand(Float16, 5), eye(Float32, 5))) == Float32
+@test partype(MvNormal(rand(Float32, 5), eye(Float32, 5))) == Float32
+
+A = rand(1:10, 5, 5)
+B = rand(Float32, 4)
+C = 1//2
+L = rand(Float32, 4, 4)
+D = PDMats.PDMat(L * L')
+@test Distributions.promote_eltype(A, B) == (convert(Array{Float32}, A), convert(Array{Float32}, B))
+@test Distributions.promote_eltype(A, C) == (convert(Array{Rational{Int}}, A), convert(Float32, C))
+AA, DD = Distributions.promote_eltype(A, D)
+@test AA == convert(Array{Float32}, A)
+@test DD.mat == convert(PDMats.PDMat{Float32}, D).mat

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -6,3 +6,6 @@ r = RealInterval(1.5, 4.0)
 @test minimum(r) == 1.5
 @test maximum(r) == 4.0
 
+@test partype(Gamma(1, 2)) == Int64
+@test partype(Gamma(1.1, 2)) == Float64
+@test partype(MvNormal(rand(Float16, 5), eye(Float32, 5))) == Float32


### PR DESCRIPTION
Companion work to JuliaStats/PDMats.jl#45 to allow for automatic differentiation of logpdfs, etc.

- Removes explicity Float64 casting in MvNormal
- defines a new utility function, `partype` that returns a type capable of holding all the element types of a distribution's parameters
- when `logpdf(d, X)`, etc. are called, the storage array passed to their in-place versions is of type `promote_type(partype(d), eltype(X))`