### PR TITLE
Define support for mixture models

### DIFF
--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -72,6 +72,9 @@ probs(d::MixtureModel) = probs(d.prior)
 params(d::MixtureModel) = ([params(c) for c in d.components], params(d.prior)[1])
 partype(d::MixtureModel) = promote_type(partype(d.prior), map(partype, d.components)...)
 
+minimum(d::MixtureModel) = minimum([minimum(dci) for dci in d.components])
+maximum(d::MixtureModel) = maximum([maximum(dci) for dci in d.components])
+
 function mean(d::UnivariateMixture)
     K = ncomponents(d)
     p = probs(d)

--- a/src/mixtures/unigmm.jl
+++ b/src/mixtures/unigmm.jl
@@ -15,6 +15,8 @@ immutable UnivariateGMM <: UnivariateMixture{Continuous,Normal}
     end
 end
 
+@distr_support UnivariateGMM -Inf Inf
+
 ncomponents(d::UnivariateGMM) = d.K
 
 component(d::UnivariateGMM, k::Int) = Normal(d.means[k], d.stds[k])

--- a/test/mixture.jl
+++ b/test/mixture.jl
@@ -144,12 +144,20 @@ g_u = MixtureModel(Normal, [(0.0, 1.0), (2.0, 1.0), (-4.0, 1.5)], [0.2, 0.5, 0.3
 @test ncomponents(g_u) == 3
 test_mixture(g_u, 1000, 10^6)
 test_params(g_u)
+@test minimum(g_u) == -Inf
+@test maximum(g_u) == Inf
+
+g_u = MixtureModel([TriangularDist(-1,2,0),TriangularDist(-.5,3,1),TriangularDist(-2,0,-1)])
+@test minimum(g_u) == -2.0
+@test maximum(g_u) == 3.0
 
 g_u = UnivariateGMM([0.0, 2.0, -4.0], [1.0, 1.2, 1.5], Categorical([0.2, 0.5, 0.3]))
 @test isa(g_u, UnivariateGMM)
 @test ncomponents(g_u) == 3
 test_mixture(g_u, 1000, 10^6)
 test_params(g_u)
+@test minimum(g_u) == -Inf
+@test maximum(g_u) == Inf
 
 println("    testing MultivariateMixture")
 g_m = MixtureModel(


### PR DESCRIPTION
Defines support for `UnivariateGMM` using `@distr_support`, and implements `minimum(::MixtureModel)` and `maximum(::MixtureModel)`, since those depend on the individual components. This also adds relevant tests.