### PR TITLE
Bump the Poisson binomial PDF test tolerance

### DIFF
--- a/test/poissonbinomial.jl
+++ b/test/poissonbinomial.jl
@@ -71,7 +71,7 @@ for (n₁, n₂, n₃, p₁, p₂, p₃) in [(10, 10, 10, 0.1, 0.5, 0.9),
             end
             m += pmf1[i+1] * mc
         end
-        @test isapprox(pdf(d, k), m, atol=1e-15)
+        @test isapprox(pdf(d, k), m, atol=2e-15)
     end
 end
 


### PR DESCRIPTION
Need to loosen the tolerance a bit since the algorithm in #641 doesn't retain tolerance to within 10<sup>-15</sup>. This bumps the tolerance to 2×10<sup>-15</sup>.