### PR TITLE
use Base.sum instead of handrolled sum with poorly initialized accumulator

### DIFF
--- a/src/multivariates.jl
+++ b/src/multivariates.jl
@@ -113,20 +113,10 @@ end
 
 ## log likelihood
 
-function _loglikelihood(d::MultivariateDistribution, X::AbstractMatrix)
-    ll = 0.0
-    for i in 1:size(X, 2)
-        ll += _logpdf(d, view(X,:,i))
-    end
-    return ll
-end
-
 function loglikelihood(d::MultivariateDistribution, X::AbstractMatrix)
-    size(X,1) == length(d) ||
-        throw(DimensionMismatch("Inconsistent array dimensions."))
-    _loglikelihood(d, X)
+    size(X, 1) == length(d) || throw(DimensionMismatch("Inconsistent array dimensions."))
+    return sum(x -> _logpdf(d, x), X, 2)
 end
-
 
 ##### Specific distributions #####
 

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -283,13 +283,7 @@ pdf(d::DiscreteUnivariateDistribution) = isbounded(d) ? pdf(d, minimum(d):maximu
 
 ## loglikelihood
 
-function _loglikelihood(d::UnivariateDistribution, X::AbstractArray)
-    ll = 0.0
-    for i in 1:length(X)
-        @inbounds ll += logpdf(d, X[i])
-    end
-    return ll
-end
+_loglikelihood(d::UnivariateDistribution, X::AbstractArray) = sum(x -> logpdf(d, x), X)
 
 loglikelihood(d::UnivariateDistribution, X::AbstractArray) =
     _loglikelihood(d, X)

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -283,11 +283,7 @@ pdf(d::DiscreteUnivariateDistribution) = isbounded(d) ? pdf(d, minimum(d):maximu
 
 ## loglikelihood
 
-_loglikelihood(d::UnivariateDistribution, X::AbstractArray) = sum(x -> logpdf(d, x), X)
-
-loglikelihood(d::UnivariateDistribution, X::AbstractArray) =
-    _loglikelihood(d, X)
-
+loglikelihood(d::UnivariateDistribution, X::AbstractArray) = sum(x -> logpdf(d, x), X)
 
 ### macros to use StatsFuns for method implementation
 


### PR DESCRIPTION
This results in better type stability in cases where the reduction output is not a `Float64`. I found this while messing about with the [code in this Discourse post](https://discourse.julialang.org/t/julia-static-compilation/296/20) and [a branch of ForwardDiff which adds stack-allocated, low-dimensional gradients](https://github.com/JuliaDiff/ForwardDiff.jl/pull/213).

Note that I found a bunch of places with the same problem throughout the codebase - all of these spots will likely kill performance with non-`Float64` number types like `Dual`.

Setup:

```julia
using BenchmarkTools, ForwardDiff, Distributions

f(x1, x2, D) = loglikelihood(Normal(x1, x2), D)
∇f(x1, x2, D) = ForwardDiff.derivative((y1, y2) -> f(y1, y2, D), (x1, x2))

x1, x2 = rand(2);
D = rand(Normal(5.0, 1.0), 10);
```

Before this PR:

```julia
julia> @benchmark ∇f($x1, $x2, $D)
BenchmarkTools.Trial:
  memory estimate:  1008 bytes
  allocs estimate:  32
  --------------
  minimum time:     704.517 ns (0.00% GC)
  median time:      744.134 ns (0.00% GC)
  mean time:        853.260 ns (12.39% GC)
  maximum time:     20.858 μs (92.76% GC)
```

After this PR:

```julia
julia> @benchmark ∇f($x1, $x2, $D)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     323.714 ns (0.00% GC)
  median time:      323.957 ns (0.00% GC)
  mean time:        325.874 ns (0.00% GC)
  maximum time:     1.221 μs (0.00% GC)
```