### PR TITLE
Add insupport method to MixtureModel

### DIFF
--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -63,7 +63,7 @@ mean(d::AbstractMixtureModel)
 
 Evaluate whether `x` is within the support of mixture distribution `d`.
 """
-insupport(d::AbstractMixtureModel, x::Any)
+insupport(d::AbstractMixtureModel, x::AbstractVector)
 
 """
     pdf(d::Union{UnivariateMixture, MultivariateMixture}, x)
@@ -270,7 +270,7 @@ end
 
 #### Evaluation
 
-function insupport(d::AbstractMixtureModel, x)
+function insupport(d::AbstractMixtureModel, x::AbstractVector)
     K = ncomponents(d)
     p = probs(d)
     @assert length(p) == K

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -59,6 +59,13 @@ Compute the overall mean (expectation).
 mean(d::AbstractMixtureModel)
 
 """
+    insupport(d::MultivariateMixture, x)
+
+Evaluate whether `x` is within the support of mixture distribution `d`.
+"""
+insupport(d::AbstractMixtureModel, x::AbstractVector)
+
+"""
     pdf(d::Union{UnivariateMixture, MultivariateMixture}, x)
 
 Evaluate the (mixed) probability density function over `x`. Here, `x` can be a single
@@ -262,6 +269,19 @@ end
 
 
 #### Evaluation
+
+function insupport(d::AbstractMixtureModel, x)
+    K = ncomponents(d)
+    p = probs(d)
+    @assert length(p) == K
+    for i = 1:K
+        @inbounds pi = p[i]
+        if pi > 0.0 && insupport(component(d, i), x)
+            return true
+        end
+    end
+    return false
+end
 
 function _cdf(d::UnivariateMixture, x::Real)
     K = ncomponents(d)

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -63,7 +63,7 @@ mean(d::AbstractMixtureModel)
 
 Evaluate whether `x` is within the support of mixture distribution `d`.
 """
-insupport(d::AbstractMixtureModel, x::AbstractVector)
+insupport(d::AbstractMixtureModel, x::Any)
 
 """
     pdf(d::Union{UnivariateMixture, MultivariateMixture}, x)

--- a/test/mixture.jl
+++ b/test/mixture.jl
@@ -150,6 +150,8 @@ test_params(g_u)
 g_u = MixtureModel([TriangularDist(-1,2,0),TriangularDist(-.5,3,1),TriangularDist(-2,0,-1)])
 @test minimum(g_u) == -2.0
 @test maximum(g_u) == 3.0
+@test insupport(g_u, 2.5) == true
+@test insupport(g_u, 3.5) == false
 
 g_u = UnivariateGMM([0.0, 2.0, -4.0], [1.0, 1.2, 1.5], Categorical([0.2, 0.5, 0.3]))
 @test isa(g_u, UnivariateGMM)
@@ -168,5 +170,6 @@ g_m = MixtureModel(
 @test isa(g_m, MixtureModel{Multivariate, Continuous, IsoNormal})
 @test length(components(g_m)) == 3
 @test length(g_m) == 2
+@test insupport(g_m, [0.0, 0.0]) == true
 test_mixture(g_m, 1000, 10^6)
 test_params(g_m)


### PR DESCRIPTION
Fixes #650 and https://github.com/brian-j-smith/Mamba.jl/issues/122

After this fix, https://github.com/brian-j-smith/Mamba.jl is able to perform MCMC on mixture distributions:

![image](https://user-images.githubusercontent.com/990069/29254333-4ea7c056-8048-11e7-8d79-8926b2ae54c1.png)