### PR TITLE
make quantile function of truncated distributions accept more than just Float64 arguments

### DIFF
--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -47,7 +47,7 @@ insupport(d::Truncated{D,Union{Discrete,Continuous}}, x::Real) where {D<:Univari
 
 ### evaluation
 
-quantile(d::Truncated, p::Real) = quantile(d.untruncated, d.lcdf + p * d.tp)
+quantile(d::Truncated, p::T) where {T<:Real} = quantile(d.untruncated, d.lcdf + p * d.tp)
 
 for f in [:pdf, :logpdf, :cdf, :logcdf, :ccdf, :logccdf]
     @eval ($f)(d::Truncated, x::Int) = ($f)(d, float(x))

--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -47,7 +47,7 @@ insupport(d::Truncated{D,Union{Discrete,Continuous}}, x::Real) where {D<:Univari
 
 ### evaluation
 
-quantile(d::Truncated, p::T) where {T<:Real} = quantile(d.untruncated, d.lcdf + p * d.tp)
+quantile(d::Truncated, p::Real) = quantile(d.untruncated, d.lcdf + p * d.tp)
 
 for f in [:pdf, :logpdf, :cdf, :logcdf, :ccdf, :logccdf]
     @eval ($f)(d::Truncated, x::Int) = ($f)(d, float(x))

--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -47,7 +47,7 @@ insupport(d::Truncated{D,Union{Discrete,Continuous}}, x::Real) where {D<:Univari
 
 ### evaluation
 
-quantile(d::Truncated, p::Float64) = quantile(d.untruncated, d.lcdf + p * d.tp)
+quantile(d::Truncated, p::Real) = quantile(d.untruncated, d.lcdf + p * d.tp)
 
 for f in [:pdf, :logpdf, :cdf, :logcdf, :ccdf, :logccdf]
     @eval ($f)(d::Truncated, x::Int) = ($f)(d, float(x))

--- a/test/truncate.jl
+++ b/test/truncate.jl
@@ -84,6 +84,12 @@ function verify_and_test(d::UnivariateDistribution, dct::Dict, n_tsamples::Int)
         # @test isapprox(cdf(d, Dual(x))   , cf, atol=sqrt(eps()))
     end
 
+    # test if truncated quantile function can be evaluated consistently for different types at certain points
+    @test isapprox(quantile(d, 0), quantile(d, Float32(0)))
+    @test isapprox(quantile(d, 1), quantile(d, Float32(1.0)))
+    @test isapprox(quantile(d, Float64(0.3)), quantile(d, Float32(0.3)))
+    @test isapprox(quantile(d, Float64(0.7)), quantile(d, Float32(0.7)))
+
     try
         m = mgf(d,0.0)
         @test m == 1.0


### PR DESCRIPTION
I have code that somewhere calls `quantile(d, x)` for a user-specified distribution `d` and a value `x` that happens to be `Float32`. At the moment this code works for general univariate distributions but it breaks when `d` is a truncated distribution, as its quantile requires `Float64`. Not sure if enforcing `Float64` is required for any specific reason, but since neither the `quantile` function for non-truncated distributions nor other functions (`pdf` etc.) for truncated distributions are as restrictive, I think the `quantile` function of truncated distributions shouldn't be, either.

Side remark: the whole definition of `Truncated` distributions is hard coded to use `Float64`:
```julia
struct Truncated{D<:UnivariateDistribution, S<:ValueSupport} <: UnivariateDistribution{S}
    untruncated::D      # the original distribution (untruncated)
    lower::Float64      # lower bound
    upper::Float64      # upper bound
    lcdf::Float64       # cdf of lower bound
    ucdf::Float64       # cdf of upper bound

    tp::Float64         # the probability of the truncated part, i.e. ucdf - lcdf
    logtp::Float64      # log(tp), i.e. log(ucdf - lcdf)
end
```
Is this desirable?

PS: have mercy with me if this is a pointless issue, it's my first PR :relaxed: 