### PR TITLE
Fix Skellam cdf ambiguity warning

### DIFF
--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -140,12 +140,16 @@ gradlogpdf(d::MvNormal, x::Vector) = -(d.Σ \ (x - d.μ))
 _rand!(d::MvNormal, x::VecOrMat) = add!(unwhiten!(d.Σ, randn!(x)), d.μ)
 
 # Workaround: randn! only works for Array, but not generally for AbstractArray
-function _rand!(d::MvNormal, x::AbstractVecOrMat)
+function _rand_abstr!(d::MvNormal, x::AbstractVecOrMat)
     for i = 1:length(x)
         @inbounds x[i] = randn()
     end
     add!(unwhiten!(d.Σ, x), d.μ)
 end
+# define these separately to avoid ambiguity with
+# _rand(d::Multivariate, x::AbstractMatrix)
+_rand!(d::MvNormal, x::AbstractMatrix) = _rand_abstr!(d, x)
+_rand!(d::MvNormal, x::AbstractVector) = _rand_abstr!(d, x)
 
 ###########################################################
 #

--- a/src/univariate/discrete/skellam.jl
+++ b/src/univariate/discrete/skellam.jl
@@ -78,6 +78,7 @@ function cf(d::Skellam, t::Real)
     exp(μ1 * (cis(t) - 1) + μ2 * (cis(-t) - 1))
 end
 
+cdf(d::Skellam, x::Int) = throw(MethodError(cdf, (d, x)))
 cdf(d::Skellam, x::Real) = throw(MethodError(cdf, (d, x)))
 
 #### Sampling

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -24,6 +24,10 @@ function test_mvnormal(g::AbstractMvNormal, n_tsamples::Int=10^6)
     vs = diag(Σ)
     @test g == typeof(g)(params(g)...)
 
+    # test sampling for AbstractMatrix (here, a SubArray):
+    subX = view(rand(d, 2d), :, 1:d)
+    @test isa(rand!(g, subX), SubArray)
+
     # sampling
     X = rand(g, n_tsamples)
     emp_mu = vec(mean(X, 2))

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -3,6 +3,7 @@
 import PDMats: ScalMat, PDiagMat, PDMat
 
 using Distributions
+import Compat.view
 using Base.Test
 import Distributions: distrname
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,4 +49,8 @@ end
 # to test and rethrow
 if VERSION < v"0.5.0-"
     map(x -> isa(x, Exception) ? throw(x) : nothing, res)
+else
+    # test that there are no method ambiguities
+    println("Potentially stale exports: ")
+    Base.Test.@test length(Base.Test.detect_ambiguities(Distributions)) == 0
 end

--- a/test/univariates.jl
+++ b/test/univariates.jl
@@ -117,6 +117,8 @@ function verify_and_test(d::UnivariateDistribution, dct::Dict, n_tsamples::Int)
         Base.Test.test_approx_eq(logpdf(d, x), lp, "logpdf(d, $x)", "lp")
         if !isa(d, Skellam)
             Base.Test.test_approx_eq(cdf(d, x), cf, "cdf(d, $x)", "cf")
+        else
+            @test_throws MethodError cdf(d, x)
         end
     end
 


### PR DESCRIPTION
Adding cdf(d::Skellam, x::Int)
- avoids ambiguity warning in v0.4