### PR TITLE
qqbuild to return observed values

### DIFF
--- a/src/qq.jl
+++ b/src/qq.jl
@@ -12,17 +12,8 @@ function qqbuild(x::Vector, y::Vector)
 end
 
 function qqbuild(x::Vector, d::UnivariateDistribution)
-	n = length(x)
-	grid = [(1 / (n - 1)):(1 / (n - 1)):(1.0 - (1 / (n - 1)));]
-	qx = quantile(x, grid)
-	qd = quantile(d, grid)
-	return QQPair(qx, qd)
+	stp = inv(length(x))
+	return QQPair(quantile(d, stp/2 : step : one(step)), sort(x))
 end
 
-function qqbuild(d::UnivariateDistribution, x::Vector)
-	n = length(x)
-	grid = [(1 / (n - 1)):(1 / (n - 1)):(1.0 - (1 / (n - 1)));]
-	qd = quantile(d, grid)
-	qx = quantile(x, grid)
-	return QQPair(qd, qx)
-end
+qqbuild(d::UnivariateDistribution, x::Vector) = qqbuild(x, d)


### PR DESCRIPTION
The current implementation of `qqbuild` returns `(n - 1)` quantiles from the sample of size `n` as the `qy` member.  For an integer-valued discrete random variable the values in `qy` will be non-integers, which is peculiar.  This version corresponds, more-or-less, to the `ppoints` function used to generate QQ plots in R.

I suspect this will be faster than creating the (n - 1) quantiles from the observed values in the current version as this simply sorts the observed values.

Currently there are no tests for qqbuild in this package.  I can add a simple test if desired.  I'm not sure how to check for all the downstream uses of `qqbuild`.  Suggestions are welcome.