### PR TITLE
fix mean and var of trunc normal

### DIFF
--- a/src/truncated/normal.jl
+++ b/src/truncated/normal.jl
@@ -97,6 +97,8 @@ function mean(d::Truncated{Normal{T},Continuous}) where T <: Real
     μ = mean(d0)
     σ = std(d0)
     if isfinite(d.lower) && isfinite(d.upper) && isfinite(μ) && isfinite(σ)
+        # avoids loss of significance when truncation is far from μ.
+        # See https://github.com/cossio/TruncatedNormal.jl/blob/master/notes/normal.pdf.
         _tnmean(d.lower, d.upper, μ, σ)
     else
         a = (d.lower - μ) / σ
@@ -110,6 +112,8 @@ function var(d::Truncated{Normal{T},Continuous}) where T <: Real
     μ = mean(d0)
     σ = std(d0)
     if isfinite(d.lower) && isfinite(d.upper) && isfinite(μ) && isfinite(σ)
+        # avoids loss of significance when truncation is far from μ.
+        # See https://github.com/cossio/TruncatedNormal.jl/blob/master/notes/normal.pdf.
         _tnvar(d.lower, d.upper, μ, σ)
     else
         a = (d.lower - μ) / σ

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ tests = [
     "quantile_newton",
     "semicircle",
     "qq",
+    "truncnormal",
 ]
 
 print_with_color(:blue, "Running tests:\n")

--- a/test/truncnormal.jl
+++ b/test/truncnormal.jl
@@ -1,0 +1,9 @@
+using Base.Test
+using Distributions
+
+@testset "Truncated normal, mean and variance" begin
+    d = Distributions.TruncatedNormal(0,1,100,115); @test mean(d) ≈ 100.00999800099926070518490239457545847490332879043
+    d = Distributions.TruncatedNormal(0,1,50,70); @test var(d) ≈ 0.00039904318680389954790992722653605933053648912703600
+    d = Distributions.TruncatedNormal(-2,3,50,70); @test mean(d) ≈ 50.171943499898757645751683644632860837133138152489
+    d = Distributions.TruncatedNormal(-2,3,50,70); @test var(d) ≈ 0.029373438107168350377591231295634273607812172191712
+end


### PR DESCRIPTION
The previous implementation had trouble when the truncation ocurred away from the mode of the distribution. This commit fixes that.

Fixes https://github.com/JuliaStats/Distributions.jl/issues/690.

See https://github.com/cossio/TruncatedNormal.jl/blob/master/notes/normal.pdf for explanation.

Test values were obtained with arbitrary precision in Mathematica.