### PR TITLE
Fix #671

### DIFF
--- a/src/samplers/categorical.jl
+++ b/src/samplers/categorical.jl
@@ -28,7 +28,7 @@ end
 struct AliasTable <: Sampleable{Univariate,Discrete}
     accept::Vector{Float64}
     alias::Vector{Int}
-    isampler::RangeGeneratorInt{Int,UInt}
+    isampler::RangeGeneratorInt{UInt,UInt}
 end
 ncategories(s::AliasTable) = length(s.accept)
 
@@ -51,4 +51,3 @@ end
 rand(s::AliasTable) = rand(Base.Random.GLOBAL_RNG, s)
 
 show(io::IO, s::AliasTable) = @printf(io, "AliasTable with %d entries", ncategories(s))
-


### PR DESCRIPTION
Looks like the issue in #671 is that #645 was written and tested before #655, but merged afterwards, so the signed-ness conflict between the two PRs (stemming from https://github.com/JuliaStats/Distributions.jl/blob/master/src/samplers/categorical.jl#L31 vs https://github.com/JuliaStats/Distributions.jl/blob/master/src/samplers/categorical.jl#L41) never came up until later. This should align the assumptions.

Probably worth a close review as I've been away from this for a while and might have missed an implication of the change. The 0.6 tests pass, at least.