### PR TITLE
Use a simple DFT algorithm when FFTW is not in Base

### DIFF
--- a/src/univariate/discrete/poissonbinomial.jl
+++ b/src/univariate/discrete/poissonbinomial.jl
@@ -149,8 +149,8 @@ end
 if VERSION >= v"0.7.0-DEV.602"
     function _dft(x::Vector{T}) where T
         n = length(x)
-        y = fill!(copy(x), zero(complex(float(T))))
-        @inbounds for j = 0:n-1, i = 0:n-1
+        y = Vector{complex(float(T))}(n)
+        @inbounds for j = 0:n-1, k = 0:n-1
             y[k+1] += x[j+1] * cis(-2π * j * k / n)
         end
         return y

--- a/src/univariate/discrete/poissonbinomial.jl
+++ b/src/univariate/discrete/poissonbinomial.jl
@@ -141,8 +141,22 @@ function poissonbinomial_pdf_fft(p::AbstractArray)
             x[n + 1 - l + 1] = conj(x[l + 1])
         end
     end
-    fft!(x)
-    [max(0, real(xi)) for xi in x]
+    [max(0, real(xi)) for xi in _dft(x)]
+end
+
+# A simple implementation of a DFT to avoid introducing a dependency
+# on an external FFT package just for this one distribution
+if VERSION >= v"0.7.0-DEV.602"
+    function _dft(x::Vector{T}) where T
+        n = length(x)
+        y = fill!(copy(x), zero(complex(float(T))))
+        @inbounds for j = 0:n-1, i = 0:n-1
+            y[k+1] += x[j+1] * cis(-2π * j * k / n)
+        end
+        return y
+    end
+else
+    _dft(x) = Base.fft(x)
 end
 
 #### Sampling

--- a/test/poissonbinomial.jl
+++ b/test/poissonbinomial.jl
@@ -74,3 +74,18 @@ for (n₁, n₂, n₃, p₁, p₂, p₃) in [(10, 10, 10, 0.1, 0.5, 0.9),
         @test isapprox(pdf(d, k), m, atol=1e-15)
     end
 end
+
+# Test the _dft helper function
+@testset "_dft" begin
+    x = Distributions._dft(collect(1:8))
+    # Comparator computed from FFTW
+    fftw_fft = [36.0 + 0.0im,
+                -4.0 + 9.65685424949238im,
+                -4.0 + 4.0im,
+                -4.0 + 1.6568542494923806im,
+                -4.0 + 0.0im,
+                -4.0 - 1.6568542494923806im,
+                -4.0 - 4.0im,
+                -4.0 - 9.65685424949238im]
+    @test x ≈ fftw_fft
+end


### PR DESCRIPTION
Avoids having to introduce a dependency on FFTW, which has binary dependencies, just for this one distribution. Distributions is already a pretty heavyweight dependency for packages; FFTW (once it actually works) will only make that worse. Thus I'm proposing this simple, standalone DFT implementation for the Poisson binomial PDF.