### PR TITLE
Fix a couple deprecation warnings on 0.6

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -10,9 +10,9 @@ using Compat
 import QuadGK.quadgk
 import Compat.view
 import Base.Random
-import Base: size, eltype, length, full, convert, show, getindex, scale, scale!, rand, rand!
+import Base: size, eltype, length, full, convert, show, getindex, scale!, rand, rand!
 import Base: sum, mean, median, maximum, minimum, quantile, std, var, cov, cor
-import Base: +, -, .+, .-
+import Base: +, -
 import Base.Math.@horner
 import Base.LinAlg: Cholesky
 

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -16,6 +16,10 @@ import Base: +, -
 import Base.Math.@horner
 import Base.LinAlg: Cholesky
 
+if isdefined(Base, :scale)
+    import Base: scale
+end
+
 import StatsBase: kurtosis, skewness, entropy, mode, modes, randi, fit, kldivergence
 import StatsBase: RandIntSampler, loglikelihood, dof, span
 import PDMats: dim, PDMat, invquad

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -29,6 +29,11 @@ convert{T}(::Type{ZeroVector{T}}, v::ZeroVector) = ZeroVector{T}(length(v))
 Base.broadcast(::typeof(+), x::AbstractArray, v::ZeroVector) = x
 Base.broadcast(::typeof(-), x::AbstractArray, v::ZeroVector) = x
 
+if VERSION < v"0.6.0-dev.1632"
+    Base.:(.+)(x::AbstractArray, v::ZeroVector) = x
+    Base.:(.-)(x::AbstractArray, v::ZeroVector) = x
+end
+
 
 ##### Utility functions
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -26,8 +26,8 @@ convert{T}(::Type{ZeroVector{T}}, v::ZeroVector) = ZeroVector{T}(length(v))
 
 +(x::AbstractArray, v::ZeroVector) = x
 -(x::AbstractArray, v::ZeroVector) = x
-.+(x::AbstractArray, v::ZeroVector) = x
-.-(x::AbstractArray, v::ZeroVector) = x
+Base.broadcast(::typeof(+), x::AbstractArray, v::ZeroVector) = x
+Base.broadcast(::typeof(-), x::AbstractArray, v::ZeroVector) = x
 
 
 ##### Utility functions


### PR DESCRIPTION
In particular, this should fix "could not import Base.scale into Distributions" and the `.+` overloading warning.