### PR TITLE
Deprecate vectorized methods for univariate distributions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ os:
 julia:
   - 0.6
   - nightly
+matrix:
+  allow_failures:
+    julia: nightly
 notifications:
   email: false
 script:

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -23,3 +23,19 @@ function BetaBinomial(n::Real, α::Real, β::Real)
 end
 
 
+# vectorized versions
+for fun in [:pdf, :logpdf,
+            :cdf, :logcdf,
+            :ccdf, :logccdf,
+            :invlogcdf, :invlogccdf,
+            :quantile, :cquantile]
+
+    _fun! = Symbol('_', fun, '!')
+    fun! = Symbol(fun, '!')
+
+    @eval begin
+        @deprecate ($_fun!)(r::AbstractArray, d::UnivariateDistribution, X::AbstractArray) r .= ($fun).(d, X) false
+        @deprecate ($fun!)(r::AbstractArray, d::UnivariateDistribution, X::AbstractArray) r .= ($fun).(d, X) false
+        @deprecate ($fun)(d::UnivariateDistribution, X::AbstractArray) ($fun).(d, X)
+    end
+end

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -1,21 +1,3 @@
-
-#### Deprecate on 0.5 (to be removed on 0.6)
-
-function dim(d::MultivariateDistribution)
-    Base.depwarn("dim(d::MultivariateDistribution) is deprecated. Please use length(d).", :dim)
-    return length(d)
-end
-
-function binaryentropy(d::UnivariateDistribution)
-    Base.depwarn("binaryentropy is deprecated. Please use entropy(d, 2).", :binaryentropy)
-    return entropy(d) / log(2)
-end
-
-@Base.deprecate logpmf logpdf
-@Base.deprecate logpmf! logpmf!
-@Base.deprecate pmf pdf
-
-
 #### Deprecate on 0.6 (to be removed on 0.7)
 
 @Base.deprecate expected_logdet meanlogdet
@@ -39,3 +21,5 @@ function BetaBinomial(n::Real, α::Real, β::Real)
     Base.depwarn("BetaBinomial(n::Real, α, β) is deprecated. Please use BetaBinomial(n::Integer, α, β) instead.", :BetaBinomial)
     BetaBinomial(Int(n), α, β)
 end
+
+

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -39,3 +39,5 @@ for fun in [:pdf, :logpdf,
         @deprecate ($fun)(d::UnivariateDistribution, X::AbstractArray) ($fun).(d, X)
     end
 end
+
+@deprecate pdf(d::DiscreteUnivariateDistribution) pdf.(d, support(d))

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -306,7 +306,11 @@ function _mixpdf!(r::AbstractArray, d::AbstractMixtureModel, x)
     for i = 1:K
         @inbounds pi = p[i]
         if pi > 0.0
-            pdf!(t, component(d, i), x)
+            if d isa UnivariateMixture
+                t .= pdf.(component(d, i), x)
+            else
+                pdf!(t, component(d, i), x)
+            end
             BLAS.axpy!(pi, t, r)
         end
     end
@@ -364,7 +368,12 @@ function _mixlogpdf!(r::AbstractArray, d::AbstractMixtureModel, x)
             lpri = log(pi)
             lp_i = view(Lp, :, i)
             # compute logpdf in batch and store
-            logpdf!(lp_i, component(d, i), x)
+            if d isa UnivariateMixture
+                lp_i .= logpdf.(component(d, i), x)
+            else
+                logpdf!(lp_i, component(d, i), x)
+            end
+
 
             # in the mean time, add log(prior) to lp and
             # update the maximum for each sample
@@ -433,7 +442,11 @@ function _cwise_pdf!(r::AbstractMatrix, d::AbstractMixtureModel, X)
     n = size(X, ndims(X))
     size(r) == (n, K) || error("The size of r is incorrect.")
     for i = 1:K
-        pdf!(view(r,:,i), component(d, i), X)
+        if d isa UnivariateMixture
+            view(r,:,i) .= pdf.(component(d, i), X)
+        else
+            pdf!(view(r,:,i),component(d, i), X)
+        end
     end
     r
 end
@@ -443,7 +456,11 @@ function _cwise_logpdf!(r::AbstractMatrix, d::AbstractMixtureModel, X)
     n = size(X, ndims(X))
     size(r) == (n, K) || error("The size of r is incorrect.")
     for i = 1:K
-        logpdf!(view(r,:,i), component(d, i), X)
+        if d isa UnivariateMixture
+            view(r,:,i) .= logpdf.(component(d, i), X)
+        else
+            logpdf!(view(r,:,i), component(d, i), X)            
+        end
     end
     r
 end

--- a/src/multivariate/dirichlet.jl
+++ b/src/multivariate/dirichlet.jl
@@ -218,7 +218,7 @@ function suffstats(::Type{Dirichlet}, P::AbstractMatrix{Float64}, w::AbstractArr
     K = size(P, 1)
     n = size(P, 2)
     if length(w) != n
-        throw(ArgumentError("Inconsistent argument dimensions."))
+        throw(DimensionMismatch("Inconsistent argument dimensions."))
     end
 
     tw = 0.
@@ -311,7 +311,7 @@ function fit_dirichlet!(elogp::Vector{Float64}, α::Vector{Float64};
     # This function directly overrides α
 
     K = length(elogp)
-    length(α) == K || throw(ArgumentError("Inconsistent argument dimensions."))
+    length(α) == K || throw(DimensionMismatch("Inconsistent argument dimensions."))
 
     g = Vector{Float64}(K)
     iq = Vector{Float64}(K)
@@ -388,7 +388,7 @@ function fit_mle(::Type{Dirichlet}, P::AbstractMatrix{Float64}, w::AbstractArray
     init::Vector{Float64}=Float64[], maxiter::Int=25, tol::Float64=1.0e-12)
 
     n = size(P, 2)
-    length(w) == n || throw(ArgumentError("Inconsistent argument dimensions."))
+    length(w) == n || throw(DimensionMismatch("Inconsistent argument dimensions."))
 
     α = isempty(init) ? dirichlet_mle_init(P, w) : init
     elogp = mean_logp(suffstats(Dirichlet, P, w))

--- a/src/multivariate/dirichletmultinomial.jl
+++ b/src/multivariate/dirichletmultinomial.jl
@@ -93,7 +93,7 @@ function suffstats(::Type{DirichletMultinomial}, x::Matrix{T}) where T<:Real
     DirichletMultinomialStats(n, s, m)
 end
 function suffstats(::Type{DirichletMultinomial}, x::Matrix{T}, w::Array{Float64}) where T<:Real
-    length(w) == size(x, 2) || throw(ArgumentError("Inconsistent argument dimensions."))
+    length(w) == size(x, 2) || throw(DimensionMismatch("Inconsistent argument dimensions."))
     ns = sum(x, 1)
     n = ns[1]
     all(ns .== n) || error("Each sample in X should sum to the same value.")

--- a/src/multivariate/multinomial.jl
+++ b/src/multivariate/multinomial.jl
@@ -197,7 +197,7 @@ function suffstats(::Type{Multinomial}, x::Matrix{T}) where T<:Real
 end
 
 function suffstats(::Type{Multinomial}, x::Matrix{T}, w::Array{Float64}) where T<:Real
-    length(w) == size(x, 2) || throw(ArgumentError("Inconsistent argument dimensions."))
+    length(w) == size(x, 2) || throw(DimensionMismatch("Inconsistent argument dimensions."))
 
     K = size(x, 1)
     n::T = zero(T)

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -371,7 +371,7 @@ end
 function suffstats(D::Type{MvNormal}, x::AbstractMatrix{Float64}, w::Array{Float64})
     d = size(x, 1)
     n = size(x, 2)
-    length(w) == n || throw(ArgumentError("Inconsistent argument dimensions."))
+    length(w) == n || throw(DimensionMismatch("Inconsistent argument dimensions."))
 
     tw = sum(w)
     s = x * vec(w)

--- a/src/multivariate/mvtdist.jl
+++ b/src/multivariate/mvtdist.jl
@@ -19,7 +19,7 @@ end
 
 function GenericMvTDist(df::T, μ::Vector{T}, Σ::Cov, zmean::Bool) where {Cov<:AbstractPDMat, T<:Real}
     d = length(μ)
-    dim(Σ) == d || throw(ArgumentError("The dimensions of μ and Σ are inconsistent."))
+    dim(Σ) == d || throw(DimensionMismatch("The dimensions of μ and Σ are inconsistent."))
     R = Base.promote_eltype(T, Σ)
     S = convert(AbstractArray{R}, Σ)
     GenericMvTDist{R, typeof(S)}(R(df), d, zmean, convert(AbstractArray{R}, μ), S)

--- a/src/samplers/binomial.jl
+++ b/src/samplers/binomial.jl
@@ -237,12 +237,7 @@ struct BinomialAliasSampler <: Sampleable{Univariate,Discrete}
     table::AliasTable
 end
 
-function BinomialAliasSampler(n::Int, p::Float64)
-    pv = binompvec(n, p)
-    alias = Vector{Int}(n+1)
-    StatsBase.make_alias_table!(pv, 1.0, pv, alias)
-    BinomialAliasSampler(AliasTable(pv, alias, RangeGenerator(1:n+1)))
-end
+BinomialAliasSampler(n::Int, p::Float64) = BinomialAliasSampler(AliasTable(binompvec(n, p)))
 
 rand(s::BinomialAliasSampler) = rand(s.table) - 1
 

--- a/src/samplers/categorical.jl
+++ b/src/samplers/categorical.jl
@@ -38,15 +38,17 @@ function AliasTable(probs::AbstractVector{T}) where T<:Real
     accp = Vector{Float64}(n)
     alias = Vector{Int}(n)
     StatsBase.make_alias_table!(probs, 1.0, accp, alias)
-    AliasTable(accp, alias, RangeGenerator(1:n))
+    un = unsigned(n)
+    AliasTable(accp, alias, Base.Random.RangeGeneratorInt(one(un),un))
 end
 
-function rand(s::AliasTable)
-    i = rand(GLOBAL_RNG, s.isampler)
+function rand(rng::AbstractRNG, s::AliasTable)
+    i = rand(GLOBAL_RNG, s.isampler) % Int
     u = rand()
     @inbounds r = u < s.accept[i] ? i : s.alias[i]
     r
 end
+rand(s::AliasTable) = rand(Base.Random.GLOBAL_RNG, s)
 
 show(io::IO, s::AliasTable) = @printf(io, "AliasTable with %d entries", ncategories(s))
 

--- a/src/samplers/multinomial.jl
+++ b/src/samplers/multinomial.jl
@@ -1,7 +1,7 @@
 
 function multinom_rand!(n::Int, p::Vector{Float64}, x::AbstractVector{T}) where T<:Real
     k = length(p)
-    length(x) == k || throw(ArgumentError("Invalid argument dimension."))
+    length(x) == k || throw(DimensionMismatch("Invalid argument dimension."))
 
     rp = 1.0  # remaining total probability
     i = 0

--- a/src/samplers/poissonbinomial.jl
+++ b/src/samplers/poissonbinomial.jl
@@ -2,21 +2,7 @@ struct PoissBinAliasSampler <: Sampleable{Univariate,Discrete}
     table::AliasTable
 end
 
-function PoissBinAliasSampler(p::AbstractVector)
-    n = length(p)
-    pv = poissonbinomial_pdf_fft(p)
-    alias = Vector{Int}(n+1)
-    StatsBase.make_alias_table!(pv, 1.0, pv, alias)
-    BinomialAliasSampler(AliasTable(pv, alias, RangeGenerator(1:n+1)))
-end
-
-function PoissBinAliasSampler(d::PoissonBinomial)
-    n = length(d.p)
-    alias = Vector{Int}(n+1)
-    pv = Vector{Float64}(n+1)
-    StatsBase.make_alias_table!(d.pmf, 1.0, pv, alias)
-    BinomialAliasSampler(AliasTable(pv, alias, RangeGenerator(1:n+1)))
-end
+PoissBinAliasSampler(d::PoissonBinomial) = PoissBinAliasSampler(AliasTable(d.pmf))
 
 rand(s::PoissBinAliasSampler) = rand(s.table) - 1
 

--- a/src/testutils.jl
+++ b/src/testutils.jl
@@ -316,7 +316,7 @@ function test_range_evaluation(d::DiscreteUnivariateDistribution)
     end
 
     if isbounded(d)
-        @test pdf(d) ≈ p0
+        @test pdf.(d, support(d)) ≈ p0
         @test pdf.(d, rmin-2:rmax) ≈ vcat(0.0, 0.0, p0)
         @test pdf.(d, rmin:rmax+3) ≈ vcat(p0, 0.0, 0.0, 0.0)
         @test pdf.(d, rmin-2:rmax+3) ≈ vcat(0.0, 0.0, p0, 0.0, 0.0, 0.0)

--- a/src/testutils.jl
+++ b/src/testutils.jl
@@ -96,7 +96,7 @@ function test_samples(s::Sampleable{Univariate, Discrete},      # the sampleable
     rmin = floor(Int,quantile(distr, 0.00001))::Int
     rmax = floor(Int,quantile(distr, 0.99999))::Int
     m = rmax - rmin + 1  # length of the range
-    p0 = pdf(distr, rmin:rmax)  # reference probability masses
+    p0 = pdf.(distr, rmin:rmax)  # reference probability masses
     @assert length(p0) == m
 
     # determine confidence intervals for counts:
@@ -189,7 +189,7 @@ function test_samples(s::Sampleable{Univariate, Continuous},    # the sampleable
     #
     clb = Vector{Int}(nbins)
     cub = Vector{Int}(nbins)
-    cdfs = cdf(distr, edges)
+    cdfs = cdf.(distr, edges)
 
     for i = 1:nbins
         pi = cdfs[i+1] - cdfs[i]
@@ -309,19 +309,19 @@ function test_range_evaluation(d::DiscreteUnivariateDistribution)
     rmin = round(Int, islowerbounded(d) ? vmin : quantile(d, 0.001))::Int
     rmax = round(Int, isupperbounded(d) ? vmax : quantile(d, 0.999))::Int
 
-    p0 = pdf(d, collect(rmin:rmax))
-    @test pdf(d, rmin:rmax) ≈ p0
+    p0 = pdf.(d, collect(rmin:rmax))
+    @test pdf.(d, rmin:rmax) ≈ p0
     if rmin + 2 <= rmax
-        @test pdf(d, rmin+1:rmax-1) ≈ p0[2:end-1]
+        @test pdf.(d, rmin+1:rmax-1) ≈ p0[2:end-1]
     end
 
     if isbounded(d)
         @test pdf(d) ≈ p0
-        @test pdf(d, rmin-2:rmax) ≈ vcat(0.0, 0.0, p0)
-        @test pdf(d, rmin:rmax+3) ≈ vcat(p0, 0.0, 0.0, 0.0)
-        @test pdf(d, rmin-2:rmax+3) ≈ vcat(0.0, 0.0, p0, 0.0, 0.0, 0.0)
+        @test pdf.(d, rmin-2:rmax) ≈ vcat(0.0, 0.0, p0)
+        @test pdf.(d, rmin:rmax+3) ≈ vcat(p0, 0.0, 0.0, 0.0)
+        @test pdf.(d, rmin-2:rmax+3) ≈ vcat(0.0, 0.0, p0, 0.0, 0.0, 0.0)
     elseif islowerbounded(d)
-        @test pdf(d, rmin-2:rmax) ≈ vcat(0.0, 0.0, p0)
+        @test pdf.(d, rmin-2:rmax) ≈ vcat(0.0, 0.0, p0)
     end
 end
 
@@ -368,13 +368,13 @@ function test_evaluation(d::DiscreteUnivariateDistribution, vs::AbstractVector, 
     end
 
     # consistency of scalar-based and vectorized evaluation
-    @test pdf(d, vs)  ≈ p
-    @test cdf(d, vs)  ≈ c
-    @test ccdf(d, vs) ≈ cc
+    @test pdf.(d, vs)  ≈ p
+    @test cdf.(d, vs)  ≈ c
+    @test ccdf.(d, vs) ≈ cc
 
-    @test logpdf(d, vs)  ≈ lp
-    @test logcdf(d, vs)  ≈ lc
-    @test logccdf(d, vs) ≈ lcc
+    @test logpdf.(d, vs)  ≈ lp
+    @test logcdf.(d, vs)  ≈ lc
+    @test logccdf.(d, vs) ≈ lcc
 end
 
 
@@ -426,13 +426,13 @@ function test_evaluation(d::ContinuousUnivariateDistribution, vs::AbstractVector
     end
 
     # consistency of scalar-based and vectorized evaluation
-    @test pdf(d, vs)  ≈ p
-    @test cdf(d, vs)  ≈ c
-    @test ccdf(d, vs) ≈ cc
+    @test pdf.(d, vs)  ≈ p
+    @test cdf.(d, vs)  ≈ c
+    @test ccdf.(d, vs) ≈ cc
 
-    @test logpdf(d, vs)  ≈ lp
-    @test logcdf(d, vs)  ≈ lc
-    @test logccdf(d, vs) ≈ lcc
+    @test logpdf.(d, vs)  ≈ lp
+    @test logcdf.(d, vs)  ≈ lc
+    @test logccdf.(d, vs) ≈ lcc
 end
 
 
@@ -442,7 +442,7 @@ function test_stats(d::DiscreteUnivariateDistribution, vs::AbstractVector)
     # using definition (or an approximation)
 
     vf = Float64[v for v in vs]
-    p = pdf(d, vf)
+    p = pdf.(d, vf)
     xmean = dot(p, vf)
     xvar = dot(p, abs2.(vf .- xmean))
     xstd = sqrt(xvar)

--- a/src/univariate/continuous/gamma.jl
+++ b/src/univariate/continuous/gamma.jl
@@ -114,7 +114,7 @@ end
 function suffstats(::Type{Gamma}, x::AbstractArray{T}, w::AbstractArray{Float64}) where T<:Real
     n = length(x)
     if length(w) != n
-        throw(ArgumentError("Inconsistent argument dimensions."))
+        throw(DimensionMismatch("Inconsistent argument dimensions."))
     end
 
     sx = zero(T)

--- a/src/univariate/discrete/bernoulli.jl
+++ b/src/univariate/discrete/bernoulli.jl
@@ -83,8 +83,6 @@ pdf(d::Bernoulli, x::Bool) = x ? succprob(d) : failprob(d)
 pdf(d::Bernoulli, x::Int) = x == 0 ? failprob(d) :
                             x == 1 ? succprob(d) : zero(d.p)
 
-pdf(d::Bernoulli) = typeof(d.p)[failprob(d), succprob(d)]
-
 cdf(d::Bernoulli, x::Bool) = x ? failprob(d) : one(d.p)
 cdf(d::Bernoulli, x::Int) = x < 0 ? zero(d.p) :
                             x < 1 ? failprob(d) : one(d.p)

--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -81,8 +81,9 @@ function kurtosis(d::BetaBinomial)
     return (left * right) - 3
 end
 
-function pdf(d::BetaBinomial, k::Int)
+function pdf(d::BetaBinomial{T}, k::Int) where T
     n, α, β = d.n, d.α, d.β
+    0 <= k <= n || return zero(T)
     chooseinv = (n + 1) * beta(k + 1, n - k + 1)
     numerator = beta(k + α, n - k + β)
     denominator = beta(α, β)

--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -92,7 +92,7 @@ end
 
 entropy(d::BetaBinomial) = entropy(Categorical(pdf.(d,support(d))))
 median(d::BetaBinomial) = median(Categorical(pdf.(d,support(d)))) - 1
-mode(d::BetaBinomial{T}) = indmax(pdf.(d,support(d))) - 1
+mode(d::BetaBinomial) = indmax(pdf.(d,support(d))) - 1
 modes(d::BetaBinomial) = modes(Categorical(pdf.(d,support(d)))) .- 1
 
 quantile(d::BetaBinomial, p::Float64) = quantile(Categorical(pdf.(d, support(d))), p) - 1

--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -83,7 +83,7 @@ end
 
 function pdf(d::BetaBinomial{T}, k::Int) where T
     n, α, β = d.n, d.α, d.β
-    0 <= k <= n || return zero(T)
+    insupport(d, k) || return zero(T)
     chooseinv = (n + 1) * beta(k + 1, n - k + 1)
     numerator = beta(k + α, n - k + β)
     denominator = beta(α, β)

--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -90,9 +90,9 @@ function pdf(d::BetaBinomial{T}, k::Int) where T
     return numerator / (denominator * chooseinv)
 end
 
-entropy(d::BetaBinomial) = entropy(Categorical(pdf(d)))
-median(d::BetaBinomial) = median(Categorical(pdf(d))) - 1
-mode(d::BetaBinomial{T}) where {T<:Real} = indmax(pdf(d)) - one(T)
-modes(d::BetaBinomial) = [x - 1 for x in modes(Categorical(pdf(d)))]
+entropy(d::BetaBinomial) = entropy(Categorical(pdf.(d,support(d))))
+median(d::BetaBinomial) = median(Categorical(pdf.(d,support(d)))) - 1
+mode(d::BetaBinomial{T}) = indmax(pdf.(d,support(d))) - 1
+modes(d::BetaBinomial) = modes(Categorical(pdf.(d,support(d)))) .- 1
 
-quantile(d::BetaBinomial, p::Float64) = quantile(Categorical(pdf(d)), p) - 1
+quantile(d::BetaBinomial, p::Float64) = quantile(Categorical(pdf.(d, support(d))), p) - 1

--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -90,18 +90,6 @@ function pdf(d::BetaBinomial{T}, k::Int) where T
     return numerator / (denominator * chooseinv)
 end
 
-function pdf(d::BetaBinomial)
-    n, α, β = d.n, d.α, d.β
-    denominator = beta(α, β)
-    values = Array{eltype(denominator)}(n+1)
-    for (i,k) in enumerate(0:n)
-        chooseinv = (n + 1) * beta(k + 1, n - k + 1)
-        numerator = beta(k + α, n - k + β)
-        @inbounds values[i] = numerator / (denominator * chooseinv)
-    end
-    return values
-end
-
 entropy(d::BetaBinomial) = entropy(Categorical(pdf(d)))
 median(d::BetaBinomial) = median(Categorical(pdf(d))) - 1
 mode(d::BetaBinomial{T}) where {T<:Real} = indmax(pdf(d)) - one(T)

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -119,7 +119,7 @@ RecursiveBinomProbEvaluator(d::Binomial) = RecursiveBinomProbEvaluator(d.n, d.p 
 nextpdf(s::RecursiveBinomProbEvaluator, pv::Float64, x::Integer) = ((s.n - x + 1) / x) * s.coef * pv
 
 function Base.broadcast!(::typeof(pdf), r::AbstractArray, d::Binomial, X::UnitRange)
-    indices(r) == indices(X) || throw(ArgumentError("Inconsistent array dimensions."))
+    indices(r) == indices(X) || throw(DimensionMismatch("Inconsistent array dimensions."))
 
     vl,vr, vfirst, vlast = _pdf_fill_outside!(r, d, X)
     if succprob(d) <= 1/2

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -118,7 +118,9 @@ end
 RecursiveBinomProbEvaluator(d::Binomial) = RecursiveBinomProbEvaluator(d.n, d.p / (1 - d.p))
 nextpdf(s::RecursiveBinomProbEvaluator, pv::Float64, x::Integer) = ((s.n - x + 1) / x) * s.coef * pv
 
-function _pdf!(r::AbstractArray, d::Binomial, X::UnitRange)
+function Base.broadcast!(::typeof(pdf), r::AbstractArray, d::Binomial, X::UnitRange)
+    indices(r) == indices(X) || throw(ArgumentError("Inconsistent array dimensions."))
+
     vl,vr, vfirst, vlast = _pdf_fill_outside!(r, d, X)
     if succprob(d) <= 1/2
         # fill normal
@@ -147,6 +149,11 @@ function _pdf!(r::AbstractArray, d::Binomial, X::UnitRange)
     end
     return r
 end
+function Base.broadcast(::typeof(pdf), d::Binomial, X::UnitRange)
+    r = similar(Array{promote_type(partype(d), eltype(X))}, indices(X))
+    r .= pdf.(d,X)
+end
+
 
 function mgf(d::Binomial, t::Real)
     n, p = params(d)

--- a/src/univariate/discrete/categorical.jl
+++ b/src/univariate/discrete/categorical.jl
@@ -170,30 +170,6 @@ logpdf(d::Categorical, x::Int) = insupport(d, x) ? log(d.p[x]) : -Inf
 
 pdf(d::Categorical) = copy(d.p)
 
-function _pdf!(r::AbstractArray, d::Categorical{T}, rgn::UnitRange) where T<:Real
-    vfirst = round(Int, first(rgn))
-    vlast = round(Int, last(rgn))
-    vl = max(vfirst, 1)
-    vr = min(vlast, d.K)
-    p = probs(d)
-    if vl > vfirst
-        for i = 1:(vl - vfirst)
-            r[i] = zero(T)
-        end
-    end
-    fm1 = vfirst - 1
-    for v = vl:vr
-        r[v - fm1] = p[v]
-    end
-    if vr < vlast
-        for i = (vr - vfirst + 2):length(rgn)
-            r[i] = zero(T)
-        end
-    end
-    return r
-end
-
-
 function quantile(d::Categorical, p::Float64)
     0 <= p <= 1 || throw(DomainError())
     k = ncategories(d)

--- a/src/univariate/discrete/categorical.jl
+++ b/src/univariate/discrete/categorical.jl
@@ -206,7 +206,7 @@ end
 function add_categorical_counts!(h::Vector{Float64}, x::AbstractArray{T}, w::AbstractArray{Float64}) where T<:Integer
     n = length(x)
     if n != length(w)
-        throw(ArgumentError("Inconsistent array lengths."))
+        throw(DimensionMismatch("Inconsistent array lengths."))
     end
     for i = 1 : n
         @inbounds xi = x[i]

--- a/src/univariate/discrete/categorical.jl
+++ b/src/univariate/discrete/categorical.jl
@@ -168,8 +168,6 @@ pdf(d::Categorical{T}, x::Int) where {T<:Real} = insupport(d, x) ? d.p[x] : zero
 
 logpdf(d::Categorical, x::Int) = insupport(d, x) ? log(d.p[x]) : -Inf
 
-pdf(d::Categorical) = copy(d.p)
-
 function quantile(d::Categorical, p::Float64)
     0 <= p <= 1 || throw(DomainError())
     k = ncategories(d)

--- a/src/univariate/discrete/discreteuniform.jl
+++ b/src/univariate/discrete/discreteuniform.jl
@@ -78,41 +78,6 @@ pdf(d::DiscreteUniform, x::Int) = insupport(d, x) ? d.pv : 0.0
 
 logpdf(d::DiscreteUniform, x::Int) = insupport(d, x) ? log(d.pv) : -Inf
 
-pdf(d::DiscreteUniform) = fill(probval(d), span(d))
-
-function _pdf!(r::AbstractArray, d::DiscreteUniform, rgn::UnitRange)
-    vfirst = round(Int, first(rgn))
-    vlast = round(Int, last(rgn))
-    vl = max(vfirst, d.a)
-    vr = min(vlast, d.b)
-    if vl > vfirst
-        for i = 1:(vl - vfirst)
-            r[i] = 0.0
-        end
-    end
-    fm1 = vfirst - 1
-    if vl <= vr
-        pv = d.pv
-        for v = vl:vr
-            r[v - fm1] = pv
-        end
-    end
-    if vr < vlast
-        for i = (vr-vfirst+2):length(rgn)
-            r[i] = 0.0
-        end
-    end
-    return r
-end
-
-function _logpdf!(r::AbstractArray, d::DiscreteUniform, x::AbstractArray)
-    lpv = log(probval(d))
-    for i = 1:length(x)
-        @inbounds r[i] = insupport(d, x[i]) ? lpv : -Inf
-    end
-    return r
-end
-
 quantile(d::DiscreteUniform, p::Float64) = d.a + floor(Int,p * span(d))
 
 function mgf(d::DiscreteUniform, t::Real)

--- a/src/univariate/discrete/geometric.jl
+++ b/src/univariate/discrete/geometric.jl
@@ -165,7 +165,7 @@ suffstats(::Type{Geometric}, x::AbstractArray{T}) where {T<:Integer} = Geometric
 function suffstats(::Type{Geometric}, x::AbstractArray{T}, w::AbstractArray{Float64}) where T<:Integer
     n = length(x)
     if length(w) != n
-        throw(ArgumentError("Inconsistent argument dimensions."))
+        throw(DimensionMismatch("Inconsistent argument dimensions."))
     end
     sx = 0.
     tw = 0.

--- a/src/univariate/discrete/geometric.jl
+++ b/src/univariate/discrete/geometric.jl
@@ -86,7 +86,14 @@ end
 
 RecursiveGeomProbEvaluator(d::Geometric) = RecursiveGeomProbEvaluator(failprob(d))
 nextpdf(s::RecursiveGeomProbEvaluator, p::Real, x::Integer) = p * s.p0
-_pdf!(r::AbstractArray, d::Geometric, rgn::UnitRange) = _pdf!(r, d, rgn, RecursiveGeomProbEvaluator(d))
+
+Base.broadcast!(::typeof(pdf), r::AbstractArray, d::Geometric, rgn::UnitRange) =
+    _pdf!(r, d, rgn, RecursiveGeomProbEvaluator(d))
+function Base.broadcast(::typeof(pdf), d::Geometric, X::UnitRange)
+    r = similar(Array{promote_type(partype(d), eltype(X))}, indices(X))
+    r .= pdf.(d,X)
+end
+
 
 
 function cdf(d::Geometric{T}, x::Int) where T<:Real

--- a/src/univariate/discrete/hypergeometric.jl
+++ b/src/univariate/discrete/hypergeometric.jl
@@ -84,4 +84,9 @@ RecursiveHypergeomProbEvaluator(d::Hypergeometric) = RecursiveHypergeomProbEvalu
 nextpdf(s::RecursiveHypergeomProbEvaluator, p::Float64, x::Integer) =
     ((s.ns - x + 1) / x) * ((s.n - x + 1) / (s.nf - s.n + x)) * p
 
-_pdf!(r::AbstractArray, d::Hypergeometric, rgn::UnitRange) = _pdf!(r, d, rgn, RecursiveHypergeomProbEvaluator(d))
+Base.broadcast!(::typeof(pdf), r::AbstractArray, d::Hypergeometric, rgn::UnitRange) =
+    _pdf!(r, d, rgn, RecursiveHypergeomProbEvaluator(d))
+function Base.broadcast(::typeof(pdf), d::Hypergeometric, X::UnitRange)
+    r = similar(Array{promote_type(partype(d), eltype(X))}, indices(X))
+    r .= pdf.(d,X)
+end

--- a/src/univariate/discrete/hypergeometric.jl
+++ b/src/univariate/discrete/hypergeometric.jl
@@ -86,6 +86,7 @@ nextpdf(s::RecursiveHypergeomProbEvaluator, p::Float64, x::Integer) =
 
 Base.broadcast!(::typeof(pdf), r::AbstractArray, d::Hypergeometric, rgn::UnitRange) =
     _pdf!(r, d, rgn, RecursiveHypergeomProbEvaluator(d))
+
 function Base.broadcast(::typeof(pdf), d::Hypergeometric, X::UnitRange)
     r = similar(Array{promote_type(partype(d), eltype(X))}, indices(X))
     r .= pdf.(d,X)

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -94,7 +94,13 @@ end
 
 RecursiveNegBinomProbEvaluator(d::NegativeBinomial) = RecursiveNegBinomProbEvaluator(d.r, failprob(d))
 nextpdf(s::RecursiveNegBinomProbEvaluator, p::Float64, x::Integer) = ((x + s.r - 1) / x) * s.p0 * p
-_pdf!(r::AbstractArray, d::NegativeBinomial, rgn::UnitRange) = _pdf!(r, d, rgn, RecursiveNegBinomProbEvaluator(d))
+
+Base.broadcast!(::typeof(pdf), r::AbstractArray, d::NegativeBinomial, rgn::UnitRange) =
+    _pdf!(r, d, rgn, RecursiveNegBinomProbEvaluator(d))
+function Base.broadcast(::typeof(pdf), d::NegativeBinomial, X::UnitRange)
+    r = similar(Array{promote_type(partype(d), eltype(X))}, indices(X))
+    r .= pdf.(d,X)
+end
 
 function mgf(d::NegativeBinomial, t::Real)
     r, p = params(d)

--- a/src/univariate/discrete/noncentralhypergeometric.jl
+++ b/src/univariate/discrete/noncentralhypergeometric.jl
@@ -114,9 +114,9 @@ convert(::Type{WalleniusNoncentralHypergeometric{T}}, ns::Real, nf::Real, n::Rea
 convert(::Type{WalleniusNoncentralHypergeometric{T}}, d::WalleniusNoncentralHypergeometric{S}) where {T<:Real, S<:Real} = WalleniusNoncentralHypergeometric(d.ns, d.nf, d.n, T(d.ω))
 
 # Properties
-mean(d::WalleniusNoncentralHypergeometric) = sum(support(d) .* pdf(d, support(d)))
-var(d::WalleniusNoncentralHypergeometric)  = sum((support(d) - mean(d)).^2 .* pdf(d, support(d)))
-mode(d::WalleniusNoncentralHypergeometric) = support(d)[indmax(pdf(d, support(d)))]
+mean(d::WalleniusNoncentralHypergeometric) = sum(support(d) .* pdf.(d, support(d)))
+var(d::WalleniusNoncentralHypergeometric)  = sum((support(d) - mean(d)).^2 .* pdf.(d, support(d)))
+mode(d::WalleniusNoncentralHypergeometric) = support(d)[indmax(pdf.(d, support(d)))]
 
 entropy(d::WalleniusNoncentralHypergeometric) = 1
 

--- a/src/univariate/discrete/poisson.jl
+++ b/src/univariate/discrete/poisson.jl
@@ -125,7 +125,7 @@ suffstats(::Type{Poisson}, x::AbstractArray{T}) where {T<:Integer} = PoissonStat
 
 function suffstats(::Type{Poisson}, x::AbstractArray{T}, w::AbstractArray{Float64}) where T<:Integer
     n = length(x)
-    n == length(w) || throw(ArgumentError("Inconsistent array lengths."))
+    n == length(w) || throw(DimensionMismatch("Inconsistent array lengths."))
     sx = 0.
     tw = 0.
     for i = 1 : n

--- a/src/univariate/discrete/poisson.jl
+++ b/src/univariate/discrete/poisson.jl
@@ -94,7 +94,14 @@ end
 
 RecursivePoissonProbEvaluator(d::Poisson) = RecursivePoissonProbEvaluator(rate(d))
 nextpdf(s::RecursivePoissonProbEvaluator, p::Float64, x::Integer) = p * s.λ / x
-_pdf!(r::AbstractArray, d::Poisson, rgn::UnitRange) = _pdf!(r, d, rgn, RecursivePoissonProbEvaluator(d))
+
+Base.broadcast!(::typeof(pdf), r::AbstractArray, d::Poisson, rgn::UnitRange) =
+    _pdf!(r, d, rgn, RecursivePoissonProbEvaluator(d))
+function Base.broadcast(::typeof(pdf), d::Poisson, X::UnitRange)
+    r = similar(Array{promote_type(partype(d), eltype(X))}, indices(X))
+    r .= pdf.(d,X)
+end
+
 
 function mgf(d::Poisson, t::Real)
     λ = rate(d)

--- a/src/univariate/discrete/poissonbinomial.jl
+++ b/src/univariate/discrete/poissonbinomial.jl
@@ -113,7 +113,6 @@ pdf(d::PoissonBinomial, k::Int) = insupport(d, k) ? d.pmf[k+1] : 0
 function logpdf(d::PoissonBinomial{T}, k::Int) where T<:Real
     insupport(d, k) ? log(d.pmf[k + 1]) : -T(Inf)
 end
-pdf(d::PoissonBinomial) = copy(d.pmf)
 
 
 # Computes the pdf of a poisson-binomial random variable using

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -319,14 +319,7 @@ cf(d::UnivariateDistribution, t)
 
 Evaluate the probability density (mass) at `x`.
 
-Note: The package implements the following generic methods to evaluate pdf values in batch.
-
-- `pdf!(dst::AbstractArray, d::Distribution, x::AbstractArray)`
-- `pdf(d::UnivariateDistribution, x::AbstractArray)`
-
-If there exists more efficient routine to evaluate pdf in batch (faster than repeatedly
-calling the scalar version of `pdf`), then one can also provide a specialized
-method of `pdf!`. The vectorized version of `pdf` simply delegats to `pdf!`.
+See also: [`logpdf`](@ref).
 """
 pdf(d::UnivariateDistribution, x::Real)
 pdf(d::DiscreteUnivariateDistribution, x::Int) = throw(MethodError(pdf, (d, x)))
@@ -339,11 +332,6 @@ pdf(d::DiscreteUnivariateDistribution, x::Real) = isinteger(x) ? pdf(d, round(In
 Evaluate the logarithm of probability density (mass) at `x`.
 Whereas there is a fallback implemented `logpdf(d, x) = log(pdf(d, x))`.
 Relying on this fallback is not recommended in general, as it is prone to overflow or underflow.
-Again, the package provides vectorized version of `logpdf!` and `logpdf`.
-One may override `logpdf!` to provide more efficient vectorized evaluation.
-Furthermore, the generic `loglikelihood` function delegates to `_loglikelihood`,
-which repeatedly calls `logpdf`. If there is a better way to compute log-likelihood,
-one should override `_loglikelihood`.
 """
 logpdf(d::UnivariateDistribution, x::Real) = log(pdf(d, x))
 logpdf(d::DiscreteUnivariateDistribution, x::Int) = log(pdf(d, x))
@@ -353,10 +341,9 @@ logpdf(d::DiscreteUnivariateDistribution, x::Real) = isinteger(x) ? logpdf(d, ro
 """
     cdf(d::UnivariateDistribution, x::Real)
 
-Evaluate the cumulative probability at `x`. The package provides generic functions to
-compute `ccdf`, `logcdf`, and `logccdf` in both scalar and vectorized forms.
-One may override these generic fallbacks if the specialized versions provide better
-numeric stability or higher efficiency.
+Evaluate the cumulative probability at `x`.
+
+See also [`ccdf`](@ref), [`logcdf`](@ref), and [`logccdf`](@ref).
 """
 cdf(d::UnivariateDistribution, x::Real)
 cdf(d::DiscreteUnivariateDistribution, x::Int) = cdf(d, x, FiniteSupport{hasfinitesupport(d)})
@@ -419,12 +406,9 @@ logccdf(d::DiscreteUnivariateDistribution, x::Real) = logccdf(d, floor(Int,x))
 """
     quantile(d::UnivariateDistribution, q::Real)
 
-Evaluate the inverse cumulative distribution function at `q`. The package provides
-generic functions to compute `cquantile`, `invlogcdf`, and `invlogccdf` in both
-scalar and vectorized forms. One may override these generic fallbacks if the specialized
-versions provide better numeric stability or higher efficiency. A generic `median` is
-provided, as `median(d) = quantile(d, 0.5)`. However, one should implement a specialized
-version of `median` if it can be computed faster than ``quantile``.
+Evaluate the inverse cumulative distribution function at `q`.
+
+See also: [`cquantile`](@ref), [`invlogcdf`](@ref), and [`invlogccdf`](@ref).
 """
 quantile(d::UnivariateDistribution, p::Real)
 

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -506,11 +506,6 @@ function _pdf!(r::AbstractArray, d::DiscreteUnivariateDistribution, X::UnitRange
     return r
 end
 
-# TODO: should we get rid of this?
-pdf(d::DiscreteUnivariateDistribution) = isbounded(d) ? pdf.(d, minimum(d):maximum(d)) :
-                                                        error("pdf(d) is not allowed when d is unbounded.")
-
-
 ## loglikelihood
 """
     loglikelihood(d::UnivariateDistribution, X::AbstractArray)

--- a/test/binomial.jl
+++ b/test/binomial.jl
@@ -8,14 +8,14 @@ for (p, n) in [(0.6, 10), (0.8, 6), (0.5, 40), (0.04, 20), (1., 100), (0., 10), 
 
     d = Binomial(n, p)
 
-    a = pdf(d, 0:n)
+    a = pdf.(d, 0:n)
     for t=0:n
         @test pdf(d, t) ≈ a[1+t]
     end
 
     li = rand(0:n, 2)
     rng = minimum(li):maximum(li)
-    b = pdf(d, rng)
+    b = pdf.(d, rng)
     for t in rng
         @test pdf(d, t) ≈ b[t - first(rng) + 1]
     end

--- a/test/categorical.jl
+++ b/test/categorical.jl
@@ -34,7 +34,7 @@ for p in Vector{Float64}[
     @test ccdf(d, 0) == 1.0
     @test ccdf(d, k+1) == 0.0
 
-    @test pdf(d) == p
+    @test pdf.(d, support(d)) == p
     @test pdf.(d, 1:k) == p
 
     test_distr(d, 10^6)

--- a/test/categorical.jl
+++ b/test/categorical.jl
@@ -35,7 +35,7 @@ for p in Vector{Float64}[
     @test ccdf(d, k+1) == 0.0
 
     @test pdf(d) == p
-    @test pdf(d, 1:k) == p
+    @test pdf.(d, 1:k) == p
 
     test_distr(d, 10^6)
 end

--- a/test/mixture.jl
+++ b/test/mixture.jl
@@ -32,7 +32,7 @@ function test_mixture(g::UnivariateMixture, n::Int, ns::Int)
     for i = 1:n
         @test cdf(g, X[i]) ≈ cf[i]
     end
-    @test cdf(g, X) ≈ cf
+    @test cdf.(g, X) ≈ cf
 
     # evaluation
     P0 = zeros(n, K)
@@ -56,8 +56,8 @@ function test_mixture(g::UnivariateMixture, n::Int, ns::Int)
         @test componentwise_logpdf(g, X[i]) ≈ vec(LP0[i,:])
     end
 
-    @test pdf(g, X)                  ≈ mix_p0
-    @test logpdf(g, X)               ≈ mix_lp0
+    @test pdf.(g, X)                  ≈ mix_p0
+    @test logpdf.(g, X)               ≈ mix_lp0
     @test componentwise_pdf(g, X)    ≈ P0
     @test componentwise_logpdf(g, X) ≈ LP0
 
@@ -108,6 +108,9 @@ function test_mixture(g::MultivariateMixture, n::Int, ns::Int)
         @test componentwise_logpdf(g, x_i) ≈ vec(LP0[i,:])
     end
 
+    @show g
+    @show size(X)
+    @show size(mix_p0)
     @test pdf(g, X)                  ≈ mix_p0
     @test logpdf(g, X)               ≈ mix_lp0
     @test componentwise_pdf(g, X)    ≈ P0

--- a/test/poissonbinomial.jl
+++ b/test/poissonbinomial.jl
@@ -51,9 +51,9 @@ for (n₁, n₂, n₃, p₁, p₂, p₃) in [(10, 10, 10, 0.1, 0.5, 0.9),
     b2 = Binomial(n₂, p₂)
     b3 = Binomial(n₃, p₃)
 
-    pmf1 = pdf(b1)
-    pmf2 = pdf(b2)
-    pmf3 = pdf(b3)
+    pmf1 = pdf.(b1, support(b1))
+    pmf2 = pdf.(b2, support(b2))
+    pmf3 = pdf.(b3, support(b3))
 
     @test mean(d) ≈ (mean(b1) + mean(b2) + mean(b3))
     @test var(d)  ≈ (var(b1) + var(b2) + var(b3))

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -71,7 +71,8 @@ S = PoissBinAliasSampler
 paramlst = (fill(0.2, 30), linspace(0.1, .99, 30), [fill(0.1, 10); fill(0.9, 10)])
 println("    testing $S")
 for p in paramlst
-    test_samples(S(p), PoissonBinomial(p), n_tsamples)
+    d = PoissonBinomial(p)
+    test_samples(S(d), d, n_tsamples)
 end
 
 

--- a/test/univariates.jl
+++ b/test/univariates.jl
@@ -85,8 +85,7 @@ function verify_and_test(D::Union{Type,Function}, d::UnivariateDistribution, dct
         expect_v = _json_value(val)
         f = eval(Symbol(fname))
         @assert isa(f, Function)
-        tol_v = abs(expect_v) * 1e-8 + 1e-12
-        Base.Test.test_approx_eq(f(d), expect_v, tol_v, "$fname(d)", "expect_v")
+        @test isapprox(f(d), expect_v; atol=1e-12, rtol=1e-8, nans=true)
     end
 
     # verify logpdf and cdf at certain points
@@ -97,20 +96,12 @@ function verify_and_test(D::Union{Type,Function}, d::UnivariateDistribution, dct
         lp = _json_value(pt["logpdf"])
         cf = _json_value(pt["cdf"])
 
-        ptol = p * 1e-8 + 1e-16
-        lptol = 1e-12
-        cftol = 1e-12
-        if isa(d, NoncentralHypergeometric)
-            lptol = 1e-4
-            cftol = 1e-8
-        end
-
-        Base.Test.test_approx_eq(pdf(d, x), p, ptol, "logpdf(d, $x)", "lp")
-        Base.Test.test_approx_eq(logpdf(d, x), lp, lptol, "logpdf(d, $x)", "lp")
+        @test isapprox(pdf.(d, x),     p; atol=1e-16, rtol=1e-8)
+        @test isapprox(logpdf.(d, x), lp; atol=isa(d, NoncentralHypergeometric) ? 1e-4 : 1e-12)
 
         # cdf method is not implemented for Skellam & NormalInverseGaussian
         if !isa(d, Union{Skellam, NormalInverseGaussian})
-            Base.Test.test_approx_eq(cdf(d, x), cf, cftol, "cdf(d, $x)", "cf")
+            @test isapprox(cdf(d, x), cf; atol=isa(d, NoncentralHypergeometric) ? 1e-8 : 1e-12)
         end
     end
 


### PR DESCRIPTION
This keeps the old behaviour for multivariate distributions, as I don't have any great ideas for those.

Still need to overload `Base.broadcast` for fast `UnitRange` methods (e.g. `Binomial`).