### PR TITLE
Add LocationScale type. Needs tests/locationscale.jl

### DIFF
--- a/doc/source/locationscale.rst
+++ b/doc/source/locationscale.rst
@@ -1,0 +1,88 @@
+.. _locationscale:
+
+Location Scale families
+========================
+
+The package provides a type named `LocationScale`, to represent distributions from a location-scale family, which is defined as:
+
+.. code:: julia
+    immutable LocationScale{D<:UnivariateDistribution, S<:ValueSupport} <: UnivariateDistribution{S}
+      base::D
+      μ::Float64
+      σ::Float64
+    end
+
+
+A location-scale distribution can be constructed using the constructor ``LocationScale`` as follows:
+
+.. function:: LocationScale(d, μ, σ):
+
+    Construct a location scale distribution.
+
+    :param d:   The base distribution for the family
+    :param μ:   The location parameter
+    :param σ:   The scale parameters
+
+
+Additionally, location-scale distributions can be constructed using arithmetic operations which are defined as:
+
+.. code:: julia
+    +(d::LocationScale, μ::Real) = LocationScale(d.base, d.μ + μ, d.σ)
+    -(d::LocationScale, μ::Real) = LocationScale(d.base, d.μ - μ, d.σ)
+    *(d::LocationScale, σ::Real) = LocationScale(d.base, d.μ*σ, d.σ*σ)
+    /(d::LocationScale, σ::Real) = LocationScale(d.base, d.μ/σ, d.σ/σ)
+
+
+    +(μ::Real, d::LocationScale) = d + μ
+    *(μ::Real, d::LocationScale) = d * μ
+
+    +(d::UnivariateDistribution, μ::Real) = LocationScale(d, μ, 1.0)
+    -(d::UnivariateDistribution, μ::Real) = LocationScale(d, -μ, 1.0)
+    *(d::UnivariateDistribution, σ::Real) = LocationScale(d, 0.0, σ)
+    /(d::UnivariateDistribution, σ::Real) = LocationScale(d, 0.0, 1/σ)
+
+
+    +(μ::Real, d::UnivariateDistribution) = d + μ
+    *(μ::Real, d::UnivariateDistribution) = d * μ
+
+
+
+Many functions, including those for the evaluation of pdf and sampling, are defined for all location-scale univariate distribuitons:
+
+    - ``maximum``
+    - ``minimum``
+    - ``insupport``
+    - ``location``
+    - ``scale``
+    - ``pdf``
+    - ``logpdf``
+    - ``cdf``
+    - ``quantile``
+    - ``rand``
+    - ``mean``
+    - ``var``
+    - ``skewness``
+    - ``kurtosis``
+    - ``rand``
+
+
+Observe that some distributions are natively parameterized as location--scale families, namely:
+
+    - ``Cauchy``
+    - ``GeneralizedExtremeValue``
+    - ``GeneralizedPareto``
+    - ``Gumbel``
+    - ``Laplace``
+    - ``Levy``
+    - ``Normal`
+    - ``SymTriangularDist``
+    - ``Weibull``
+
+
+Distributions can be standardized with the function ``standardize`` as follows:
+
+.. function:: standardize(d):
+
+    Center and scale the distribution ``d`` to have zero mean and unit variance.
+
+    :param d:   The distribution we wish to standardize

--- a/src/locationscale.jl
+++ b/src/locationscale.jl
@@ -1,0 +1,78 @@
+immutable LocationScale{D<:UnivariateDistribution, S<:ValueSupport} <: UnivariateDistribution{S}
+  base::D
+  μ::Float64
+  σ::Float64
+end
+
+### Constructors
+
+function LocationScale(base::UnivariateDistribution, μ::Float64, σ::Float64)
+  σ > 0 || throw(ArgumentError("Scale parameter σ should be positive"))
+  LocationScale{typeof(base), value_support(typeof(base))}(base, μ, σ)
+end
+
+LocationScale(base::UnivariateDistribution, μ::Real, σ::Real) = LocationScale(base, Float64(μ), Float64(σ))
+
+params(d::LocationScale) = tuple(params(d.base)..., d.μ, d.σ)
+partype(d::LocationScale) = partype(d.base)
+
+## range and support
+islowerbounded(d::LocationScale) = islowerbounded(d.base)
+isupperbounded(d::LocationScale) = isupperbounded(d.base)
+
+minimum(d::LocationScale) = minimum(d.base)*d.σ + d.μ
+maximum(d::LocationScale) = maximum(d.base)*d.σ + d.μ
+
+insupport{D<:DiscreteUnivariateDistribution}(d::LocationScale{D, Discrete}, x::Real) =
+  insupport(d.base, (x - d.μ)/d.σ)
+
+## other common and useful functions
+
+location(d::LocationScale) = d.μ
+scale(d::LocationScale) = d.σ
+
+pdf(d::LocationScale, x::Real) =
+  pdf(d.base, (x - d.μ)/d.σ) / (typeof(d).parameters[2] == Continuous ? d.σ : 1)
+
+logpdf(d::LocationScale, x::Real) =
+  logpdf(d.base, (x - d.μ)/d.σ) - (typeof(d).parameters[2] == Continuous ? log(σ) : 0)
+
+cdf(d::LocationScale, x::Real) =
+   cdf(d.base, (x- d.μ) / d.σ)
+
+logcdf(d::LocationScale, x::Real) =
+   logcdf(d.base, (x - d.μ)/ d.σ)
+
+quantile(d::LocationScale, x::Real) = quantile(d.base, x)*d.σ + d.μ
+
+mean(d::LocationScale) = d.μ + d.σ*mean(d.base)
+var(d::LocationScale) = var(d.base)*d.σ*d.σ
+skewness(d::LocationScale) = skewness(d.base)
+kurtosis(d::LocationScale) = kurtosis(d.base)
+
+### Operations as convenience constructors
+
++(d::LocationScale, μ::Real) = LocationScale(d.base, d.μ + μ, d.σ)
+-(d::LocationScale, μ::Real) = LocationScale(d.base, d.μ - μ, d.σ)
+*(d::LocationScale, σ::Real) = LocationScale(d.base, d.μ*σ, d.σ*σ)
+/(d::LocationScale, σ::Real) = LocationScale(d.base, d.μ/σ, d.σ/σ)
+
+
++(μ::Real, d::LocationScale) = d + μ
+*(μ::Real, d::LocationScale) = d * μ
+
++(d::UnivariateDistribution, μ::Real) = LocationScale(d, μ, 1.0)
+-(d::UnivariateDistribution, μ::Real) = LocationScale(d, -μ, 1.0)
+*(d::UnivariateDistribution, σ::Real) = LocationScale(d, 0.0, σ)
+/(d::UnivariateDistribution, σ::Real) = LocationScale(d, 0.0, 1/σ)
+
+
++(μ::Real, d::UnivariateDistribution) = d + μ
+*(μ::Real, d::UnivariateDistribution) = d * μ
+
+### Standardizing a LocationScale family
+standardize(d::UnivariateDistribution) = (d- mean(d)) / std(d)
+
+### Random sample generation
+
+rand(d::LocationScale) = d.μ + d.σ*rand(d.base)


### PR DESCRIPTION
So, I created this LocationScale type which works for univariate distributions.  The most common functions are already implemented.  I didn't bother adding moment generating functions or characteristic functions, but they would be easy to add.
Arithmetic operations are also defined to make things simpler.  A function "standardize" is given which provides the standard (mean = 0, var = 1) distribution for the family.  For instance standardize(TDist(6)) gives the standard T distribution with 6 degrees of freedom defined as
 (TDist(6) - mean(TDist(6)) / std(TDist(6)).
Documentation is also added.  I don't quite understand what kind of tests are required or how to write those files (even after reading a couple of them...yes, I am rather new to Julia), which is why they are lacking, but as far as I have tested it, it works just fine.
