### PR TITLE
Use rand() and Base.Random.RangeGeneratorInt instead of randi() and RandIntGenerator

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -16,14 +16,14 @@ import Base: sum, mean, median, maximum, minimum, quantile, std, var, cov, cor
 import Base: +, -
 import Base.Math.@horner
 import Base.LinAlg: Cholesky
-import Base.Random: GLOBAL_RNG
+import Base.Random: GLOBAL_RNG, RangeGenerator, RangeGeneratorInt
 
 if isdefined(Base, :scale)
     import Base: scale
 end
 
-import StatsBase: kurtosis, skewness, entropy, mode, modes, randi, fit, kldivergence
-import StatsBase: RandIntSampler, loglikelihood, dof, span
+import StatsBase: kurtosis, skewness, entropy, mode, modes, fit, kldivergence
+import StatsBase: loglikelihood, dof, span
 import PDMats: dim, PDMat, invquad
 
 importall SpecialFunctions

--- a/src/samplers/binomial.jl
+++ b/src/samplers/binomial.jl
@@ -241,7 +241,7 @@ function BinomialAliasSampler(n::Int, p::Float64)
     pv = binompvec(n, p)
     alias = Vector{Int}(n+1)
     StatsBase.make_alias_table!(pv, 1.0, pv, alias)
-    BinomialAliasSampler(AliasTable(pv, alias, RandIntSampler(n+1)))
+    BinomialAliasSampler(AliasTable(pv, alias, RangeGenerator(1:n+1)))
 end
 
 rand(s::BinomialAliasSampler) = rand(s.table) - 1

--- a/src/samplers/poissonbinomial.jl
+++ b/src/samplers/poissonbinomial.jl
@@ -7,7 +7,7 @@ function PoissBinAliasSampler(p::AbstractVector)
     pv = poissonbinomial_pdf_fft(p)
     alias = Vector{Int}(n+1)
     StatsBase.make_alias_table!(pv, 1.0, pv, alias)
-    BinomialAliasSampler(AliasTable(pv, alias, RandIntSampler(n+1)))
+    BinomialAliasSampler(AliasTable(pv, alias, RangeGenerator(1:n+1)))
 end
 
 function PoissBinAliasSampler(d::PoissonBinomial)
@@ -15,7 +15,7 @@ function PoissBinAliasSampler(d::PoissonBinomial)
     alias = Vector{Int}(n+1)
     pv = Vector{Float64}(n+1)
     StatsBase.make_alias_table!(d.pmf, 1.0, pv, alias)
-    BinomialAliasSampler(AliasTable(pv, alias, RandIntSampler(n+1)))
+    BinomialAliasSampler(AliasTable(pv, alias, RangeGenerator(1:n+1)))
 end
 
 rand(s::PoissBinAliasSampler) = rand(s.table) - 1

--- a/src/univariate/discrete/discreteuniform.jl
+++ b/src/univariate/discrete/discreteuniform.jl
@@ -129,7 +129,7 @@ end
 ### Sampling
 
 rand(d::DiscreteUniform) = rand(GLOBAL_RNG, d)
-rand(rng::AbstractRNG, d::DiscreteUniform) = randi(rng, d.a, d.b)
+rand(rng::AbstractRNG, d::DiscreteUniform) = rand(rng, d.a:d.b)
 
 # Fit model
 


### PR DESCRIPTION


The latter functions have been deprecated in StatsBase (https://github.com/JuliaStats/StatsBase.jl/pull/279).