### PR TITLE
rand(rng, d) for certain distributions (starting with MvNormal)

### DIFF
--- a/doc/source/multivariate.rst
+++ b/doc/source/multivariate.rst
@@ -223,6 +223,11 @@ In addition to the methods listed in the common interface above, we also provide
 
     Write the squared Mahalanbobis distances from each column of x to the center of d to r.
 
+.. function:: rand(rng, d)
+              rand(rng, d, n)
+              rand!(rng, d, x)
+
+    Sample from distribution ``d`` using the random number generator ``rng``.
 
 Canonical form
 ~~~~~~~~~~~~~~~

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -55,9 +55,9 @@ end
 _pdf!(r::AbstractArray, d::AbstractMvNormal, x::AbstractMatrix) = exp!(_logpdf!(r, d, x))
 
 # Sampling with designated rng
-rand(rng::AbstractRNG, d::AbstractMvNormal) = _rand!(rng, d, Array{eltype(d)}(length(d)))
+rand(rng::AbstractRNG, d::AbstractMvNormal) = _rand!(rng, d, Vector{eltype(d)}(length(d)))
 rand!(rng::AbstractRNG, d::AbstractMvNormal, x::VecOrMat) = _rand!(rng, d, x)
-rand(rng::AbstractRNG, d::AbstractMvNormal, n::Int64) = _rand!(rng, d, Array{eltype(d)}(length(d), n))
+rand(rng::AbstractRNG, d::AbstractMvNormal, n::Int64) = _rand!(rng, d, Matrix{eltype(d)}(length(d), n))
 
 
 ###########################################################

--- a/src/multivariate/mvnormalcanon.jl
+++ b/src/multivariate/mvnormalcanon.jl
@@ -116,4 +116,5 @@ unwhiten_winv!(J::AbstractPDMat, x::AbstractVecOrMat) = unwhiten!(inv(J), x)
 unwhiten_winv!(J::PDiagMat, x::AbstractVecOrMat) = whiten!(J, x)
 unwhiten_winv!(J::ScalMat, x::AbstractVecOrMat) = whiten!(J, x)
 
-_rand!(d::MvNormalCanon, x::AbstractMatrix) = add!(unwhiten_winv!(d.J, randn!(x)), d.μ)
+_rand!(rng::AbstractRNG, d::MvNormalCanon, x::AbstractMatrix) = add!(unwhiten_winv!(d.J, randn!(rng,x)), d.μ)
+_rand!(d::MvNormalCanon, x::AbstractMatrix) = _rand!(Base.GLOBAL_RNG, d, x)

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -42,6 +42,20 @@ function test_mvnormal(g::AbstractMvNormal, n_tsamples::Int=10^6)
         @test isapprox(emp_cov[i,j], Σ[i,j], atol=sqrt(vs[i] * vs[j]) * 10.0 / sqrt(n_tsamples))
     end
 
+    X = rand(MersenneTwister(14), g, n_tsamples)
+    Y = rand(MersenneTwister(14), g, n_tsamples)
+    @test X == Y
+    emp_mu = vec(mean(X, 2))
+    Z = X .- emp_mu
+    emp_cov = A_mul_Bt(Z, Z) * (1.0 / n_tsamples)
+    for i = 1:d
+        @test isapprox(emp_mu[i]   , μ[i]  , atol=sqrt(vs[i] / n_tsamples) * 8.0)
+    end
+    for i = 1:d, j = 1:d
+        @test isapprox(emp_cov[i,j], Σ[i,j], atol=sqrt(vs[i] * vs[j]) * 10.0 / sqrt(n_tsamples))
+    end
+
+
     # evaluation of sqmahal & logpdf
     U = X .- μ
     sqm = vec(sum(U .* (Σ \ U), 1))


### PR DESCRIPTION
#436 has made using Distributions.jl with POMDPs.jl difficult. Unfortunately completely addressing #436 seems to be a large task since the issue has not been addressed for a long time. To enable the use of some distributions, we have been using [this hack](https://github.com/JuliaPOMDP/POMDPToolbox.jl/blob/master/src/distributions/distributions_jl.jl), which I would like to get rid of. I am wondering if JuliaStats would be amenable to adding the `rng` argument to `rand` for only a subset of distributions. After all, people using POMDPs.jl tend to only use either `MvNormal` or the univariate distributions.

This PR contains the implementation for `AbstractMvNormal`. If you think this is a good idea, I will also add it for some of the univariate distributions.