### PR TITLE
changed binomial to accept generic first argument

### DIFF
--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -6,7 +6,7 @@ function dim(d::MultivariateDistribution)
     return length(d)
 end
 
-function binaryentropy(d::UnivariateDistribution) 
+function binaryentropy(d::UnivariateDistribution)
     Base.depwarn("binaryentropy is deprecated. Please use entropy(d, 2).", :binaryentropy)
     return entropy(d) / log(2)
 end
@@ -25,3 +25,17 @@ function probs(d::DiscreteUnivariateDistribution)
     return probs(d)
 end
 
+function Binomial(n::Real, p::Real)
+    Base.depwarn("Binomial(n::Real, p) is deprecated. Please use Binomial(n::Integer, p) instead.", :Binomial)
+    Binomial(Int(n), p)
+end
+
+function Binomial(n::Real)
+    Base.depwarn("Binomial(n::Real) is deprecated. Please use Binomial(n::Integer) instead.", :Binomial)
+    Binomial(Int(n))
+end
+
+function BetaBinomial(n::Real, α::Real, β::Real)
+    Base.depwarn("BetaBinomial(n::Real, α, β) is deprecated. Please use BetaBinomial(n::Integer, α, β) instead.", :BetaBinomial)
+    BetaBinomial(Int(n), α, β)
+end

--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -30,7 +30,6 @@ end
 
 BetaBinomial{T<:Real}(n::Integer, α::T, β::T) = BetaBinomial{T}(n, α, β)
 BetaBinomial(n::Integer, α::Real, β::Real) = BetaBinomial(n, promote(α, β)...)
-BetaBinomial(n::Real, α::Real, β::Real) = Base.depwarn("BetaBinomial(n::Real, α, β) is deprecated. Please use BetaBinomial(n::Integer, α, β) instead.", :BetaBinomial)
 BetaBinomial(n::Integer, α::Integer, β::Integer) = BetaBinomial(n, Float64(α), Float64(β))
 
 @distr_support BetaBinomial 0 d.n

--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -28,9 +28,10 @@ immutable BetaBinomial{T<:Real} <: DiscreteUnivariateDistribution
     end
 end
 
-BetaBinomial{T<:Real}(n::Int, α::T, β::T) = BetaBinomial{T}(n, α, β)
-BetaBinomial(n::Int, α::Real, β::Real) = BetaBinomial(n, promote(α, β)...)
-BetaBinomial(n::Int, α::Integer, β::Integer) = BetaBinomial(n, Float64(α), Float64(β))
+BetaBinomial{T<:Real}(n::Integer, α::T, β::T) = BetaBinomial{T}(n, α, β)
+BetaBinomial(n::Integer, α::Real, β::Real) = BetaBinomial(n, promote(α, β)...)
+BetaBinomial(n::Real, α::Real, β::Real) = Base.depwarn("BetaBinomial(n::Real, α, β) is deprecated. Please use BetaBinomial(n::Integer, α, β) instead.", :BetaBinomial)
+BetaBinomial(n::Integer, α::Integer, β::Integer) = BetaBinomial(n, Float64(α), Float64(β))
 
 @distr_support BetaBinomial 0 d.n
 insupport(d::BetaBinomial, x::Real) = 0 <= x <= d.n

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -25,7 +25,7 @@ immutable Binomial{T<:Real} <: DiscreteUnivariateDistribution
     n::Int
     p::T
 
-    function Binomial(n::Int, p::T)
+    function Binomial(n, p)
         @check_args(Binomial, n >= zero(n))
         @check_args(Binomial, zero(p) <= p <= one(p))
         new(n, p)
@@ -33,9 +33,9 @@ immutable Binomial{T<:Real} <: DiscreteUnivariateDistribution
 
 end
 
-Binomial{T<:Real}(n::Integer, p::T) = Binomial{T}(n, p)
-Binomial(n::Integer, p::Integer) = Binomial(n, Float64(p))
-Binomial(n::Integer) = Binomial(n, 0.5)
+Binomial{T<:Real}(n, p::T) = Binomial{T}(n, p)
+Binomial(n, p::Integer) = Binomial(n, Float64(p))
+Binomial(n) = Binomial(n, 0.5)
 Binomial() = Binomial(1, 0.5)
 
 @distr_support Binomial 0 d.n

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -34,10 +34,8 @@ immutable Binomial{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 Binomial{T<:Real}(n::Integer, p::T) = Binomial{T}(n, p)
-Binomial(n::Real, p::Real) = Base.depwarn("Binomial(n::Real, p) is deprecated. Please use Binomial(n::Integer, p) instead.", :Binomial)
 Binomial(n::Integer, p::Integer) = Binomial(n, Float64(p))
 Binomial(n::Integer) = Binomial(n, 0.5)
-Binomial(n::Real) = Base.depwarn("Binomial(n::Real) is deprecated. Please use Binomial(n::Integer) instead.", :Binomial)
 Binomial() = Binomial(1, 0.5)
 
 @distr_support Binomial 0 d.n

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -33,9 +33,11 @@ immutable Binomial{T<:Real} <: DiscreteUnivariateDistribution
 
 end
 
-Binomial{T<:Real}(n, p::T) = Binomial{T}(n, p)
-Binomial(n, p::Integer) = Binomial(n, Float64(p))
-Binomial(n) = Binomial(n, 0.5)
+Binomial{T<:Real}(n::Integer, p::T) = Binomial{T}(n, p)
+Binomial(n::Real, p::Real) = Base.depwarn("Binomial(n::Real, p) is deprecated. Please use Binomial(n::Integer, p) instead.", :Binomial)
+Binomial(n::Integer, p::Integer) = Binomial(n, Float64(p))
+Binomial(n::Integer) = Binomial(n, 0.5)
+Binomial(n::Real) = Base.depwarn("Binomial(n::Real) is deprecated. Please use Binomial(n::Integer) instead.", :Binomial)
 Binomial() = Binomial(1, 0.5)
 
 @distr_support Binomial 0 d.n


### PR DESCRIPTION
This addresses the issue raised in JuliaGraphs/LightGraphs.jl#407. It's entirely reasonable for users to be able to write
```julia
Binomial(1., 0.75)
```
Previously, the inner constructor handled the implicit conversion of the first argument to Int. This just restores that behavior. 
```julia
Binomial(1.5, 0.5)
```
will throw an `InexactError` as before.