### PR TITLE
more parametric distributions

### DIFF
--- a/src/matrix/inversewishart.jl
+++ b/src/matrix/inversewishart.jl
@@ -29,7 +29,7 @@ InverseWishart(df::Real, Ψ::Cholesky) = InverseWishart(df, PDMat(Ψ))
 function _invwishart_c0(df::Real, Ψ::AbstractPDMat)
     h_df = df / 2
     p = dim(Ψ)
-    h_df * (p * logtwo - logdet(Ψ)) + logmvgamma(p, h_df)
+    h_df * (p * typeof(df)(logtwo) - logdet(Ψ)) + logmvgamma(p, h_df)
 end
 
 
@@ -42,6 +42,16 @@ dim(d::InverseWishart) = dim(d.Ψ)
 size(d::InverseWishart) = (p = dim(d); (p, p))
 params(d::InverseWishart) = (d.df, d.Ψ, d.c0)
 @inline partype{T<:Real}(d::InverseWishart{T}) = T
+
+### Conversion
+function convert{T<:Real}(::Type{InverseWishart{T}}, d::InverseWishart)
+    P = convert_eltype(T, d.Ψ)
+    InverseWishart{T, typeof(P)}(T(d.df), P, T(d.c0))
+end
+function convert{T<:Real}(::Type{InverseWishart{T}}, df, Ψ::AbstractPDMat, c0)
+    P = convert_eltype(T, Ψ)
+    InverseWishart{T, typeof(P)}(T(df), P, T(c0))
+end
 
 #### Show
 

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -29,7 +29,7 @@ Wishart(df::Real, S::Cholesky) = Wishart(df, PDMat(S))
 function _wishart_c0(df::Real, S::AbstractPDMat)
     h_df = df / 2
     p = dim(S)
-    h_df * (logdet(S) + p * logtwo) + logmvgamma(p, h_df)
+    h_df * (logdet(S) + p * typeof(df)(logtwo)) + logmvgamma(p, h_df)
 end
 
 
@@ -42,6 +42,16 @@ dim(d::Wishart) = dim(d.S)
 size(d::Wishart) = (p = dim(d); (p, p))
 params(d::Wishart) = (d.df, d.S, d.c0)
 @inline partype{T<:Real}(d::Wishart{T}) = T
+
+### Conversion
+function convert{T<:Real}(::Type{Wishart{T}}, d::Wishart)
+    P = convert_eltype(T, d.S)
+    Wishart{T, typeof(P)}(T(d.df), P, T(d.c0))
+end
+function convert{T<:Real}(::Type{Wishart{T}}, df, S::AbstractPDMat, c0)
+    P = convert_eltype(T, S)
+    Wishart{T, typeof(P)}(T(df), P, T(c0))
+end
 
 #### Show
 

--- a/src/multivariate/mvlognormal.jl
+++ b/src/multivariate/mvlognormal.jl
@@ -107,13 +107,13 @@ params{D<:AbstractMvLogNormal}(::Type{D},m::AbstractVector,S::AbstractMatrix) = 
 #   Multivariate lognormal distribution based on MvNormal
 #
 #########################################################
-immutable MvLogNormal <: AbstractMvLogNormal
-    normal::MvNormal
+immutable MvLogNormal{T<:Real,Cov<:AbstractPDMat,Mean<:Union{Vector, ZeroVector}} <: AbstractMvLogNormal
+    normal::MvNormal{T,Cov,Mean}
 end
 
 #Constructors mirror the ones for MvNormmal
 MvLogNormal(μ::Union{Vector,ZeroVector},Σ::AbstractPDMat) = MvLogNormal(MvNormal(μ,Σ))
-MvLogNormal(Σ::AbstractPDMat) = MvLogNormal(MvNormal(ZeroVector(Float64,dim(Σ)),Σ))
+MvLogNormal(Σ::AbstractPDMat) = MvLogNormal(MvNormal(ZeroVector(eltype(Σ),dim(Σ)),Σ))
 MvLogNormal(μ::Vector,Σ::Matrix) = MvLogNormal(MvNormal(μ,Σ))
 MvLogNormal(μ::Vector,σ::Vector) = MvLogNormal(MvNormal(μ,σ))
 MvLogNormal(μ::Vector,s::Real) = MvLogNormal(MvNormal(μ,s))
@@ -121,8 +121,17 @@ MvLogNormal(Σ::Matrix) = MvLogNormal(MvNormal(Σ))
 MvLogNormal(σ::Vector) = MvLogNormal(MvNormal(σ))
 MvLogNormal(d::Int,s::Real) = MvLogNormal(MvNormal(d,s))
 
+### Conversion
+function convert{T<:Real}(::Type{MvLogNormal{T}}, d::MvLogNormal)
+    MvLogNormal(convert(MvNormal{T}, d.normal))
+end
+function convert{T<:Real}(::Type{MvLogNormal{T}}, pars...)
+    MvLogNormal(convert(MvNormal{T}, MvNormal(pars...)))
+end
+
 length(d::MvLogNormal) = length(d.normal)
 params(d::MvLogNormal) = params(d.normal)
+@inline partype{T<:Real}(d::MvLogNormal{T}) = T
 location(d::MvLogNormal) = mean(d.normal)
 scale(d::MvLogNormal) = cov(d.normal)
 

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -101,6 +101,14 @@ MvNormal{T<:Real}(Σ::Matrix{T}) = MvNormal(PDMat(Σ))
 MvNormal{T<:Real}(σ::Vector{T}) = MvNormal(PDiagMat(abs2(σ)))
 MvNormal(d::Int, σ::Real) = MvNormal(ScalMat(d, abs2(σ)))
 
+### Conversion
+function convert{T<:Real}(::Type{MvNormal{T}}, d::MvNormal)
+    MvNormal(convert_eltype(T, d.μ), convert_eltype(T, d.Σ))
+end
+function convert{T<:Real}(::Type{MvNormal{T}}, μ::Union{Vector, ZeroVector}, Σ::AbstractPDMat)
+    MvNormal(convert_eltype(T, μ), convert_eltype(T, Σ))
+end
+
 ### Show
 
 distrname(d::IsoNormal) = "IsoNormal"    # Note: IsoNormal, etc are just alias names
@@ -117,7 +125,7 @@ Base.show(io::IO, d::MvNormal) =
 ### Basic statistics
 
 length(d::MvNormal) = length(d.μ)
-mean(d::MvNormal) = convert(Vector{Float64}, d.μ)
+mean(d::MvNormal) = full(d.μ)
 params(d::MvNormal) = (d.μ, d.Σ)
 @inline partype{T<:Real}(d::MvNormal{T}) = T
 

--- a/src/multivariate/mvnormalcanon.jl
+++ b/src/multivariate/mvnormalcanon.jl
@@ -64,6 +64,14 @@ distrname(d::ZeroMeanIsoNormalCanon) = "ZeroMeanIsoNormalCanon"
 distrname(d::ZeroMeanDiagNormalCanon) = "ZeroMeanDiagormalCanon"
 distrname(d::ZeroMeanFullNormalCanon) = "ZeroMeanFullNormalCanon"
 
+### Conversion
+function convert{T<:Real}(::Type{MvNormalCanon{T}}, d::MvNormalCanon)
+    MvNormalCanon(convert_eltype(T, d.μ), convert_eltype(T, d.h), convert_eltype(T, d.J))
+end
+function convert{T<:Real,V<:Union{Vector, ZeroVector}}(::Type{MvNormalCanon{T}}, μ::V, h::V, J::AbstractPDMat)
+    MvNormalCanon(convert_eltype(T, μ), convert_eltype(T, h), convert_eltype(T, J))
+end
+
 ### conversion between conventional form and canonical form
 
 meanform(d::MvNormalCanon) = MvNormal(d.μ, inv(d.J))

--- a/src/multivariate/mvtdist.jl
+++ b/src/multivariate/mvtdist.jl
@@ -11,7 +11,7 @@ immutable GenericMvTDist{T<:Real, Cov<:AbstractPDMat} <: AbstractMvTDist
     μ::Vector{T}
     Σ::Cov
 
-    function GenericMvTDist{T}(df::T, dim::Int, zmean::Bool, μ::Vector{T}, Σ::AbstractPDMat{T})
+    function GenericMvTDist(df::T, dim::Int, zmean::Bool, μ::Vector{T}, Σ::AbstractPDMat{T})
       df > zero(df) || error("df must be positive")
       new(df, dim, zmean, μ, Σ)
     end
@@ -33,6 +33,16 @@ end
 GenericMvTDist{Cov<:AbstractPDMat, S<:Real}(df::Real, μ::Vector{S}, Σ::Cov) = GenericMvTDist(df, μ, Σ, allzeros(μ))
 
 GenericMvTDist{Cov<:AbstractPDMat, T<:Real}(df::T, Σ::Cov) = GenericMvTDist(df, zeros(dim(Σ)), Σ, true)
+
+### Conversion
+function convert{T<:Real}(::Type{GenericMvTDist{T}}, d::GenericMvTDist)
+    S = convert_eltype(T, d.Σ)
+    GenericMvTDist{T, typeof(S)}(T(d.df), d.dim, d.zeromean, convert_eltype(T, d.μ), S)
+end
+function convert{T<:Real}(::Type{GenericMvTDist{T}}, df, dim, zeromean, μ::Union{Vector, ZeroVector}, Σ::AbstractPDMat)
+    S = convert_eltype(T, Σ)
+    GenericMvTDist{T, typeof(S)}(T(df), dim, zeromean, convert_eltype(T, μ), S)
+end
 
 ## Construction of multivariate normal with specific covariance type
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -22,6 +22,7 @@ length(v::ZeroVector) = v.len
 full{T}(v::ZeroVector{T}) = zeros(T, v.len)
 
 convert{T}(::Type{Vector{T}}, v::ZeroVector{T}) = full(v)
+convert{T}(::Type{ZeroVector{T}}, v::ZeroVector) = ZeroVector{T}(length(v))
 
 +(x::AbstractArray, v::ZeroVector) = x
 -(x::AbstractArray, v::ZeroVector) = x
@@ -156,8 +157,9 @@ end
 promote_eltype{T, S}(A::ZeroVector{T}, B::AbstractPDMat{S}) = (ZeroVector{S}(A.len), B)
 
 # utility function to change element type of container
-function convert_eltype{T}(::Type{T}, A::Union{AbstractArray, AbstractPDMat})
+convert_eltype{T}(::Type{T}, A::AbstractArray) = convert(AbstractArray{T}, A)
+function convert_eltype{T}(::Type{T}, A::AbstractPDMat)
     R = typeof(A).name.primary
     convert(R{T}, A)
 end
-convert_eltype{T,S}(::Type{T}, Z::ZeroVector{S}) = ZeroVector{T}(length(Z))
+convert_eltype{T}(::Type{T}, Z::ZeroVector) = convert(ZeroVector{T}, Z)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -154,3 +154,10 @@ function promote_eltype{S}(A::Real, B::AbstractPDMat{S})
     (R(A), convert(typeof(B).name.primary{R}, B))
 end
 promote_eltype{T, S}(A::ZeroVector{T}, B::AbstractPDMat{S}) = (ZeroVector{S}(A.len), B)
+
+# utility function to change element type of container
+function convert_eltype{T}(::Type{T}, A::Union{AbstractArray, AbstractPDMat})
+    R = typeof(A).name.primary
+    convert(R{T}, A)
+end
+convert_eltype{T,S}(::Type{T}, Z::ZeroVector{S}) = ZeroVector{T}(length(Z))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -157,9 +157,9 @@ end
 promote_eltype{T, S}(A::ZeroVector{T}, B::AbstractPDMat{S}) = (ZeroVector{S}(A.len), B)
 
 # utility function to change element type of container
-convert_eltype{T}(::Type{T}, A::AbstractArray) = convert(AbstractArray{T}, A)
-function convert_eltype{T}(::Type{T}, A::AbstractPDMat)
+@inline convert_eltype{T}(::Type{T}, A::AbstractArray) = convert(AbstractArray{T}, A)
+@inline function convert_eltype{T}(::Type{T}, A::AbstractPDMat)
     R = typeof(A).name.primary
     convert(R{T}, A)
 end
-convert_eltype{T}(::Type{T}, Z::ZeroVector) = convert(ZeroVector{T}, Z)
+@inline convert_eltype{T}(::Type{T}, Z::ZeroVector) = convert(ZeroVector{T}, Z)

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -12,10 +12,16 @@ for d in [W,IW]
     @test size(d) == size(rand(d))
     @test length(d) == length(rand(d))
     @test typeof(d)(params(d)...) == d
+
+    ### conversions
+    D = typeof(d).name.primary
+    @test typeof(convert(D{Float32}, d)) == typeof(D(Float32(v), Array{Float32}(S)))
+
+    @test typeof(convert(D{Float32}, params(d)...)) == typeof(D(Float32(v), Array{Float32}(S)))
 end
 
-@test partype(Wishart(7, eye(Float32, 2))) == Float64
-@test partype(InverseWishart(7, eye(Float32, 2))) == Float64
+@test partype(Wishart(7, eye(Float32, 2))) == Float32
+@test partype(InverseWishart(7, eye(Float32, 2))) == Float32
 
 @test_approx_eq_eps mean(rand(W,100000)) mean(W) 0.1
 @test_approx_eq_eps mean(rand(IW,100000)) mean(IW) 0.1

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -12,6 +12,7 @@ for d in [W,IW]
     @test size(d) == size(rand(d))
     @test length(d) == length(rand(d))
     @test typeof(d)(params(d)...) == d
+    @test partype(d) == Float64
 
     ### conversions
     D = typeof(d).name.primary

--- a/test/multinomial.jl
+++ b/test/multinomial.jl
@@ -17,6 +17,14 @@ d = Multinomial(nt, p)
 
 @test insupport(d, [1, 6, 3])
 @test !insupport(d, [2, 6, 3])
+@test partype(d) == Float64
+@test partype(Multinomial(nt, Vector{Float32}(p))) == Float32
+
+# Conversion
+@test typeof(d) == Multinomial{Float64}
+@test typeof(Multinomial(nt, Vector{Float32}(p))) == Multinomial{Float32}
+@test typeof(convert(Multinomial{Float32}, d)) == Multinomial{Float32}
+@test typeof(convert(Multinomial{Float32}, params(d)...)) == Multinomial{Float32}
 
 # random sampling
 
@@ -52,6 +60,9 @@ for i in 1 : size(x, 2)
 	@test_approx_eq pv[i] pdf(d, x[:,i])
 	@test_approx_eq lp[i] logpdf(d, x[:,i])
 end
+
+# test type stability of logpdf
+@test typeof(logpdf(convert(Multinomial{Float32}, d), x1)) == Float32
 
 # suffstats
 

--- a/test/mvlognormal.jl
+++ b/test/mvlognormal.jl
@@ -14,6 +14,7 @@ function test_mvlognormal(g::MvLogNormal, n_tsamples::Int=10^6)
     S = cov(g)
     s = var(g)
     e = entropy(g)
+    @test partype(g) == Float64
     @test isa(mn, Vector{Float64})
     @test isa(md, Vector{Float64})
     @test isa(mo, Vector{Float64})

--- a/test/mvlognormal.jl
+++ b/test/mvlognormal.jl
@@ -29,7 +29,7 @@ function test_mvlognormal(g::MvLogNormal, n_tsamples::Int=10^6)
     @test_approx_eq mn exp(mean(g.normal) + var(g.normal)/2)
     @test_approx_eq mo exp(mean(g.normal) - var(g.normal))
     @test_approx_eq entropy(g) d*(1 + Distributions.log2π)/2 + logdetcov(g.normal)/2 + sum(mean(g.normal))
-    gg = typeof(g)(params(g)...)
+    gg = typeof(g)(MvNormal(params(g)...))
     @test full(g.normal.μ) == full(gg.normal.μ)
     @test full(g.normal.Σ) == full(gg.normal.Σ)
     @test insupport(g,ones(d))
@@ -118,3 +118,8 @@ for (g, μ, Σ) in [
     @test_approx_eq full(m) μ
     test_mvlognormal(g, 10^4)
 end
+
+##### Constructors and conversions
+d = MvLogNormal(Array{Float32}(mu), PDMats.PDMat(Array{Float32}(C)))
+@test typeof(convert(MvLogNormal{Float64}, d)) == typeof(MvLogNormal(mu, PDMats.PDMat(C)))
+@test typeof(convert(MvLogNormal{Float64}, d.normal.μ, d.normal.Σ)) == typeof(MvLogNormal(mu, PDMats.PDMat(C)))

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -115,6 +115,15 @@ h = J \ mu
 @test typeof(MvNormalCanon(h, 2.0f0)) == typeof(MvNormalCanon(h, 2.0))
 
 @test typeof(MvNormalCanon(mu, Array{Float16}(h), PDMat(Array{Float32}(J)))) == typeof(MvNormalCanon(mu, h, PDMat(J)))
+
+d = MvNormal(Array{Float32}(mu), PDMat(Array{Float32}(C)))
+@test typeof(convert(MvNormal{Float64}, d)) == typeof(MvNormal(mu, PDMat(C)))
+@test typeof(convert(MvNormal{Float64}, d.μ, d.Σ)) == typeof(MvNormal(mu, PDMat(C)))
+
+d = MvNormalCanon(Array{Float32}(mu), Array{Float32}(h), PDMat(Array{Float32}(J)))
+@test typeof(convert(MvNormalCanon{Float64}, d)) == typeof(MvNormalCanon(mu, h, PDMat(J)))
+@test typeof(convert(MvNormalCanon{Float64}, d.μ, d.h, d.J)) == typeof(MvNormalCanon(mu, h, PDMat(J)))
+
 ##### MLE
 
 # a slow but safe way to implement MLE for verification

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -13,6 +13,7 @@ function test_mvnormal(g::AbstractMvNormal, n_tsamples::Int=10^6)
     d = length(g)
     μ = mean(g)
     Σ = cov(g)
+    @test partype(g) == Float64
     @test isa(μ, Vector{Float64})
     @test isa(Σ, Matrix{Float64})
     @test length(μ) == d

--- a/test/mvtdist.jl
+++ b/test/mvtdist.jl
@@ -39,3 +39,4 @@ end
 d = GenericMvTDist(1, Array{Float32}(mu), PDMat(Array{Float32}(Sigma)))
 @test typeof(convert(GenericMvTDist{Float64}, d)) == typeof(GenericMvTDist(1, mu, PDMat(Sigma)))
 @test typeof(convert(GenericMvTDist{Float64}, d.df, d.dim, d.zeromean, d.μ, d.Σ)) == typeof(GenericMvTDist(1, mu, PDMat(Sigma)))
+@test partype(d) == Float32

--- a/test/mvtdist.jl
+++ b/test/mvtdist.jl
@@ -35,3 +35,7 @@ end
 @test typeof(GenericMvTDist(1, Vector{Float32}(mu), PDMat(Sigma))) == typeof(GenericMvTDist(1., mu, PDMat(Sigma)))
 
 @test typeof(GenericMvTDist(1, mu, PDMat(Array{Float32}(Sigma)))) == typeof(GenericMvTDist(1., mu, PDMat(Sigma)))
+
+d = GenericMvTDist(1, Array{Float32}(mu), PDMat(Array{Float32}(Sigma)))
+@test typeof(convert(GenericMvTDist{Float64}, d)) == typeof(GenericMvTDist(1, mu, PDMat(Sigma)))
+@test typeof(convert(GenericMvTDist{Float64}, d.df, d.dim, d.zeromean, d.μ, d.Σ)) == typeof(GenericMvTDist(1, mu, PDMat(Sigma)))

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -30,3 +30,6 @@ AA, DD = Distributions.promote_eltype(A, D)
 ZZ, DD = Distributions.promote_eltype(Z, D)
 @test ZZ == Distributions.ZeroVector{Float32}(5)
 @test DD.mat == convert(PDMats.PDMat{Float32}, D).mat
+@test Distributions.convert_eltype(Float32, A) == convert(Array{Float32}, A)
+@test Distributions.convert_eltype(Float32, Z) == Distributions.ZeroVector{Float32}(length(Z))
+@test Distributions.convert_eltype(Float64, D).mat == convert(PDMats.PDMat{Float64}, D).mat

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -33,3 +33,4 @@ ZZ, DD = Distributions.promote_eltype(Z, D)
 @test Distributions.convert_eltype(Float32, A) == convert(Array{Float32}, A)
 @test Distributions.convert_eltype(Float32, Z) == Distributions.ZeroVector{Float32}(length(Z))
 @test Distributions.convert_eltype(Float64, D).mat == convert(PDMats.PDMat{Float64}, D).mat
+@test typeof(convert(Distributions.ZeroVector{Float32}, Z)) == Distributions.ZeroVector{Float32}

--- a/test/vonmisesfisher.jl
+++ b/test/vonmisesfisher.jl
@@ -24,7 +24,12 @@ function test_vonmisesfisher(p::Int, κ::Float64, n::Int, ns::Int)
     @test meandir(d) == μ
     @test concentration(d) == κ
     @test d == typeof(d)(params(d)...)
+    @test partype(d) == Float64
     # println(d)
+
+    # conversions
+    @test typeof(convert(VonMisesFisher{Float32}, d)) == VonMisesFisher{Float32}
+    @test typeof(convert(VonMisesFisher{Float32}, d.μ, d.κ, d.logCκ)) == VonMisesFisher{Float32}
 
     θ = κ * μ
     d2 = VonMisesFisher(θ)


### PR DESCRIPTION
This PR encompasses two sets of changes:
- fleshing out conversions (with tests) for multivariate and matrix-variate distributions that had already been parameterized
- adding the last unparameterized multivariates:
  - `MvLogNormal`
  - `Multinomial`
  - `VonMisesFisher`

On the roadmap to fully parametric, there remains:

1. Fixing remaining hardcoded `Float64`s. In particular:
  - aliases like `ZeroMeanIsoNormal` in the multivariates
  - code for computing MLEs, where type stability is trickier to think through
1. Truncated distributions
1. Mixtures (though I was under the impression that these were moving out; should this be a priority?)