### PR TITLE
Replace deprecated call to hist

### DIFF
--- a/src/testutils.jl
+++ b/src/testutils.jl
@@ -211,7 +211,7 @@ function test_samples(s::Sampleable{Univariate, Continuous},    # the sampleable
     end
 
     # get counts
-    cnts = hist(samples, edges)[2]
+    cnts = fit(Histogram, samples, edges).weights
     @assert length(cnts) == nbins
 
     # check the counts


### PR DESCRIPTION
`hist` is deprecated in v0.5 so this line threw a lot of warnings in `Pkg.test("Distributions")`