### PR TITLE
Negative scale in location scale

### DIFF
--- a/src/univariate/continuous/locationscale.jl
+++ b/src/univariate/continuous/locationscale.jl
@@ -23,7 +23,7 @@ struct LocationScale{T<:Real, D<:ContinuousUnivariateDistribution} <: Continuous
     σ::T
     ρ::D
 
-    LocationScale{T,D}(μ::T,σ::T,ρ::D) where {T, D} = (@check_args(LocationScale, σ > zero(σ)); new{T,D}(μ,σ,ρ))
+    LocationScale{T,D}(μ::T,σ::T,ρ::D) where {T, D} = new{T,D}(μ,σ,ρ)
 end
 
 LocationScale(μ::T,σ::T,ρ::D) where {T<:Real, D<:ContinuousUnivariateDistribution} = LocationScale{T,D}(μ,σ,ρ)


### PR DESCRIPTION
Scale should be allowed to be negative in location scale family. 

e.g. Lets say I have a random variable X= -10X + 3 where X is gamma(2,2).  This should be 

```julia
LocationScale(3.0, -10.0, Gamma(2.0, 2.0))
```

Currently throws argument error