### PR TITLE
Stop exporting `pmf`.

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -199,8 +199,6 @@ export
     loglikelihood,      # log probability of array of IID draws
     logpdf,             # log probability density
     logpdf!,            # evaluate log pdf to provided storage
-    logpmf,             # log probability mass
-    logpmf!,            # evaluate log pmf to provided storage
 
     invscale,           # Inverse scale parameter
     sqmahal,            # squared Mahalanobis distance to Gaussian center
@@ -224,7 +222,6 @@ export
     params!,            # provide storage space to calculate the tuple of parameters for a multivariate distribution like mvlognormal
     partype,            # returns a type large enough to hold all of a distribution's parameters' element types
     pdf,                # probability density function (ContinuousDistribution)
-    pmf,                # probability mass function (DiscreteDistribution)
     probs,              # Get the vector of probabilities
     probval,            # The pdf/pmf value for a uniform distribution
     quantile,           # inverse of cdf (defined for p in (0,1))

--- a/src/functionals.jl
+++ b/src/functionals.jl
@@ -13,7 +13,7 @@ end
 
 ## Assuming that discrete distributions only take integer values.
 function expectation(distr::DiscreteUnivariateDistribution, g::Function, epsilon::Real)
-    f = x->pmf(distr,x)
+    f = x->pdf(distr,x)
     (leftEnd, rightEnd) = getEndpoints(distr, epsilon)
     sum(map(x -> f(x)*g(x), leftEnd:rightEnd))
 end

--- a/test/binomial.jl
+++ b/test/binomial.jl
@@ -23,3 +23,7 @@ for (p, n) in [(0.6, 10), (0.8, 6), (0.5, 40), (0.04, 20), (1., 100), (0., 10), 
     end
 
 end
+
+# Test calculation of expectation value for Binomial distribution
+@test Distributions.expectation(Binomial(6), identity) ≈ 3.0
+@test Distributions.expectation(Binomial(10, 0.2), x->-x) ≈ -2.0


### PR DESCRIPTION
The `pmf` function is exported in `Distributions.jl` but not defined anywhere. If I understand correctly, there is a move towards using `pdf` for discrete as well as continuous distributions and this name should no longer be exported.