### PR TITLE
Fix most depwarn/error on 0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,6 +3,6 @@ PDMats 0.5.4
 StatsFuns 0.3.1
 Calculus
 StatsBase 0.8.3
-Compat 0.17.0
+Compat 0.18.0
 QuadGK 0.1.1
 SpecialFunctions 0.1.0

--- a/doc/source/mixture.rst
+++ b/doc/source/mixture.rst
@@ -26,8 +26,8 @@ This package introduces a type ``MixtureModel``, defined as follows, to represen
         prior::Categorical
     end
 
-    typealias UnivariateMixture    AbstractMixtureModel{Univariate} 
-    typealias MultivariateMixture  AbstractMixtureModel{Multivariate}
+    const UnivariateMixture    = AbstractMixtureModel{Univariate} 
+    const MultivariateMixture  = AbstractMixtureModel{Multivariate}
 
 **Remarks:**
 

--- a/doc/source/multivariate.rst
+++ b/doc/source/multivariate.rst
@@ -7,10 +7,10 @@ Multivariate Distributions
 
 .. code-block:: julia
 
-    typealias MultivariateDistribution{S<:ValueSupport} Distribution{Multivariate,S}
+    const MultivariateDistribution{S<:ValueSupport} = Distribution{Multivariate,S}
 
-    typealias DiscreteMultivariateDistribution   Distribution{Multivariate, Discrete}
-    typealias ContinuousMultivariateDistribution Distribution{Multivariate, Continuous}
+    const DiscreteMultivariateDistribution   = Distribution{Multivariate, Discrete}
+    const ContinuousMultivariateDistribution = Distribution{Multivariate, Continuous}
 
 
 Common Interface
@@ -155,13 +155,13 @@ We also define a set of alias for the types using different combinations of mean
 
 .. code-block:: julia
 
-    typealias IsoNormal  MvNormal{ScalMat,  Vector{Float64}}
-    typealias DiagNormal MvNormal{PDiagMat, Vector{Float64}}
-    typealias FullNormal MvNormal{PDMat,    Vector{Float64}}
+    const IsoNormal  = MvNormal{ScalMat,  Vector{Float64}}
+    const DiagNormal = MvNormal{PDiagMat, Vector{Float64}}
+    const FullNormal = MvNormal{PDMat,    Vector{Float64}}
 
-    typealias ZeroMeanIsoNormal  MvNormal{ScalMat,  ZeroVector{Float64}}
-    typealias ZeroMeanDiagNormal MvNormal{PDiagMat, ZeroVector{Float64}}
-    typealias ZeroMeanFullNormal MvNormal{PDMat,    ZeroVector{Float64}}
+    const ZeroMeanIsoNormal  = MvNormal{ScalMat,  ZeroVector{Float64}}
+    const ZeroMeanDiagNormal = MvNormal{PDiagMat, ZeroVector{Float64}}
+    const ZeroMeanFullNormal = MvNormal{PDMat,    ZeroVector{Float64}}
 
 
 Construction
@@ -247,13 +247,13 @@ We also define aliases for common specializations of this parametric type:
 
 .. code:: julia
 
-    typealias FullNormalCanon MvNormalCanon{PDMat,    Vector{Float64}}
-    typealias DiagNormalCanon MvNormalCanon{PDiagMat, Vector{Float64}}
-    typealias IsoNormalCanon  MvNormalCanon{ScalMat,  Vector{Float64}}
+    const FullNormalCanon = MvNormalCanon{PDMat,    Vector{Float64}}
+    const DiagNormalCanon = MvNormalCanon{PDiagMat, Vector{Float64}}
+    const IsoNormalCanon  = MvNormalCanon{ScalMat,  Vector{Float64}}
 
-    typealias ZeroMeanFullNormalCanon MvNormalCanon{PDMat,    ZeroVector{Float64}}
-    typealias ZeroMeanDiagNormalCanon MvNormalCanon{PDiagMat, ZeroVector{Float64}}
-    typealias ZeroMeanIsoNormalCanon  MvNormalCanon{ScalMat,  ZeroVector{Float64}}
+    const ZeroMeanFullNormalCanon = MvNormalCanon{PDMat,    ZeroVector{Float64}}
+    const ZeroMeanDiagNormalCanon = MvNormalCanon{PDiagMat, ZeroVector{Float64}}
+    const ZeroMeanIsoNormalCanon  = MvNormalCanon{ScalMat,  ZeroVector{Float64}}
 
 A multivariate distribution with canonical parameterization can be constructed using a common constructor ``MvNormalCanon`` as:
 

--- a/doc/source/types.rst
+++ b/doc/source/types.rst
@@ -103,20 +103,20 @@ To simplify the use in practice, we introduce a series of type alias as follows:
 
 .. code-block:: julia
 
-    typealias UnivariateDistribution{S<:ValueSupport}   Distribution{Univariate,S}
-    typealias MultivariateDistribution{S<:ValueSupport} Distribution{Multivariate,S}
-    typealias MatrixDistribution{S<:ValueSupport}       Distribution{Matrixvariate,S}
-    typealias NonMatrixDistribution Union{UnivariateDistribution, MultivariateDistribution}
+    const UnivariateDistribution{S<:ValueSupport}   = Distribution{Univariate,S}
+    const MultivariateDistribution{S<:ValueSupport} = Distribution{Multivariate,S}
+    const MatrixDistribution{S<:ValueSupport}       = Distribution{Matrixvariate,S}
+    const NonMatrixDistribution = Union{UnivariateDistribution, MultivariateDistribution}
 
-    typealias DiscreteDistribution{F<:VariateForm}   Distribution{F,Discrete}
-    typealias ContinuousDistribution{F<:VariateForm} Distribution{F,Continuous}
+    const DiscreteDistribution{F<:VariateForm}   = Distribution{F,Discrete}
+    const ContinuousDistribution{F<:VariateForm} = Distribution{F,Continuous}
 
-    typealias DiscreteUnivariateDistribution     Distribution{Univariate,    Discrete}
-    typealias ContinuousUnivariateDistribution   Distribution{Univariate,    Continuous}
-    typealias DiscreteMultivariateDistribution   Distribution{Multivariate,  Discrete}
-    typealias ContinuousMultivariateDistribution Distribution{Multivariate,  Continuous}
-    typealias DiscreteMatrixDistribution         Distribution{Matrixvariate, Discrete}
-    typealias ContinuousMatrixDistribution       Distribution{Matrixvariate, Continuous}
+    const DiscreteUnivariateDistribution     = Distribution{Univariate,    Discrete}
+    const ContinuousUnivariateDistribution   = Distribution{Univariate,    Continuous}
+    const DiscreteMultivariateDistribution   = Distribution{Multivariate,  Discrete}
+    const ContinuousMultivariateDistribution = Distribution{Multivariate,  Continuous}
+    const DiscreteMatrixDistribution         = Distribution{Matrixvariate, Discrete}
+    const ContinuousMatrixDistribution       = Distribution{Matrixvariate, Continuous}
 
 All methods applicable to `Sampleable` also applies to `Distribution`. The API for distributions of different variate forms are different (refer to :ref:`univariates`, :ref:`multivariates`, and :ref:`matrix` for details).
 

--- a/doc/source/univariate.rst
+++ b/doc/source/univariate.rst
@@ -14,10 +14,10 @@ Univariate Distributions
 
 .. code-block:: julia
 
-    typealias UnivariateDistribution{S<:ValueSupport} Distribution{Univariate,S}
+    const UnivariateDistribution{S<:ValueSupport} = Distribution{Univariate,S}
 
-    typealias DiscreteUnivariateDistribution   Distribution{Univariate, Discrete}
-    typealias ContinuousUnivariateDistribution Distribution{Univariate, Continuous}
+    const DiscreteUnivariateDistribution   = Distribution{Univariate, Discrete}
+    const ContinuousUnivariateDistribution = Distribution{Univariate, Continuous}
 
 
 Common Interface

--- a/src/common.jl
+++ b/src/common.jl
@@ -38,20 +38,20 @@ nsamples{D<:Sampleable{Matrixvariate},T<:Number}(::Type{D}, x::Array{Matrix{T}})
 
 @compat abstract type Distribution{F<:VariateForm,S<:ValueSupport} <: Sampleable{F,S} end
 
-typealias UnivariateDistribution{S<:ValueSupport}   Distribution{Univariate,S}
-typealias MultivariateDistribution{S<:ValueSupport} Distribution{Multivariate,S}
-typealias MatrixDistribution{S<:ValueSupport}       Distribution{Matrixvariate,S}
-typealias NonMatrixDistribution Union{UnivariateDistribution, MultivariateDistribution}
+@compat const UnivariateDistribution{S<:ValueSupport}   = Distribution{Univariate,S}
+@compat const MultivariateDistribution{S<:ValueSupport} = Distribution{Multivariate,S}
+@compat const MatrixDistribution{S<:ValueSupport}       = Distribution{Matrixvariate,S}
+const NonMatrixDistribution = Union{UnivariateDistribution, MultivariateDistribution}
 
-typealias DiscreteDistribution{F<:VariateForm}   Distribution{F,Discrete}
-typealias ContinuousDistribution{F<:VariateForm} Distribution{F,Continuous}
+@compat const DiscreteDistribution{F<:VariateForm}   = Distribution{F,Discrete}
+@compat const ContinuousDistribution{F<:VariateForm} = Distribution{F,Continuous}
 
-typealias DiscreteUnivariateDistribution     Distribution{Univariate,    Discrete}
-typealias ContinuousUnivariateDistribution   Distribution{Univariate,    Continuous}
-typealias DiscreteMultivariateDistribution   Distribution{Multivariate,  Discrete}
-typealias ContinuousMultivariateDistribution Distribution{Multivariate,  Continuous}
-typealias DiscreteMatrixDistribution         Distribution{Matrixvariate, Discrete}
-typealias ContinuousMatrixDistribution       Distribution{Matrixvariate, Continuous}
+const DiscreteUnivariateDistribution     = Distribution{Univariate,    Discrete}
+const ContinuousUnivariateDistribution   = Distribution{Univariate,    Continuous}
+const DiscreteMultivariateDistribution   = Distribution{Multivariate,  Discrete}
+const ContinuousMultivariateDistribution = Distribution{Multivariate,  Continuous}
+const DiscreteMatrixDistribution         = Distribution{Matrixvariate, Discrete}
+const ContinuousMatrixDistribution       = Distribution{Matrixvariate, Continuous}
 
 variate_form{VF<:VariateForm,VS<:ValueSupport}(::Type{Distribution{VF,VS}}) = VF
 variate_form{T<:Distribution}(::Type{T}) = variate_form(supertype(T))
@@ -63,5 +63,5 @@ value_support{T<:Distribution}(::Type{T}) = value_support(supertype(T))
 @compat abstract type SufficientStats end
 @compat abstract type IncompleteDistribution end
 
-typealias DistributionType{D<:Distribution} Type{D}
-typealias IncompleteFormulation Union{DistributionType,IncompleteDistribution}
+@compat const DistributionType{D<:Distribution} = Type{D}
+const IncompleteFormulation = Union{DistributionType,IncompleteDistribution}

--- a/src/edgeworth.jl
+++ b/src/edgeworth.jl
@@ -13,9 +13,9 @@ immutable EdgeworthZ{D<:UnivariateDistribution} <: EdgeworthAbstract
     dist::D
     n::Float64
 
-    function EdgeworthZ{T<:UnivariateDistribution}(d::T, n::Real)
+    function (::Type{EdgeworthZ{D}}){D<:UnivariateDistribution,T<:UnivariateDistribution}(d::T, n::Real)
         @check_args(EdgeworthZ, n > zero(n))
-        new(d, n)
+        new{D}(d, n)
     end
 end
 EdgeworthZ(d::UnivariateDistribution,n::Real) = EdgeworthZ{typeof(d)}(d,n)
@@ -77,9 +77,9 @@ end
 immutable EdgeworthSum{D<:UnivariateDistribution} <: EdgeworthAbstract
     dist::D
     n::Float64
-    function EdgeworthSum{T<:UnivariateDistribution}(d::T, n::Real)
+    function (::Type{EdgeworthSum{D}}){D<:UnivariateDistribution,T<:UnivariateDistribution}(d::T, n::Real)
         @check_args(EdgeworthSum, n > zero(n))
-        new(d, n)
+        new{D}(d, n)
     end
 end
 EdgeworthSum(d::UnivariateDistribution, n::Real) = EdgeworthSum{typeof(d)}(d,n)
@@ -91,11 +91,11 @@ var(d::EdgeworthSum) = d.n*var(d.dist)
 immutable EdgeworthMean{D<:UnivariateDistribution} <: EdgeworthAbstract
     dist::D
     n::Float64
-    function EdgeworthMean{T<:UnivariateDistribution}(d::T, n::Real)
+    function (::Type{EdgeworthMean{D}}){D<:UnivariateDistribution,T<:UnivariateDistribution}(d::T, n::Real)
         # although n would usually be an integer, no methods are require this
         n > zero(n) ||
             error("n must be positive")
-        new(d, Float64(n))
+        new{D}(d, Float64(n))
     end
 end
 EdgeworthMean(d::UnivariateDistribution,n::Real) = EdgeworthMean{typeof(d)}(d,n)

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -17,16 +17,16 @@ immutable MixtureModel{VF<:VariateForm,VS<:ValueSupport,C<:Distribution} <: Abst
     components::Vector{C}
     prior::Categorical
 
-    function MixtureModel(cs::Vector{C}, pri::Categorical)
+    function (::Type{MixtureModel{VF,VS,C}}){VF,VS,C}(cs::Vector{C}, pri::Categorical)
         length(cs) == ncategories(pri) ||
             error("The number of components does not match the length of prior.")
-        new(cs, pri)
+        new{VF,VS,C}(cs, pri)
     end
 end
 
-typealias UnivariateMixture{S<:ValueSupport,   C<:Distribution} AbstractMixtureModel{Univariate,S,C}
-typealias MultivariateMixture{S<:ValueSupport, C<:Distribution} AbstractMixtureModel{Multivariate,S,C}
-typealias MatrixvariateMixture{S<:ValueSupport,C<:Distribution} AbstractMixtureModel{Matrixvariate,S,C}
+@compat const UnivariateMixture{S<:ValueSupport,   C<:Distribution} = AbstractMixtureModel{Univariate,S,C}
+@compat const MultivariateMixture{S<:ValueSupport, C<:Distribution} = AbstractMixtureModel{Multivariate,S,C}
+@compat const MatrixvariateMixture{S<:ValueSupport,C<:Distribution} = AbstractMixtureModel{Matrixvariate,S,C}
 
 component_type{VF,VS,C}(d::AbstractMixtureModel{VF,VS,C}) = C
 

--- a/src/multivariate/dirichlet.jl
+++ b/src/multivariate/dirichlet.jl
@@ -3,7 +3,7 @@ immutable Dirichlet{T<:Real} <: ContinuousMultivariateDistribution
     alpha0::T
     lmnB::T
 
-    function Dirichlet(alpha::Vector{T})
+    function (::Type{Dirichlet{T}}){T}(alpha::Vector{T})
         alpha0::T = zero(T)
         lmnB::T = zero(T)
         for i in 1:length(alpha)
@@ -13,12 +13,12 @@ immutable Dirichlet{T<:Real} <: ContinuousMultivariateDistribution
             lmnB += lgamma(ai)
         end
         lmnB -= lgamma(alpha0)
-        new(alpha, alpha0, lmnB)
+        new{T}(alpha, alpha0, lmnB)
     end
 
-    function Dirichlet(d::Integer, alpha::T)
+    function (::Type{Dirichlet{T}}){T}(d::Integer, alpha::T)
         alpha0 = alpha * d
-        new(fill(alpha, d), alpha0, lgamma(alpha) * d - lgamma(alpha0))
+        new{T}(fill(alpha, d), alpha0, lgamma(alpha) * d - lgamma(alpha0))
     end
 end
 

--- a/src/multivariate/dirichletmultinomial.jl
+++ b/src/multivariate/dirichletmultinomial.jl
@@ -3,11 +3,11 @@ immutable DirichletMultinomial{T <: Real} <: DiscreteMultivariateDistribution
     α::Vector{T}
     α0::T
 
-    function DirichletMultinomial(n::Integer, α::Vector{T})
+    function (::Type{DirichletMultinomial{T}}){T}(n::Integer, α::Vector{T})
         α0 = sum(abs, α)
         sum(α) == α0 || throw(ArgumentError("alpha must be a positive vector."))
         n > 0 || throw(ArgumentError("n must be a positive integer."))
-        new(Int(n), α, α0)
+        new{T}(Int(n), α, α0)
     end
 end
 DirichletMultinomial{T <: Real}(n::Integer, α::Vector{T}) = DirichletMultinomial{T}(n, α)

--- a/src/multivariate/multinomial.jl
+++ b/src/multivariate/multinomial.jl
@@ -2,16 +2,16 @@ immutable Multinomial{T<:Real} <: DiscreteMultivariateDistribution
     n::Int
     p::Vector{T}
 
-    function Multinomial(n::Integer, p::Vector{T})
+    function (::Type{Multinomial{T}}){T}(n::Integer, p::Vector{T})
         if n < 0
             throw(ArgumentError("n must be a nonnegative integer."))
         end
         if !isprobvec(p)
             throw(ArgumentError("p = $p is not a probability vector."))
         end
-        new(round(Int, n), p)
+        new{T}(round(Int, n), p)
     end
-    Multinomial(n::Integer, p::Vector{T}, ::NoArgCheck) = new(round(Int, n), p)
+    (::Type{Multinomial{T}}){T}(n::Integer, p::Vector{T}, ::NoArgCheck) = new{T}(round(Int, n), p)
 end
 Multinomial{T<:Real}(n::Integer, p::Vector{T}) = Multinomial{T}(n, p)
 Multinomial(n::Integer, k::Integer) = Multinomial{Float64}(round(Int, n), fill(1.0 / k, k))

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -69,13 +69,13 @@ end
 
 const MultivariateNormal = MvNormal  # for the purpose of backward compatibility
 
-typealias IsoNormal  MvNormal{Float64,ScalMat{Float64},Vector{Float64}}
-typealias DiagNormal MvNormal{Float64,PDiagMat{Float64,Vector{Float64}},Vector{Float64}}
-typealias FullNormal MvNormal{Float64,PDMat{Float64,Matrix{Float64}},Vector{Float64}}
+const IsoNormal  = MvNormal{Float64,ScalMat{Float64},Vector{Float64}}
+const DiagNormal = MvNormal{Float64,PDiagMat{Float64,Vector{Float64}},Vector{Float64}}
+const FullNormal = MvNormal{Float64,PDMat{Float64,Matrix{Float64}},Vector{Float64}}
 
-typealias ZeroMeanIsoNormal  MvNormal{Float64,ScalMat{Float64},ZeroVector{Float64}}
-typealias ZeroMeanDiagNormal MvNormal{Float64,PDiagMat{Float64,Vector{Float64}},ZeroVector{Float64}}
-typealias ZeroMeanFullNormal MvNormal{Float64,PDMat{Float64,Matrix{Float64}},ZeroVector{Float64}}
+const ZeroMeanIsoNormal  = MvNormal{Float64,ScalMat{Float64},ZeroVector{Float64}}
+const ZeroMeanDiagNormal = MvNormal{Float64,PDiagMat{Float64,Vector{Float64}},ZeroVector{Float64}}
+const ZeroMeanFullNormal = MvNormal{Float64,PDMat{Float64,Matrix{Float64}},ZeroVector{Float64}}
 
 ### Construction
 function MvNormal{T<:Real}(μ::Union{Vector{T}, ZeroVector{T}}, Σ::AbstractPDMat{T})

--- a/src/multivariate/mvnormalcanon.jl
+++ b/src/multivariate/mvnormalcanon.jl
@@ -8,13 +8,13 @@ immutable MvNormalCanon{T<:Real,P<:AbstractPDMat,V<:Union{Vector,ZeroVector}} <:
     J::P    # precision matrix, i.e. inv(Σ)
 end
 
-typealias FullNormalCanon MvNormalCanon{Float64, PDMat{Float64,Matrix{Float64}},Vector{Float64}}
-typealias DiagNormalCanon MvNormalCanon{Float64,PDiagMat{Float64,Vector{Float64}},Vector{Float64}}
-typealias IsoNormalCanon  MvNormalCanon{Float64,ScalMat{Float64},Vector{Float64}}
+const FullNormalCanon = MvNormalCanon{Float64, PDMat{Float64,Matrix{Float64}},Vector{Float64}}
+const DiagNormalCanon = MvNormalCanon{Float64,PDiagMat{Float64,Vector{Float64}},Vector{Float64}}
+const IsoNormalCanon  = MvNormalCanon{Float64,ScalMat{Float64},Vector{Float64}}
 
-typealias ZeroMeanFullNormalCanon MvNormalCanon{Float64,PDMat{Float64,Matrix{Float64}},ZeroVector{Float64}}
-typealias ZeroMeanDiagNormalCanon MvNormalCanon{Float64,PDiagMat{Float64,Vector{Float64}},ZeroVector{Float64}}
-typealias ZeroMeanIsoNormalCanon  MvNormalCanon{Float64,ScalMat{Float64},ZeroVector{Float64}}
+const ZeroMeanFullNormalCanon = MvNormalCanon{Float64,PDMat{Float64,Matrix{Float64}},ZeroVector{Float64}}
+const ZeroMeanDiagNormalCanon = MvNormalCanon{Float64,PDiagMat{Float64,Vector{Float64}},ZeroVector{Float64}}
+const ZeroMeanIsoNormalCanon  = MvNormalCanon{Float64,ScalMat{Float64},ZeroVector{Float64}}
 
 
 ### Constructors

--- a/src/multivariate/mvtdist.jl
+++ b/src/multivariate/mvtdist.jl
@@ -11,9 +11,9 @@ immutable GenericMvTDist{T<:Real, Cov<:AbstractPDMat} <: AbstractMvTDist
     μ::Vector{T}
     Σ::Cov
 
-    function GenericMvTDist(df::T, dim::Int, zmean::Bool, μ::Vector{T}, Σ::AbstractPDMat{T})
+    function (::Type{GenericMvTDist{T,Cov}}){T,Cov}(df::T, dim::Int, zmean::Bool, μ::Vector{T}, Σ::AbstractPDMat{T})
       df > zero(df) || error("df must be positive")
-      new(df, dim, zmean, μ, Σ)
+      new{T,Cov}(df, dim, zmean, μ, Σ)
     end
 end
 
@@ -46,9 +46,9 @@ end
 
 ## Construction of multivariate normal with specific covariance type
 
-typealias IsoTDist  GenericMvTDist{Float64, ScalMat{Float64}}
-typealias DiagTDist GenericMvTDist{Float64, PDiagMat{Float64,Vector{Float64}}}
-typealias MvTDist GenericMvTDist{Float64, PDMat{Float64,Matrix{Float64}}}
+const IsoTDist  = GenericMvTDist{Float64, ScalMat{Float64}}
+const DiagTDist = GenericMvTDist{Float64, PDiagMat{Float64,Vector{Float64}}}
+const MvTDist = GenericMvTDist{Float64, PDMat{Float64,Matrix{Float64}}}
 
 MvTDist(df::Real, μ::Vector{Float64}, C::PDMat) = GenericMvTDist(df, μ, C)
 MvTDist(df::Real, C::PDMat) = GenericMvTDist(df, C)

--- a/src/multivariate/vonmisesfisher.jl
+++ b/src/multivariate/vonmisesfisher.jl
@@ -17,14 +17,14 @@ immutable VonMisesFisher{T<:Real} <: ContinuousMultivariateDistribution
     κ::T
     logCκ::T
 
-    function VonMisesFisher(μ::Vector{T}, κ::T; checknorm::Bool=true)
+    function (::Type{VonMisesFisher{T}}){T}(μ::Vector{T}, κ::T; checknorm::Bool=true)
         if checknorm
             isunitvec(μ) || error("μ must be a unit vector")
         end
         κ > 0 || error("κ must be positive.")
         logCκ = vmflck(length(μ), κ)
         S = promote_type(T, typeof(logCκ))
-        new(Vector{S}(μ), S(κ), S(logCκ))
+        new{T}(Vector{S}(μ), S(κ), S(logCκ))
     end
 end
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -20,7 +20,7 @@ function show(io::IO, d::Distribution, pnames)
     uml ? show_multline(io, d, namevals) : show_oneline(io, d, namevals)
 end
 
-typealias _NameVal Tuple{Symbol,Any}
+const _NameVal = Tuple{Symbol,Any}
 
 function _use_multline_show(d::Distribution, pnames)
     # decide whether to use one-line or multi-line format

--- a/src/univariate/continuous/arcsine.jl
+++ b/src/univariate/continuous/arcsine.jl
@@ -27,7 +27,7 @@ immutable Arcsine{T<:Real} <: ContinuousUnivariateDistribution
     a::T
     b::T
 
-    Arcsine(a::T, b::T) = (@check_args(Arcsine, a < b); new(a, b))
+    (::Type{Arcsine{T}}){T}(a::T, b::T) = (@check_args(Arcsine, a < b); new{T}(a, b))
 end
 
 Arcsine{T<:Real}(a::T, b::T) = Arcsine{T}(a, b)

--- a/src/univariate/continuous/beta.jl
+++ b/src/univariate/continuous/beta.jl
@@ -29,9 +29,9 @@ immutable Beta{T<:Real} <: ContinuousUnivariateDistribution
     α::T
     β::T
 
-    function Beta(α::T, β::T)
+    function (::Type{Beta{T}}){T}(α::T, β::T)
         @check_args(Beta, α > zero(α) && β > zero(β))
-        new(α, β)
+        new{T}(α, β)
     end
 end
 

--- a/src/univariate/continuous/betaprime.jl
+++ b/src/univariate/continuous/betaprime.jl
@@ -29,9 +29,9 @@ immutable BetaPrime{T<:Real} <: ContinuousUnivariateDistribution
     α::T
     β::T
 
-    function BetaPrime(α::T, β::T)
+    function (::Type{BetaPrime{T}}){T}(α::T, β::T)
         @check_args(BetaPrime, α > zero(α) && β > zero(β))
-        new(α, β)
+        new{T}(α, β)
     end
 end
 

--- a/src/univariate/continuous/biweight.jl
+++ b/src/univariate/continuous/biweight.jl
@@ -2,7 +2,7 @@ immutable Biweight{T<:Real} <: ContinuousUnivariateDistribution
     μ::T
     σ::T
 
-    Biweight(μ::T, σ::T) = (@check_args(Biweight, σ > zero(σ)); new(μ, σ))
+    (::Type{Biweight{T}}){T}(μ::T, σ::T) = (@check_args(Biweight, σ > zero(σ)); new{T}(μ, σ))
 end
 
 Biweight{T<:Real}(μ::T, σ::T) = Biweight{T}(μ, σ)

--- a/src/univariate/continuous/cauchy.jl
+++ b/src/univariate/continuous/cauchy.jl
@@ -25,9 +25,9 @@ immutable Cauchy{T<:Real} <: ContinuousUnivariateDistribution
     μ::T
     σ::T
 
-    function Cauchy(μ::T, σ::T)
+    function (::Type{Cauchy{T}}){T}(μ::T, σ::T)
         @check_args(Cauchy, σ > zero(σ))
-        new(μ, σ)
+        new{T}(μ, σ)
     end
 end
 

--- a/src/univariate/continuous/chi.jl
+++ b/src/univariate/continuous/chi.jl
@@ -23,7 +23,7 @@ External links
 immutable Chi{T<:Real} <: ContinuousUnivariateDistribution
     ν::T
 
-    Chi(ν::T) = (@check_args(Chi, ν > zero(ν)); new(ν))
+    (::Type{Chi{T}}){T}(ν::T) = (@check_args(Chi, ν > zero(ν)); new{T}(ν))
 end
 
 Chi{T<:Real}(ν::T) = Chi{T}(ν)

--- a/src/univariate/continuous/chisq.jl
+++ b/src/univariate/continuous/chisq.jl
@@ -22,7 +22,7 @@ External links
 immutable Chisq{T<:Real} <: ContinuousUnivariateDistribution
     ν::T
 
-    Chisq(ν::T) = (@check_args(Chisq, ν > zero(ν)); new(ν))
+    (::Type{Chisq{T}}){T}(ν::T) = (@check_args(Chisq, ν > zero(ν)); new{T}(ν))
 end
 
 Chisq{T<:Real}(ν::T) = Chisq{T}(ν)

--- a/src/univariate/continuous/cosine.jl
+++ b/src/univariate/continuous/cosine.jl
@@ -7,7 +7,7 @@ immutable Cosine{T<:Real} <: ContinuousUnivariateDistribution
     μ::T
     σ::T
 
-    Cosine(μ::T, σ::T) = (@check_args(Cosine, σ > zero(σ)); new(μ, σ))
+    (::Type{Cosine{T}}){T}(μ::T, σ::T) = (@check_args(Cosine, σ > zero(σ)); new{T}(μ, σ))
 end
 
 Cosine{T<:Real}(μ::T, σ::T) = Cosine{T}(μ, σ)

--- a/src/univariate/continuous/epanechnikov.jl
+++ b/src/univariate/continuous/epanechnikov.jl
@@ -2,7 +2,7 @@ immutable Epanechnikov{T<:Real} <: ContinuousUnivariateDistribution
     μ::T
     σ::T
 
-    Epanechnikov(μ::T, σ::T) = (@check_args(Epanechnikov, σ > zero(σ)); new(μ, σ))
+    (::Type{Epanechnikov{T}}){T}(μ::T, σ::T) = (@check_args(Epanechnikov, σ > zero(σ)); new{T}(μ, σ))
 end
 
 Epanechnikov{T<:Real}(μ::T, σ::T) = Epanechnikov{T}(μ, σ)

--- a/src/univariate/continuous/erlang.jl
+++ b/src/univariate/continuous/erlang.jl
@@ -19,9 +19,9 @@ immutable Erlang{T<:Real} <: ContinuousUnivariateDistribution
     α::Int
     θ::T
 
-    function Erlang(α::Real, θ::T)
+    function (::Type{Erlang{T}}){T}(α::Real, θ::T)
         @check_args(Erlang, isinteger(α) && α >= zero(α))
-        new(α, θ)
+        new{T}(α, θ)
     end
 end
 

--- a/src/univariate/continuous/exponential.jl
+++ b/src/univariate/continuous/exponential.jl
@@ -22,7 +22,7 @@ External links
 immutable Exponential{T<:Real} <: ContinuousUnivariateDistribution
     θ::T		# note: scale not rate
 
-    Exponential(θ::Real) = (@check_args(Exponential, θ > zero(θ)); new(θ))
+    (::Type{Exponential{T}}){T}(θ::Real) = (@check_args(Exponential, θ > zero(θ)); new{T}(θ))
 end
 
 Exponential{T<:Real}(θ::T) = Exponential{T}(θ)

--- a/src/univariate/continuous/fdist.jl
+++ b/src/univariate/continuous/fdist.jl
@@ -26,9 +26,9 @@ immutable FDist{T<:Real} <: ContinuousUnivariateDistribution
     ν1::T
     ν2::T
 
-    function FDist(ν1::T, ν2::T)
+    function (::Type{FDist{T}}){T}(ν1::T, ν2::T)
         @check_args(FDist, ν1 > zero(ν1) && ν2 > zero(ν2))
-        new(ν1, ν2)
+        new{T}(ν1, ν2)
     end
 end
 

--- a/src/univariate/continuous/frechet.jl
+++ b/src/univariate/continuous/frechet.jl
@@ -25,9 +25,9 @@ immutable Frechet{T<:Real} <: ContinuousUnivariateDistribution
     α::T
     θ::T
 
-    function Frechet(α::T, θ::T)
-    	@check_args(Frechet, α > zero(α) && θ > zero(θ))
-    	new(α, θ)
+    function (::Type{Frechet{T}}){T}(α::T, θ::T)
+        @check_args(Frechet, α > zero(α) && θ > zero(θ))
+        new{T}(α, θ)
     end
 
 end

--- a/src/univariate/continuous/gamma.jl
+++ b/src/univariate/continuous/gamma.jl
@@ -26,9 +26,9 @@ immutable Gamma{T<:Real} <: ContinuousUnivariateDistribution
     α::T
     θ::T
 
-    function Gamma(α, θ)
+    function (::Type{Gamma{T}}){T}(α, θ)
         @check_args(Gamma, α > zero(α) && θ > zero(θ))
-        new(α, θ)
+        new{T}(α, θ)
     end
 end
 

--- a/src/univariate/continuous/generalizedextremevalue.jl
+++ b/src/univariate/continuous/generalizedextremevalue.jl
@@ -36,9 +36,9 @@ immutable GeneralizedExtremeValue{T<:Real} <: ContinuousUnivariateDistribution
     σ::T
     ξ::T
 
-    function GeneralizedExtremeValue(μ::T, σ::T, ξ::T)
+    function (::Type{GeneralizedExtremeValue{T}}){T}(μ::T, σ::T, ξ::T)
         σ > zero(σ) || error("Scale must be positive")
-        new(μ, σ, ξ)
+        new{T}(μ, σ, ξ)
     end
 end
 

--- a/src/univariate/continuous/generalizedpareto.jl
+++ b/src/univariate/continuous/generalizedpareto.jl
@@ -35,9 +35,9 @@ immutable GeneralizedPareto{T<:Real} <: ContinuousUnivariateDistribution
     σ::T
     ξ::T
 
-    function GeneralizedPareto(μ::T, σ::T, ξ::T)
+    function (::Type{GeneralizedPareto{T}}){T}(μ::T, σ::T, ξ::T)
         @check_args(GeneralizedPareto, σ > zero(σ))
-        new(μ, σ, ξ)
+        new{T}(μ, σ, ξ)
     end
 
 end

--- a/src/univariate/continuous/gumbel.jl
+++ b/src/univariate/continuous/gumbel.jl
@@ -24,7 +24,7 @@ immutable Gumbel{T<:Real} <: ContinuousUnivariateDistribution
     μ::T  # location
     θ::T  # scale
 
-    Gumbel(μ::T, θ::T) = (@check_args(Gumbel, θ > zero(θ)); new(μ, θ))
+    (::Type{Gumbel{T}}){T}(μ::T, θ::T) = (@check_args(Gumbel, θ > zero(θ)); new{T}(μ, θ))
 end
 
 Gumbel{T<:Real}(μ::T, θ::T) = Gumbel{T}(μ, θ)

--- a/src/univariate/continuous/inversegamma.jl
+++ b/src/univariate/continuous/inversegamma.jl
@@ -28,9 +28,9 @@ immutable InverseGamma{T<:Real} <: ContinuousUnivariateDistribution
     invd::Gamma{T}
     θ::T
 
-    function InverseGamma(α, θ)
+    function (::Type{InverseGamma{T}}){T}(α, θ)
         @check_args(InverseGamma, α > zero(α) && θ > zero(θ))
-        new(Gamma(α, 1 / θ), θ)
+        new{T}(Gamma(α, 1 / θ), θ)
     end
 end
 

--- a/src/univariate/continuous/inversegaussian.jl
+++ b/src/univariate/continuous/inversegaussian.jl
@@ -25,9 +25,9 @@ immutable InverseGaussian{T<:Real} <: ContinuousUnivariateDistribution
     μ::T
     λ::T
 
-    function InverseGaussian(μ::T, λ::T)
+    function (::Type{InverseGaussian{T}}){T}(μ::T, λ::T)
         @check_args(InverseGaussian, μ > zero(μ) && λ > zero(λ))
-        new(μ, λ)
+        new{T}(μ, λ)
     end
 end
 

--- a/src/univariate/continuous/laplace.jl
+++ b/src/univariate/continuous/laplace.jl
@@ -25,7 +25,7 @@ immutable Laplace{T<:Real} <: ContinuousUnivariateDistribution
     μ::T
     θ::T
 
-    Laplace(μ::T, θ::T) = (@check_args(Laplace, θ > zero(θ)); new(μ, θ))
+    (::Type{Laplace{T}}){T}(μ::T, θ::T) = (@check_args(Laplace, θ > zero(θ)); new{T}(μ, θ))
 end
 
 Laplace{T<:Real}(μ::T, θ::T) = Laplace{T}(μ, θ)
@@ -34,7 +34,7 @@ Laplace(μ::Integer, θ::Integer) = Laplace(Float64(μ), Float64(θ))
 Laplace(μ::Real) = Laplace(μ, 1.0)
 Laplace() = Laplace(0.0, 1.0)
 
-typealias Biexponential Laplace
+const Biexponential = Laplace
 
 @distr_support Laplace -Inf Inf
 

--- a/src/univariate/continuous/levy.jl
+++ b/src/univariate/continuous/levy.jl
@@ -23,7 +23,7 @@ immutable Levy{T<:Real} <: ContinuousUnivariateDistribution
     μ::T
     σ::T
 
-    Levy(μ::T, σ::T) = (@check_args(Levy, σ > zero(σ)); new(μ, σ))
+    (::Type{Levy{T}}){T}(μ::T, σ::T) = (@check_args(Levy, σ > zero(σ)); new{T}(μ, σ))
 end
 
 Levy{T<:Real}(μ::T, σ::T) = Levy{T}(μ, σ)

--- a/src/univariate/continuous/logistic.jl
+++ b/src/univariate/continuous/logistic.jl
@@ -26,7 +26,7 @@ immutable Logistic{T<:Real} <: ContinuousUnivariateDistribution
     μ::T
     θ::T
 
-    Logistic(μ::T, θ::T) = (@check_args(Logistic, θ > zero(θ)); new(μ, θ))
+    (::Type{Logistic{T}}){T}(μ::T, θ::T) = (@check_args(Logistic, θ > zero(θ)); new{T}(μ, θ))
 end
 
 Logistic{T<:Real}(μ::T, θ::T) = Logistic{T}(μ, θ)

--- a/src/univariate/continuous/lognormal.jl
+++ b/src/univariate/continuous/lognormal.jl
@@ -27,7 +27,7 @@ immutable LogNormal{T<:Real} <: ContinuousUnivariateDistribution
     μ::T
     σ::T
 
-    LogNormal(μ::T, σ::T) = (@check_args(LogNormal, σ > zero(σ)); new(μ, σ))
+    (::Type{LogNormal{T}}){T}(μ::T, σ::T) = (@check_args(LogNormal, σ > zero(σ)); new{T}(μ, σ))
 end
 
 LogNormal{T<:Real}(μ::T, σ::T) = LogNormal{T}(μ, σ)

--- a/src/univariate/continuous/noncentralbeta.jl
+++ b/src/univariate/continuous/noncentralbeta.jl
@@ -3,10 +3,10 @@ immutable NoncentralBeta{T<:Real} <: ContinuousUnivariateDistribution
     β::T
     λ::T
 
-    function NoncentralBeta(α::T, β::T, λ::T)
-    	@check_args(NoncentralBeta, α > zero(α) && β > zero(β))
+    function (::Type{NoncentralBeta{T}}){T}(α::T, β::T, λ::T)
+        @check_args(NoncentralBeta, α > zero(α) && β > zero(β))
         @check_args(NoncentralBeta, λ >= zero(λ))
-    	new(α, β, λ)
+        new{T}(α, β, λ)
     end
 end
 

--- a/src/univariate/continuous/noncentralchisq.jl
+++ b/src/univariate/continuous/noncentralchisq.jl
@@ -22,10 +22,10 @@ External links
 immutable NoncentralChisq{T<:Real} <: ContinuousUnivariateDistribution
     ν::T
     λ::T
-    function NoncentralChisq(ν::T, λ::T)
+    function (::Type{NoncentralChisq{T}}){T}(ν::T, λ::T)
         @check_args(NoncentralChisq, ν > zero(ν))
         @check_args(NoncentralChisq, λ >= zero(λ))
-    	new(ν, λ)
+        new{T}(ν, λ)
     end
 end
 

--- a/src/univariate/continuous/noncentralf.jl
+++ b/src/univariate/continuous/noncentralf.jl
@@ -3,10 +3,10 @@ immutable NoncentralF{T<:Real} <: ContinuousUnivariateDistribution
     ν2::T
     λ::T
 
-    function NoncentralF(ν1::T, ν2::T, λ::T)
+    function (::Type{NoncentralF{T}}){T}(ν1::T, ν2::T, λ::T)
         @check_args(NoncentralF, ν1 > zero(T) && ν2 > zero(T))
         @check_args(NoncentralF, λ >= zero(T))
-	    new(ν1, ν2, λ)
+        new{T}(ν1, ν2, λ)
     end
 end
 

--- a/src/univariate/continuous/noncentralt.jl
+++ b/src/univariate/continuous/noncentralt.jl
@@ -2,10 +2,10 @@ immutable NoncentralT{T<:Real} <: ContinuousUnivariateDistribution
     ν::T
     λ::T
 
-    function NoncentralT(ν::T, λ::T)
-    	@check_args(NoncentralT, ν > zero(ν))
+    function (::Type{NoncentralT{T}}){T}(ν::T, λ::T)
+        @check_args(NoncentralT, ν > zero(ν))
         @check_args(NoncentralT, λ >= zero(λ))
-        new(ν, λ)
+        new{T}(ν, λ)
     end
 end
 

--- a/src/univariate/continuous/normal.jl
+++ b/src/univariate/continuous/normal.jl
@@ -25,7 +25,7 @@ immutable Normal{T<:Real} <: ContinuousUnivariateDistribution
     μ::T
     σ::T
 
-    Normal(μ, σ) = (@check_args(Normal, σ > zero(σ)); new(μ, σ))
+    (::Type{Normal{T}}){T}(μ, σ) = (@check_args(Normal, σ > zero(σ)); new{T}(μ, σ))
 end
 
 #### Outer constructors
@@ -35,7 +35,7 @@ Normal(μ::Integer, σ::Integer) = Normal(Float64(μ), Float64(σ))
 Normal(μ::Real) = Normal(μ, 1.0)
 Normal() = Normal(0.0, 1.0)
 
-typealias Gaussian Normal
+const Gaussian = Normal
 
 # #### Conversions
 convert{T <: Real, S <: Real}(::Type{Normal{T}}, μ::S, σ::S) = Normal(T(μ), T(σ))

--- a/src/univariate/continuous/normalcanon.jl
+++ b/src/univariate/continuous/normalcanon.jl
@@ -4,9 +4,9 @@ immutable NormalCanon{T<:Real} <: ContinuousUnivariateDistribution
     λ::T       # σ^(-2)
     μ::T       # μ
 
-    function NormalCanon(η, λ)
+    function (::Type{NormalCanon{T}}){T}(η, λ)
         @check_args(NormalCanon, λ > zero(λ))
-    	new(η, λ, η / λ)
+        new{T}(η, λ, η / λ)
     end
 end
 

--- a/src/univariate/continuous/normalinversegaussian.jl
+++ b/src/univariate/continuous/normalinversegaussian.jl
@@ -19,8 +19,8 @@ immutable NormalInverseGaussian{T<:Real} <: ContinuousUnivariateDistribution
   β::T
   δ::T
 
-  function NormalInverseGaussian(μ::T, α::T, β::T, δ::T)
-    new(μ, α, β, δ)
+  function (::Type{NormalInverseGaussian{T}}){T}(μ::T, α::T, β::T, δ::T)
+    new{T}(μ, α, β, δ)
   end
 end
 

--- a/src/univariate/continuous/pareto.jl
+++ b/src/univariate/continuous/pareto.jl
@@ -23,9 +23,9 @@ immutable Pareto{T<:Real} <: ContinuousUnivariateDistribution
     α::T
     θ::T
 
-    function Pareto(α::T, θ::T)
+    function (::Type{Pareto{T}}){T}(α::T, θ::T)
         @check_args(Pareto, α > zero(α) && θ > zero(θ))
-        new(α, θ)
+        new{T}(α, θ)
     end
 end
 

--- a/src/univariate/continuous/rayleigh.jl
+++ b/src/univariate/continuous/rayleigh.jl
@@ -24,7 +24,7 @@ External links
 immutable Rayleigh{T<:Real} <: ContinuousUnivariateDistribution
     σ::T
 
-    Rayleigh(σ::T) = (@check_args(Rayleigh, σ > zero(σ)); new(σ))
+    (::Type{Rayleigh{T}}){T}(σ::T) = (@check_args(Rayleigh, σ > zero(σ)); new{T}(σ))
 end
 
 Rayleigh{T<:Real}(σ::T) = Rayleigh{T}(σ)

--- a/src/univariate/continuous/symtriangular.jl
+++ b/src/univariate/continuous/symtriangular.jl
@@ -19,9 +19,9 @@ immutable SymTriangularDist{T<:Real} <: ContinuousUnivariateDistribution
     μ::T
     σ::T
 
-    function SymTriangularDist(μ::T, σ::T)
+    function (::Type{SymTriangularDist{T}}){T}(μ::T, σ::T)
         @check_args(SymTriangularDist, σ > zero(σ))
-        new(μ, σ)
+        new{T}(μ, σ)
     end
 end
 

--- a/src/univariate/continuous/tdist.jl
+++ b/src/univariate/continuous/tdist.jl
@@ -21,7 +21,7 @@ External links
 immutable TDist{T<:Real} <: ContinuousUnivariateDistribution
     ν::T
 
-    TDist(ν::T) = (@check_args(TDist, ν > zero(ν)); new(ν))
+    (::Type{TDist{T}}){T}(ν::T) = (@check_args(TDist, ν > zero(ν)); new{T}(ν))
 end
 
 TDist{T<:Real}(ν::T) = TDist{T}(ν)

--- a/src/univariate/continuous/triangular.jl
+++ b/src/univariate/continuous/triangular.jl
@@ -30,14 +30,14 @@ immutable TriangularDist{T<:Real} <: ContinuousUnivariateDistribution
     b::T
     c::T
 
-    function TriangularDist(a::T, b::T, c::T)
+    function (::Type{TriangularDist{T}}){T}(a::T, b::T, c::T)
         @check_args(TriangularDist, a < b)
         @check_args(TriangularDist, a <= c <= b)
-        new(a, b, c)
+        new{T}(a, b, c)
     end
-    function TriangularDist(a::T, b::T)
+    function (::Type{TriangularDist{T}}){T}(a::T, b::T)
         @check_args(TriangularDist, a < b)
-        new(a, b, middle(a, b))
+        new{T}(a, b, middle(a, b))
     end
 end
 

--- a/src/univariate/continuous/triweight.jl
+++ b/src/univariate/continuous/triweight.jl
@@ -2,7 +2,7 @@ immutable Triweight{T<:Real} <: ContinuousUnivariateDistribution
     μ::T
     σ::T
 
-    Triweight(μ::T, σ::T) = (@check_args(Triweight, σ > zero(σ)); new(μ, σ))
+    (::Type{Triweight{T}}){T}(μ::T, σ::T) = (@check_args(Triweight, σ > zero(σ)); new{T}(μ, σ))
 end
 
 Triweight{T<:Real}(μ::T, σ::T) = Triweight{T}(μ, σ)

--- a/src/univariate/continuous/uniform.jl
+++ b/src/univariate/continuous/uniform.jl
@@ -25,7 +25,7 @@ immutable Uniform{T<:Real} <: ContinuousUnivariateDistribution
     a::T
     b::T
 
-    Uniform(a::T, b::T) = (@check_args(Uniform, a < b); new(a, b))
+    (::Type{Uniform{T}}){T}(a::T, b::T) = (@check_args(Uniform, a < b); new{T}(a, b))
 end
 
 Uniform{T<:Real}(a::T, b::T) = Uniform{T}(a, b)

--- a/src/univariate/continuous/vonmises.jl
+++ b/src/univariate/continuous/vonmises.jl
@@ -21,9 +21,9 @@ immutable VonMises{T<:Real} <: ContinuousUnivariateDistribution
     κ::T      # concentration
     I0κ::T    # I0(κ), where I0 is the modified Bessel function of order 0
 
-    function VonMises(μ::T, κ::T)
+    function (::Type{VonMises{T}}){T}(μ::T, κ::T)
         @check_args(VonMises, κ > zero(κ))
-        new(μ, κ, besseli(zero(T), κ))
+        new{T}(μ, κ, besseli(zero(T), κ))
     end
 end
 

--- a/src/univariate/continuous/weibull.jl
+++ b/src/univariate/continuous/weibull.jl
@@ -25,9 +25,9 @@ immutable Weibull{T<:Real} <: ContinuousUnivariateDistribution
     α::T   # shape
     θ::T   # scale
 
-    function Weibull(α::T, θ::T)
-    	@check_args(Weibull, α > zero(α) && θ > zero(θ))
-    	new(α, θ)
+    function (::Type{Weibull{T}}){T}(α::T, θ::T)
+        @check_args(Weibull, α > zero(α) && θ > zero(θ))
+        new{T}(α, θ)
     end
 end
 

--- a/src/univariate/discrete/bernoulli.jl
+++ b/src/univariate/discrete/bernoulli.jl
@@ -26,9 +26,9 @@ External links:
 immutable Bernoulli{T<:Real} <: DiscreteUnivariateDistribution
     p::T
 
-    function Bernoulli(p::T)
+    function (::Type{Bernoulli{T}}){T}(p::T)
         @check_args(Bernoulli, zero(p) <= p <= one(p))
-        new(p)
+        new{T}(p)
     end
 
 end

--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -22,9 +22,9 @@ immutable BetaBinomial{T<:Real} <: DiscreteUnivariateDistribution
     α::T
     β::T
 
-    function BetaBinomial(n::Int, α::T, β::T)
+    function (::Type{BetaBinomial{T}}){T}(n::Int, α::T, β::T)
         @check_args(BetaBinomial, n >= zero(n) && α >= zero(α) && β >= zero(β))
-        new(n, α, β)
+        new{T}(n, α, β)
     end
 end
 

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -25,10 +25,10 @@ immutable Binomial{T<:Real} <: DiscreteUnivariateDistribution
     n::Int
     p::T
 
-    function Binomial(n, p)
+    function (::Type{Binomial{T}}){T}(n, p)
         @check_args(Binomial, n >= zero(n))
         @check_args(Binomial, zero(p) <= p <= one(p))
-        new(n, p)
+        new{T}(n, p)
     end
 
 end
@@ -191,7 +191,7 @@ function suffstats{T<:Integer}(::Type{Binomial}, n::Integer, x::AbstractArray{T}
     BinomialStats(ns, ne, n)
 end
 
-typealias BinomData Tuple{Int, AbstractArray}
+const BinomData = Tuple{Int, AbstractArray}
 
 suffstats(::Type{Binomial}, data::BinomData) = suffstats(Binomial, data...)
 suffstats(::Type{Binomial}, data::BinomData, w::AbstractArray{Float64}) = suffstats(Binomial, data..., w)

--- a/src/univariate/discrete/categorical.jl
+++ b/src/univariate/discrete/categorical.jl
@@ -18,16 +18,16 @@ immutable Categorical{T<:Real} <: DiscreteUnivariateDistribution
     K::Int
     p::Vector{T}
 
-    Categorical(p::Vector{T}, ::NoArgCheck) = new(length(p), p)
+    (::Type{Categorical{T}}){T}(p::Vector{T}, ::NoArgCheck) = new{T}(length(p), p)
 
-    function Categorical(p::Vector{T})
+    function (::Type{Categorical{T}}){T}(p::Vector{T})
         @check_args(Categorical, isprobvec(p))
-        new(length(p), p)
+        new{T}(length(p), p)
     end
 
-    function Categorical(k::Integer)
+    function (::Type{Categorical{T}}){T}(k::Integer)
         @check_args(Categorical, k >= 1)
-        new(k, fill(1/k, k))
+        new{T}(k, fill(1/k, k))
     end
 end
 
@@ -245,7 +245,7 @@ function suffstats{T<:Integer}(::Type{Categorical}, k::Int, x::AbstractArray{T},
     CategoricalStats(add_categorical_counts!(zeros(k), x, w))
 end
 
-typealias CategoricalData Tuple{Int, AbstractArray}
+const CategoricalData = Tuple{Int, AbstractArray}
 
 suffstats(::Type{Categorical}, data::CategoricalData) = suffstats(Categorical, data...)
 suffstats(::Type{Categorical}, data::CategoricalData, w::AbstractArray{Float64}) = suffstats(Categorical, data..., w)

--- a/src/univariate/discrete/geometric.jl
+++ b/src/univariate/discrete/geometric.jl
@@ -23,9 +23,9 @@ External links
 immutable Geometric{T<:Real} <: DiscreteUnivariateDistribution
     p::T
 
-    function Geometric(p::T)
+    function (::Type{Geometric{T}}){T}(p::T)
         @check_args(Geometric, zero(p) < p < one(p))
-    	new(p)
+        new{T}(p)
     end
 
 end

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -29,10 +29,10 @@ immutable NegativeBinomial{T<:Real} <: DiscreteUnivariateDistribution
     r::T
     p::T
 
-    function NegativeBinomial(r::T, p::T)
+    function (::Type{NegativeBinomial{T}}){T}(r::T, p::T)
         @check_args(NegativeBinomial, r > zero(r))
         @check_args(NegativeBinomial, zero(p) < p <= one(p))
-        new(r, p)
+        new{T}(r, p)
     end
 
 end

--- a/src/univariate/discrete/noncentralhypergeometric.jl
+++ b/src/univariate/discrete/noncentralhypergeometric.jl
@@ -43,11 +43,11 @@ immutable FisherNoncentralHypergeometric{T<:Real} <: NoncentralHypergeometric{T}
     n::Int     # sample size
     ω::T # odds ratio
 
-    function FisherNoncentralHypergeometric(ns::Real, nf::Real, n::Real, ω::T)
+    function (::Type{FisherNoncentralHypergeometric{T}}){T}(ns::Real, nf::Real, n::Real, ω::T)
         @check_args(FisherNoncentralHypergeometric, ns >= zero(ns) && nf >= zero(nf))
         @check_args(FisherNoncentralHypergeometric, zero(n) < n < ns + nf)
         @check_args(FisherNoncentralHypergeometric, ω > zero(ω))
-        new(ns, nf, n, ω)
+        new{T}(ns, nf, n, ω)
     end
 end
 
@@ -97,11 +97,11 @@ immutable WalleniusNoncentralHypergeometric{T<:Real} <: NoncentralHypergeometric
     n::Int     # sample size
     ω::T # odds ratio
 
-    function WalleniusNoncentralHypergeometric(ns::Real, nf::Real, n::Real, ω::T)
+    function (::Type{WalleniusNoncentralHypergeometric{T}}){T}(ns::Real, nf::Real, n::Real, ω::T)
         @check_args(WalleniusNoncentralHypergeometric, ns >= zero(ns) && nf >= zero(nf))
         @check_args(WalleniusNoncentralHypergeometric, zero(n) < n < ns + nf)
         @check_args(WalleniusNoncentralHypergeometric, ω > zero(ω))
-        new(ns, nf, n, ω)
+        new{T}(ns, nf, n, ω)
     end
 end
 

--- a/src/univariate/discrete/poisson.jl
+++ b/src/univariate/discrete/poisson.jl
@@ -21,7 +21,7 @@ External links:
 immutable Poisson{T<:Real} <: DiscreteUnivariateDistribution
     λ::T
 
-    Poisson(λ::Real) = (@check_args(Poisson, λ >= zero(λ)); new(λ))
+    (::Type{Poisson{T}}){T}(λ::Real) = (@check_args(Poisson, λ >= zero(λ)); new{T}(λ))
 end
 
 Poisson{T<:Real}(λ::T) = Poisson{T}(λ)

--- a/src/univariate/discrete/poissonbinomial.jl
+++ b/src/univariate/discrete/poissonbinomial.jl
@@ -25,7 +25,7 @@ immutable PoissonBinomial{T<:Real} <: DiscreteUnivariateDistribution
 
     p::Vector{T}
     pmf::Vector{T}
-    function PoissonBinomial(p::AbstractArray)
+    function (::Type{PoissonBinomial{T}}){T}(p::AbstractArray)
         for i=1:length(p)
             if !(0 <= p[i] <= 1)
                 error("Each element of p must be in [0, 1].")
@@ -33,7 +33,7 @@ immutable PoissonBinomial{T<:Real} <: DiscreteUnivariateDistribution
         end
         pb = poissonbinomial_pdf_fft(p)
         @assert isprobvec(pb)
-        new(p, pb)
+        new{T}(p, pb)
     end
 
 end

--- a/src/univariate/discrete/skellam.jl
+++ b/src/univariate/discrete/skellam.jl
@@ -22,9 +22,9 @@ immutable Skellam{T<:Real} <: DiscreteUnivariateDistribution
     μ1::T
     μ2::T
 
-    function Skellam(μ1::T, μ2::T)
+    function (::Type{Skellam{T}}){T}(μ1::T, μ2::T)
         @check_args(Skellam, μ1 > zero(μ1) && μ2 > zero(μ2))
-        new(μ1, μ2)
+        new{T}(μ1, μ2)
     end
 
 end


### PR DESCRIPTION
IIRC the warning I didn't fix are two `.+`/`.-` overloads and a `scale` import warnings.

The broadcast overload one will probably need to make `ZeroVector` actually an `AbstractVector` and the `scale` one is a public API so might require more careful deprecation.
