### PR TITLE
Fix kurtosis calculation for FDist

### DIFF
--- a/src/univariate/continuous/fdist.jl
+++ b/src/univariate/continuous/fdist.jl
@@ -79,7 +79,7 @@ function kurtosis{T<:Real}(d::FDist{T})
     (ν1, ν2) = params(d)
     if ν2 > 8
         a = ν1 * (5ν2 - 22) * (ν1 + ν2 - 2) + (ν2 - 4) * (ν2 - 2)^2
-        b = ν1 * (ν2 - 6) * (ν2 - 8) * (ν2 - 2)
+        b = ν1 * (ν2 - 6) * (ν2 - 8) * (ν1 + ν2 - 2)
         return 12a / b
     else
         return T(NaN)

--- a/test/ref/continuous_test.ref.json
+++ b/test/ref/continuous_test.ref.json
@@ -1133,6 +1133,19 @@
   ]
 },
 {
+    "expr": "FDist(30, 40)",
+    "dtype": "FDist",
+    "minimum": 0,
+    "maximum": "inf",
+    "properties": {
+      "kurtosis": 2.2442906574394463
+    },
+    "points": [
+    ],
+    "quans": [
+    ]
+},
+{
   "expr": "Frechet()",
   "dtype": "Frechet",
   "minimum": 0,


### PR DESCRIPTION
Before:

```
julia> using Distributions

julia> d = FDist(30, 40)
Distributions.FDist{Float64}(ν1=30.0, ν2=40.0)

julia> kurtosis(d)
4.016099071207431

julia> kurtosis(rand(d, 5_000_000))
2.245386630172172
```

After:

```
julia> using Distributions

julia> d = FDist(30, 40)
Distributions.FDist{Float64}(ν1=30.0, ν2=40.0)

julia> kurtosis(d)
2.2442906574394463

julia> kurtosis(rand(d, 5_000_000))
2.2924267619033687
```

Closes #590