### PR TITLE
[WIP] Add drop in replacements for Rmath functions

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -222,11 +222,14 @@ export
     params!,            # provide storage space to calculate the tuple of parameters for a multivariate distribution like mvlognormal
     partype,            # returns a type large enough to hold all of a distribution's parameters' element types
     pdf,                # probability density function (ContinuousDistribution)
+    pnorm,              # Find cumulative probability for a normal distribution
     probs,              # Get the vector of probabilities
     probval,            # The pdf/pmf value for a uniform distribution
+    qnorm,              # inverse of cdf (defined for p in (0,1))
     quantile,           # inverse of cdf (defined for p in (0,1))
     qqbuild,            # build a paired quantiles data structure for qqplots
     rate,               # get the rate parameter
+    rnorm,              # Random generation for the normal distribution
     sampler,            # create a Sampler object for efficient samples
     scale,              # get the scale parameter
     scale!,             # provide storage for the scale parameter (used in multivariate distribution mvlognormal)
@@ -279,6 +282,7 @@ include("conversion.jl")
 include("qq.jl")
 include("estimators.jl")
 include("testutils.jl")
+include("rmath.jl")
 
 # mixture distributions (TODO: moveout)
 include("mixtures/mixturemodel.jl")

--- a/src/rmath.jl
+++ b/src/rmath.jl
@@ -1,0 +1,5 @@
+# Drop-in replacements for some Rmath functions
+
+pnorm(q, mean=0.0, sd=1.0) = cdf(Normal(mean, sd), q)
+qnorm(p, mean=0.0, sd=1.0) = quantile(Normal(mean, sd), p)
+rnorm(n, mean=0.0, sd=1.0) = rand(Normal(mean, sd), n)


### PR DESCRIPTION
Currently exporting : 
`qnorm`,  `pnorm`,  `rnorm`.
