### PR TITLE
Emergency fix to get distributions to work on 0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,4 +6,3 @@ StatsBase 0.17.0
 Compat 0.18.0
 QuadGK 0.1.1
 SpecialFunctions 0.1.0
-FFTW

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -8,7 +8,6 @@ using StatsBase
 using Compat
 
 import QuadGK.quadgk
-import FFTW.fft!
 import Compat.view
 import Base.Random
 import Base: size, eltype, length, full, convert, show, getindex, scale!, rand, rand!


### PR DESCRIPTION
This reverts parts of #627, to remove the dependency on FFTW, which is currently breaking most usages of Distributions on Julia v0.6. 

I would advocate merging this, tagging, then putting the dependency on `FFTW` back, and tagging a 0.7 only release. 

I release there is no consensus on this approach right now, but I'm putting this out there at the very least for users to patch their systems locally -- use this branch, and delete `FFTW` and `AbstractFFT` from `~/.julia/v0.6/` if you are struggling with precompilation issues around Distributions and FFTW. 

Fix #631

cc: @ararslan @stefankarpinski