### PR TITLE
import StatsBase.params

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,7 +2,7 @@ julia 0.6
 PDMats 0.6.0
 StatsFuns 0.3.1
 Calculus
-StatsBase 0.15.0
+StatsBase 0.17.0
 Compat 0.18.0
 QuadGK 0.1.1
 SpecialFunctions 0.1.0

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -23,7 +23,7 @@ if isdefined(Base, :scale)
 end
 
 import StatsBase: kurtosis, skewness, entropy, mode, modes, fit, kldivergence
-import StatsBase: loglikelihood, dof, span, params
+import StatsBase: loglikelihood, dof, span, params, params!
 import PDMats: dim, PDMat, invquad
 
 importall SpecialFunctions

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -23,7 +23,7 @@ if isdefined(Base, :scale)
 end
 
 import StatsBase: kurtosis, skewness, entropy, mode, modes, fit, kldivergence
-import StatsBase: loglikelihood, dof, span
+import StatsBase: loglikelihood, dof, span, params
 import PDMats: dim, PDMat, invquad
 
 importall SpecialFunctions


### PR DESCRIPTION
I've opened a PR in StatsBase (https://github.com/JuliaStats/StatsBase.jl/pull/274) to add `params`, so packages can use it without the entire Distributions dependency.  This PR simply imports params from StatsBase, and shouldn't be merged before the other.