### PR TITLE
Revert change to multivariate log likelihood

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.5
-PDMats 0.5.4
+PDMats 0.6.0
 StatsFuns 0.3.1
 Calculus
 StatsBase 0.8.3

--- a/src/multivariates.jl
+++ b/src/multivariates.jl
@@ -113,9 +113,17 @@ end
 
 ## log likelihood
 
+function _loglikelihood(d::MultivariateDistribution, X::AbstractMatrix)
+    ll = 0.0
+    @inbounds for i in 1:size(X, 2)
+        ll += _logpdf(d, view(X, :, i))
+    end
+    return ll
+end
+
 function loglikelihood(d::MultivariateDistribution, X::AbstractMatrix)
     size(X, 1) == length(d) || throw(DimensionMismatch("Inconsistent array dimensions."))
-    return sum(x -> _logpdf(d, x), X, 2)
+    return _loglikelihood(d, X)
 end
 
 ##### Specific distributions #####

--- a/src/multivariates.jl
+++ b/src/multivariates.jl
@@ -113,17 +113,9 @@ end
 
 ## log likelihood
 
-function _loglikelihood(d::MultivariateDistribution, X::AbstractMatrix)
-    ll = 0.0
-    @inbounds for i in 1:size(X, 2)
-        ll += _logpdf(d, view(X, :, i))
-    end
-    return ll
-end
-
 function loglikelihood(d::MultivariateDistribution, X::AbstractMatrix)
     size(X, 1) == length(d) || throw(DimensionMismatch("Inconsistent array dimensions."))
-    return _loglikelihood(d, X)
+    return sum(i -> _logpdf(d, view(X, :, i)), 1:size(X, 2))
 end
 
 ##### Specific distributions #####

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -55,6 +55,9 @@ function test_mvnormal(g::AbstractMvNormal, n_tsamples::Int=10^6)
         @test logpdf(g, X[:,i]) ≈ lp[i]
     end
     @test logpdf(g, X) ≈ lp
+
+    # log likelihood
+    @test loglikelihood(g, X) ≈ sum([Distributions._logpdf(g, X[:,i]) for i in 1:size(X, 2)])
 end
 
 


### PR DESCRIPTION
This reinstates the previous definition of `loglikelihood` for multivariate distributions that was changed in #592. Unfortunately there were no tests to verify the behavior so an issue went unnoticed. Addresses https://github.com/JuliaLang/METADATA.jl/pull/8848#issuecomment-294328801.

@jrevels Let me know if you have any ideas for a better way to initialize the accumulator or to otherwise approach this.

Fixes  #595