### PR TITLE
Various cleanup

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -190,12 +190,6 @@ export
     logpdf!,            # evaluate log pdf to provided storage
     logpmf,             # log probability mass
     logpmf!,            # evaluate log pmf to provided storage
-    posterior,          # get posterior distribution given prior and observed data
-    posterior_canon,    # get the canonical form of the posterior distribution
-    posterior_mode,     # get the mode of posterior distribution
-    posterior_rand,     # draw samples from the posterior distribution
-    posterior_rand!,
-    posterior_randmodel,
 
     invscale,           # Inverse scale parameter
     sqmahal,            # squared Mahalanobis distance to Gaussian center

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -151,13 +151,8 @@ export
     cdf,                # cumulative distribution function
     cf,                 # characteristic function
     cgf,                # cumulant generating function
-    circmean,           # mean of circular distribution
-    circmedian,         # median of circular distribution
-    circmode,           # mode of circular distribution
-    circvar,            # variance of circular distribution
     cquantile,          # complementary quantile (i.e. using prob in right hand tail)
     cumulant,           # cumulants of distribution
-    complete,           # turn an incomplete formulation into a complete distribution
     component,          # get the k-th component of a mixture model
     components,         # get components from a mixture model
     componentwise_pdf,      # component-wise pdf for mixture models
@@ -171,8 +166,8 @@ export
     fit_mle,            # fit a distribution to data using MLE
     fit_mle!,           # fit a distribution to data using MLE (inplace update to initial guess)
     fit_map,            # fit a distribution to data using MAP
+    fit_map!,           # fit a distribution to data using MAP (inplace update to initial guess)
     freecumulant,       # free cumulants of distribution
-    gmvnormal,          # a generic function to construct multivariate normal distributions
     insupport,          # predicate, is x in the support of the distribution?
     invcov,             # get the inversed covariance
     invlogccdf,         # complementary quantile based on log probability

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -1,7 +1,7 @@
 # uniform interface for model estimation
 
-export Estimator, MLEstimator, MAPEstimator
-export nsamples, estimate, prior_score
+export Estimator, MLEstimator
+export nsamples, estimate
 
 abstract Estimator{D<:Distribution}
 
@@ -13,13 +13,3 @@ MLEstimator{D<:Distribution}(::Type{D}) = MLEstimator{D}()
 
 estimate{D<:Distribution}(e::MLEstimator{D}, x) = fit_mle(D, x)
 estimate{D<:Distribution}(e::MLEstimator{D}, x, w) = fit_mle(D, x, w)
-
-prior_score{D<:Distribution}(e::MLEstimator{D}, d::D) = 0.
-
-immutable MAPEstimator{D<:Distribution,Pri} <: Estimator{D} 
-	pri::Pri
-end
-MAPEstimator{D<:Distribution,Pri}(::Type{D}, pri::Pri) = MAPEstimator{D,Pri}(pri)
-
-estimate{D<:Distribution,Pri}(e::MAPEstimator{D,Pri}, x) = fit_map(e.pri, D, x)
-estimate{D<:Distribution,Pri}(e::MAPEstimator{D,Pri}, x, w) = fit_map(e.pri, D, x, w) 

--- a/src/univariate/continuous/vonmises.jl
+++ b/src/univariate/continuous/vonmises.jl
@@ -53,7 +53,9 @@ params(d::VonMises) = (d.μ, d.κ)
 mean(d::VonMises) = d.μ
 median(d::VonMises) = d.μ
 mode(d::VonMises) = d.μ
-circvar(d::VonMises) = 1 - besseli(1, d.κ) / d.I0κ
+var(d::VonMises) = 1 - besseli(1, d.κ) / d.I0κ
+# deprecated 12 September 2016
+@deprecate circvar(d) var(d)
 entropy(d::VonMises) = log(twoπ * d.I0κ) - d.κ * (besseli(1, d.κ) / d.I0κ)
 
 cf(d::VonMises, t::Real) = (besseli(abs(t), d.κ) / d.I0κ) * cis(t * d.μ)


### PR DESCRIPTION
Things that we have forgotten to remove at various refactorizations. It could be argued that we should keep the `posterior` definitions but they don't seem to be used much right now and I think they would fit better in something like `BayesianBase`.

Notice: This PR includes the bug fix for `Laplace`. I'll refactor once that PR has been merged.
