### PR TITLE
fix infinite loop of Newton's method

### DIFF
--- a/src/quantilealgs.jl
+++ b/src/quantilealgs.jl
@@ -35,7 +35,7 @@ function quantile_newton(d::ContinuousUnivariateDistribution, p::Real, xs::Real=
     T = typeof(x)
     if 0 < p < 1
         x0 = T(xs)
-        while abs(x-x0) >= max(abs(x),abs(x0)) * tol
+        while abs(x-x0) > max(abs(x),abs(x0)) * tol
             x0 = x
             x = x0 + (p - cdf(d, x0)) / pdf(d, x0)
         end
@@ -54,7 +54,7 @@ function cquantile_newton(d::ContinuousUnivariateDistribution, p::Real, xs::Real
     T = typeof(x)
     if 0 < p < 1
         x0 = T(xs)
-        while abs(x-x0) >= max(abs(x),abs(x0)) * tol
+        while abs(x-x0) > max(abs(x),abs(x0)) * tol
             x0 = x
             x = x0 + (ccdf(d, x0)-p) / pdf(d, x0)
         end

--- a/test/quantile_newton.jl
+++ b/test/quantile_newton.jl
@@ -1,0 +1,6 @@
+using Distributions
+using Base.Test
+
+d = Normal()
+@test Distributions.quantile_newton(d, 0.5) == quantile(d, 0.5)
+@test Distributions.cquantile_newton(d, 0.5) == cquantile(d, 0.5)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,9 @@ tests = [
     "gradlogpdf",
     "truncate",
     "noncentralt",
-    "locationscale"]
+    "locationscale",
+    "quantile_newton",
+]
 
 print_with_color(:blue, "Running tests:\n")
 


### PR DESCRIPTION
quantile_newton and cquantile_newton find a quantile of a distribution
using Newton's method. However, their convergence will never be
satisfied when the initial point and the mode are the same. For example,
quantile_newton(Normal(0, 1), 0.5) will result in an infinite loop. This
patch fixes the problem by relaxing the convergence criterion.

This must be merged before #665.