### PR TITLE
Remove Calculus from REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,6 @@
 julia 0.6
 PDMats 0.6.0
 StatsFuns 0.3.1
-Calculus
 StatsBase 0.17.0
 Compat 0.32.0
 QuadGK 0.1.1


### PR DESCRIPTION
It is only used in tests and already in `test/REQUIRE`.