### PR TITLE
Fix precision in _dft by reducing the magnitude of the argument in cis

### DIFF
--- a/src/univariate/discrete/poissonbinomial.jl
+++ b/src/univariate/discrete/poissonbinomial.jl
@@ -149,9 +149,9 @@ end
 if VERSION >= v"0.7.0-DEV.602"
     function _dft(x::Vector{T}) where T
         n = length(x)
-        y = Vector{complex(float(T))}(n)
+        y = zeros(complex(float(T)), n)
         @inbounds for j = 0:n-1, k = 0:n-1
-            y[k+1] += x[j+1] * cis(-2π * j * k / n)
+            y[k+1] += x[j+1] * cis(-π * float(T)(2 * mod(j * k, n)) / n)
         end
         return y
     end

--- a/test/poissonbinomial.jl
+++ b/test/poissonbinomial.jl
@@ -71,7 +71,7 @@ for (n₁, n₂, n₃, p₁, p₂, p₃) in [(10, 10, 10, 0.1, 0.5, 0.9),
             end
             m += pmf1[i+1] * mc
         end
-        @test isapprox(pdf(d, k), m, atol=2e-15)
+        @test isapprox(pdf(d, k), m, atol=5e-16)
     end
 end
 


### PR DESCRIPTION
Also, fix initialization of the `y` vector. (Sorry, Alex)