### PR TITLE
Fix handling of .+ and .- overload deprecation

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -30,8 +30,10 @@ Base.broadcast(::typeof(+), x::AbstractArray, v::ZeroVector) = x
 Base.broadcast(::typeof(-), x::AbstractArray, v::ZeroVector) = x
 
 if VERSION < v"0.6.0-dev.1632"
-    Base.:(.+)(x::AbstractArray, v::ZeroVector) = x
-    Base.:(.-)(x::AbstractArray, v::ZeroVector) = x
+    include_string("""
+        Base.:(.+)(x::AbstractArray, v::ZeroVector) = x
+        Base.:(.-)(x::AbstractArray, v::ZeroVector) = x
+    """)
 end
 
 


### PR DESCRIPTION
Clearly I was not sufficiently diligent when initially attempting to fix this, as wrapping the definitions in a version conditional does not get around a warning emitted by the parser. This gets around it by using `include_string`.