### PR TITLE
RFC: Officially allow/document overriding distribution support type

### DIFF
--- a/docs/src/extends.md
+++ b/docs/src/extends.md
@@ -4,6 +4,8 @@ Whereas this package already provides a large collection of common distributions
 
 Generally, you don't have to implement every API method listed in the documentation. This package provides a series of generic functions that turn a small number of internal methods into user-end API methods. What you need to do is to implement this small set of internal methods for your distributions.
 
+By default, `Discrete` sampleables have support of type `Int` while `Continuous` sampleables have support of type `Float64`. If this assumption does not hold for your new distribution or sampler, or its `ValueSupport` is neither `Discrete` nor `Continuous`, you should implement the `eltype` method in addition to the other methods listed below.
+
 **Note:** the methods need to be implemented are different for distributions of different variate forms.
 
 

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -20,7 +20,7 @@ It has two type parameters that define the kind of samples that can be drawn the
 --- | --- |---
 `Univariate` | a scalar number | A numeric array of arbitrary shape, each element being a sample
 `Multivariate` | a numeric vector | A matrix, each column being a sample
-`Matrixvariate` | a numeric matrix | An array of matrices, each element being a sample matrix  
+`Matrixvariate` | a numeric matrix | An array of matrices, each element being a sample matrix
 
 ### ValueSupport
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -9,9 +9,6 @@ abstract type ValueSupport end
 struct Discrete   <: ValueSupport end
 struct Continuous <: ValueSupport end
 
-Base.eltype(::Type{Discrete}) = Int
-Base.eltype(::Type{Continuous}) = Float64
-
 ## Sampleable
 
 """
@@ -50,7 +47,6 @@ The default element type of a sample. This is the type of elements of the sample
 by the `rand` method. However, one can provide an array of different element types to
 store the samples using `rand!`.
 """
-Base.eltype(s::Sampleable{F,S}) where {F,S} = eltype(S)
 Base.eltype(s::Sampleable{F,Discrete}) where {F} = Int
 Base.eltype(s::Sampleable{F,Continuous}) where {F} = Float64
 

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -485,7 +485,7 @@ function _cwise_logpdf!(r::AbstractMatrix, d::AbstractMixtureModel, X)
         if d isa UnivariateMixture
             view(r,:,i) .= logpdf.(Ref(component(d, i)), X)
         else
-            logpdf!(view(r,:,i), component(d, i), X)            
+            logpdf!(view(r,:,i), component(d, i), X)
         end
     end
     r


### PR DESCRIPTION
Removes strict coupling between continuous/discrete distributions and support types, as discussed in #681.

No actual new code here, just an update to the the docs to flag the assumptions about support types of different distributions and the ability to override the defaults. The `eltype(::Type{<:ValueSupport})` methods are unused and wouldn't be accurate anyways in the case of an override, so they're removed.

This sets the stage for allowing discrete non-integer-support distributions (e.g. #634 and #661).