### PR TITLE
Make AliasTable.isampler type concrete

### DIFF
--- a/src/samplers/categorical.jl
+++ b/src/samplers/categorical.jl
@@ -28,7 +28,7 @@ end
 immutable AliasTable <: Sampleable{Univariate,Discrete}
     accept::Vector{Float64}
     alias::Vector{Int}
-    isampler::RangeGeneratorInt
+    isampler::RangeGeneratorInt{Int,UInt}
 end
 ncategories(s::AliasTable) = length(s.accept)
 


### PR DESCRIPTION
Makes the return type of `rand(::AliasTable)` inferable, with the associated performance boost.

```julia
using Distributions
x = rand(1000)
d = Categorical(x ./ sum(x))
```

`master`:
```julia
julia> @time rand(d, 1_000_000);
  0.240576 seconds (3.17 M allocations: 56.091 MiB, 13.16% gc time)
julia> @time rand(d, 1_000_000);
  0.210680 seconds (3.18 M allocations: 56.127 MiB, 0.59% gc time)
julia> @time rand(d, 1_000_000);
  0.206656 seconds (3.18 M allocations: 56.128 MiB, 1.55% gc time)
```
This PR:
```julia
julia> @time rand(d, 1_000_000);
  0.035367 seconds (11 allocations: 7.661 MiB)
julia> @time rand(d, 1_000_000);
  0.036287 seconds (11 allocations: 7.661 MiB)
julia> @time rand(d, 1_000_000);
  0.041560 seconds (11 allocations: 7.661 MiB, 15.54% gc time)
```