### PR TITLE
Safer log-pmf (logpdf) for BetaBinomial distribution

### DIFF
--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -90,6 +90,14 @@ function pdf(d::BetaBinomial{T}, k::Int) where T
     return numerator / (denominator * chooseinv)
 end
 
+function logpdf(d::BetaBinomial{T}, k::Int) where T
+    n, α, β = d.n, d.α, d.β
+    logbinom = - log1p(n) - lbeta(k + 1, n - k + 1)
+    lognum   = lbeta(k + α, n - k + β)
+    logdenom = lbeta(α, β)
+    logbinom + lognum - logdenom
+end
+
 entropy(d::BetaBinomial) = entropy(Categorical(pdf.(d,support(d))))
 median(d::BetaBinomial) = median(Categorical(pdf.(d,support(d)))) - 1
 mode(d::BetaBinomial) = indmax(pdf.(d,support(d))) - 1


### PR DESCRIPTION
Specialize `logpdf(::UnivariateDistribution,...)` for `BetaBinomial`. Doing `log(pdf(::BetaBinomial))` will not work if `α`, `β` are large, and Poisson approximation is to be avoided.

It makes use of the fact that `binomial(n,k) = 1/((n+1) * beta(k+1, n-k+1)`.