### PR TITLE
Ensure test dependencies are precompiled before distributing tests

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,5 @@
 JSON 0.4.0
 ForwardDiff
+Compat
+Calculus
+PDMats

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,7 @@
+using Distributions
+using JSON, ForwardDiff, Calculus, PDMats, Compat # test dependencies
+using Base.Test
+
 tests = [
     "types",
     "utils",
@@ -24,7 +28,7 @@ tests = [
     "gradlogpdf",
     "truncate",
     "truncatednormal",
-	"generalizedextremevalue"]
+    "generalizedextremevalue"]
 
 print_with_color(:blue, "Running tests:\n")
 
@@ -38,7 +42,9 @@ else
     addprocs(Sys.CPU_CORES, exeflags = "--check-bounds=yes")
 end
 
-using Distributions
+@everywhere using Distributions
+@everywhere using JSON, ForwardDiff, Calculus, PDMats, Compat # test dependencies
+@everywhere using Base.Test
 @everywhere srand(345679)
 res = pmap(tests) do t
     include(t*".jl")


### PR DESCRIPTION
I've moved all `using` statements to runtests.jl and I've declared all test dependencies in test/REQUIRE. The hope is that this will fix #538 by ensuring that all modules used by tests are precompiled prior to running the tests in parallel.