### PR TITLE
add Wigner semicircle distribution

### DIFF
--- a/docs/src/univariate.md
+++ b/docs/src/univariate.md
@@ -132,6 +132,7 @@ NormalCanon
 NormalInverseGaussian
 Pareto
 Rayleigh
+Semicircle
 SymTriangularDist
 TDist
 TriangularDist

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -129,6 +129,7 @@ export
     PoissonBinomial,
     QQPair,
     Rayleigh,
+    Semicircle,
     Skellam,
     SymTriangularDist,
     TDist,

--- a/src/univariate/continuous/semicircle.jl
+++ b/src/univariate/continuous/semicircle.jl
@@ -24,28 +24,34 @@ mode(d::Semicircle) = zero(d.r)
 entropy(d::Semicircle) = log(π * d.r) - oftype(d.r, 0.5)
 
 function pdf(d::Semicircle, x::Real)
-    if abs(x) < d.r
-        return 2 / (π * d.r^2) * sqrt(d.r^2 - x^2)
-    else
-        return 0.0
+    let x = float(x)
+        if abs(x) < d.r
+            return oftype(x, 2 / (π * d.r^2) * sqrt(d.r^2 - x^2))
+        else
+            return oftype(x, 0)
+        end
     end
 end
 
 function logpdf(d::Semicircle, x::Real)
-    if abs(x) < d.r
-        return log(2 / π) - 2 * log(d.r) + 1/2 * log(r^2 - x^2)
-    else
-        return oftype(x, Inf)
+    let x = float(x)
+        if abs(x) < d.r
+            return oftype(x, log(2 / π) - 2 * log(d.r) + 1/2 * log(r^2 - x^2))
+        else
+            return oftype(x, Inf)
+        end
     end
 end
 
 function cdf(d::Semicircle, x::Real)
-    if abs(x) < d.r
-        u = x / d.r
-        return (u * sqrt(1 - u^2) + asin(u)) / π + one(x) / 2
-    elseif x ≥ d.r
-        return one(x)
-    else
-        return zero(x)
+    let x = float(x)
+        if abs(x) < d.r
+            u = x / d.r
+            return oftype(x, (u * sqrt(1 - u^2) + asin(u)) / π + one(x) / 2)
+        elseif x ≥ d.r
+            return one(x)
+        else
+            return zero(x)
+        end
     end
 end

--- a/src/univariate/continuous/semicircle.jl
+++ b/src/univariate/continuous/semicircle.jl
@@ -1,7 +1,22 @@
 """
     Semicircle(r)
 
-The Wigner semicircle distribution with radius `r`.
+The Wigner semicircle distribution with radius parameter `r` has probability
+density function
+
+```math
+f(x; r) = \\frac{2}{\\pi r^2} \\sqrt{r^2 - x^2}, \\quad x \\in [-r, r].
+```
+
+```julia
+Semicircle(r)   # Wigner semicircle distribution with radius r
+
+params(d)       # Get the radius parameter, i.e. (r,)
+```
+
+External links
+
+* [Wigner semicircle distribution on Wikipedia](https://en.wikipedia.org/wiki/Wigner_semicircle_distribution)
 """
 struct Semicircle{T<:Real} <: ContinuousUnivariateDistribution
     r::T

--- a/src/univariate/continuous/semicircle.jl
+++ b/src/univariate/continuous/semicircle.jl
@@ -24,34 +24,33 @@ mode(d::Semicircle) = zero(d.r)
 entropy(d::Semicircle) = log(π * d.r) - oftype(d.r, 0.5)
 
 function pdf(d::Semicircle, x::Real)
-    let x = float(x)
-        if abs(x) < d.r
-            return oftype(x, 2 / (π * d.r^2) * sqrt(d.r^2 - x^2))
-        else
-            return oftype(x, 0)
-        end
+    xx, r = promote(x, float(d.r))
+    if insupport(d, xx)
+        return 2 / (π * r^2) * sqrt(r^2 - xx^2)
+    else
+        return oftype(r, 0)
     end
 end
 
 function logpdf(d::Semicircle, x::Real)
-    let x = float(x)
-        if abs(x) < d.r
-            return oftype(x, log(2 / π) - 2 * log(d.r) + 1/2 * log(r^2 - x^2))
-        else
-            return oftype(x, Inf)
-        end
+    xx, r = promote(x, float(d.r))
+    if insupport(d, xx)
+        return log(oftype(r, 2) / π) - 2 * log(r) + log(r^2 - xx^2) / 2
+    else
+        return oftype(r, -Inf)
     end
 end
 
 function cdf(d::Semicircle, x::Real)
-    let x = float(x)
-        if abs(x) < d.r
-            u = x / d.r
-            return oftype(x, (u * sqrt(1 - u^2) + asin(u)) / π + one(x) / 2)
-        elseif x ≥ d.r
-            return one(x)
-        else
-            return zero(x)
-        end
+    xx, r = promote(x, float(d.r))
+    if insupport(d, xx)
+        u = xx / r
+        return (u * sqrt(1 - u^2) + asin(u)) / π + one(xx) / 2
+    elseif x < minimum(d)
+        return zero(r)
+    else
+        return one(r)
     end
 end
+
+@quantile_newton Semicircle

--- a/src/univariate/continuous/semicircle.jl
+++ b/src/univariate/continuous/semicircle.jl
@@ -1,0 +1,51 @@
+"""
+    Semicircle(r)
+
+The Wigner semicircle distribution with radius `r`.
+"""
+struct Semicircle{T<:Real} <: ContinuousUnivariateDistribution
+    r::T
+
+    Semicircle{T}(r) where {T} = (@check_args(Semicircle, r > 0); new{T}(r))
+end
+
+Semicircle(r::Real) = Semicircle{typeof(r)}(r)
+Semicircle(r::Integer) = Semicircle(Float64(r))
+
+@distr_support Semicircle -d.r +d.r
+
+params(d::Semicircle) = (d.r,)
+
+mean(d::Semicircle) = zero(d.r)
+var(d::Semicircle) = d.r^2 / 4
+skewness(d::Semicircle) = zero(d.r)
+median(d::Semicircle) = zero(d.r)
+mode(d::Semicircle) = zero(d.r)
+entropy(d::Semicircle) = log(π * d.r) - oftype(d.r, 0.5)
+
+function pdf(d::Semicircle, x::Real)
+    if abs(x) < d.r
+        return 2 / (π * d.r^2) * sqrt(d.r^2 - x^2)
+    else
+        return 0.0
+    end
+end
+
+function logpdf(d::Semicircle, x::Real)
+    if abs(x) < d.r
+        return log(2 / π) - 2 * log(d.r) + 1/2 * log(r^2 - x^2)
+    else
+        return oftype(x, Inf)
+    end
+end
+
+function cdf(d::Semicircle, x::Real)
+    if abs(x) < d.r
+        u = x / d.r
+        return (u * sqrt(1 - u^2) + asin(u)) / π + one(x) / 2
+    elseif x ≥ d.r
+        return one(x)
+    else
+        return zero(x)
+    end
+end

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -605,6 +605,7 @@ const continuous_distributions = [
     "lognormal",    # LogNormal depends on Normal
     "pareto",
     "rayleigh",
+    "semicircle",
     "symtriangular",
     "tdist",
     "triangular",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,7 @@ tests = [
     "noncentralt",
     "locationscale",
     "quantile_newton",
+    "semicircle",
 ]
 
 print_with_color(:blue, "Running tests:\n")

--- a/test/semicircle.jl
+++ b/test/semicircle.jl
@@ -1,0 +1,8 @@
+using Distributions
+using Base.Test
+
+d = Semicircle(2.0)
+
+@test pdf(d, 0)  == .31830988618379067153776752674
+@test pdf(d, -2) == .0
+@test pdf(d, 2)  == .0

--- a/test/semicircle.jl
+++ b/test/semicircle.jl
@@ -3,6 +3,36 @@ using Base.Test
 
 d = Semicircle(2.0)
 
-@test pdf(d, 0)  == .31830988618379067153776752674
+@test params(d) == (2.0,)
+
+@test minimum(d) == -2.0
+@test maximum(d) == +2.0
+
+@test mean(d)     ==  .0
+@test var(d)      == 1.0
+@test skewness(d) ==  .0
+@test median(d)   ==  .0
+@test mode(d)     ==  .0
+@test entropy(d)  == 1.33787706640934544458
+
+@test pdf(d, -5) == .0
 @test pdf(d, -2) == .0
-@test pdf(d, 2)  == .0
+@test pdf(d,  0) == .31830988618379067154
+@test pdf(d, +2) == .0
+@test pdf(d, +5) == .0
+
+@test logpdf(d, -5) == -Inf
+@test logpdf(d, -2) == -Inf
+@test logpdf(d,  0) ≈  log(.31830988618379067154)
+@test logpdf(d, +2) == -Inf
+@test logpdf(d, +5) == -Inf
+
+@test cdf(d, -5) ==  .0
+@test cdf(d, -2) ==  .0
+@test cdf(d,  0) ==  .5
+@test cdf(d, +2) == 1.0
+@test cdf(d, +5) == 1.0
+
+@test quantile(d,  .0) == -2.0
+@test quantile(d,  .5) ==   .0
+@test quantile(d, 1.0) == +2.0


### PR DESCRIPTION
A simple continuous univariate distribution: https://en.wikipedia.org/wiki/Wigner_semicircle_distribution.

I think it needs more methods and tests, but I'd like to get your quick check before going further.

You will see this distribution in [Wigner's semicircle law](http://mathworld.wolfram.com/WignersSemicircleLaw.html).  Here is a simulation code:
```julia
using Distributions
using PyPlot

function symmat(d, n)
    X = Matrix{Float64}(n, n)
    for i in 1:n, j in i:n
        X[i,j] = X[j,i] = rand(d)
    end
    return X
end

N = 1000
bins = 100
fig, ax = subplots(3, sharex=true, sharey=true)
srand(1234)
for (i, d) in enumerate([Normal(), Uniform(-1, 1), DiscreteUniform(-1, 1)])
    X = symmat(d, N) ./ sqrt(N)
    Λ = eigvals(X)
    ax[i][:hist](Λ, bins=bins, label="eigen values")
    semicircle = Semicircle(2 * std(d))
    lo, hi = minimum(semicircle), maximum(semicircle)
    xs = linspace(lo, hi)
    ax[i][:plot](xs, pdf.(semicircle, xs) * (N * (hi - lo) / bins), label="pdf")
    ax[i][:set_title](repr(d))
    ax[i][:legend](loc=1)
end
fig[:tight_layout]()
fig[:savefig]("semicircle.png")
```

![semicircle](https://user-images.githubusercontent.com/905683/30597502-21f7240e-9d92-11e7-8ed7-4742da954341.png)
