### PR TITLE
Add dependency on FFTW, bump Julia to 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 PDMats 0.6.0
 StatsFuns 0.3.1
 Calculus
@@ -6,3 +6,4 @@ StatsBase 0.15.0
 Compat 0.18.0
 QuadGK 0.1.1
 SpecialFunctions 0.1.0
+FFTW

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -8,6 +8,7 @@ using StatsBase
 using Compat
 
 import QuadGK.quadgk
+import FFTW.fft!
 import Compat.view
 import Base.Random
 import Base: size, eltype, length, full, convert, show, getindex, scale!, rand, rand!


### PR DESCRIPTION
Should get the tests passing on nightly (I hope) since we use FFTs to compute the Poisson binomial PDF that the Base DFT functionality has been removed in 0.7. This requires bumping the required Julia version to 0.6.