### PR TITLE
Cleanup, docs, 1.0 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ Distributions.jl
 [![Appveyor status](https://ci.appveyor.com/api/projects/status/xqm07gyruflhnha7/branch/master?svg=true)](https://ci.appveyor.com/project/simonbyrne/distributions-jl/branch/master)
 [![Coverage Status](https://coveralls.io/repos/JuliaStats/Distributions.jl/badge.svg?branch=master)](https://coveralls.io/r/JuliaStats/Distributions.jl?branch=master)
 [![](https://img.shields.io/badge/docs-latest-blue.svg)](https://JuliaStats.github.io/Distributions.jl/latest/)
+[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaStats.github.io/Distributions.jl/stable/)
 [![Distributions](http://pkg.julialang.org/badges/Distributions_0.5.svg)](http://pkg.julialang.org/?pkg=Distributions)
 [![Distributions](http://pkg.julialang.org/badges/Distributions_0.6.svg)](http://pkg.julialang.org/?pkg=Distributions)
+[![Distributions](http://pkg.julialang.org/badges/Distributions_0.7.svg)](http://pkg.julialang.org/?pkg=Distributions)
 
 A Julia package for probability distributions and associated functions. Particularly, Distributions implements:
 
@@ -21,5 +23,5 @@ A Julia package for probability distributions and associated functions. Particul
 
 #### Resources
 
-* **Documentation**: <https://JuliaStats.github.io/Distributions.jl/latest/>
+* **Documentation**: <https://JuliaStats.github.io/Distributions.jl/stable/>
 * **Release Notes**: <https://github.com/JuliaStats/Distributions.jl/blob/master/NEWS.md>

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,5 @@
 using Documenter, Distributions
 import Random: AbstractRNG, rand!
-import Statistics: mean, var, std
-import StatsBase: entropy, kurtosis, skewness
 
 makedocs(
     format = :html,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,7 @@
 using Documenter, Distributions
+import Random: AbstractRNG, rand!
+import Statistics: mean, var, std
+import StatsBase: entropy, kurtosis, skewness
 
 makedocs(
     format = :html,
@@ -21,7 +24,7 @@ makedocs(
 deploydocs(
     repo = "github.com/JuliaStats/Distributions.jl.git",
     target = "build",
-    julia  = "0.6",
+    julia  = "1.0",
     deps = nothing,
     make = nothing
 )

--- a/docs/src/extends.md
+++ b/docs/src/extends.md
@@ -120,9 +120,9 @@ It is also recommended that one also implements the following statistics functio
 - [`var(d::UnivariateDistribution)`](@ref)
 - [`modes(d::UnivariateDistribution)`](@ref)
 - [`mode(d::UnivariateDistribution)`](@ref)
-- [`StatsBase.skewness(d::UnivariateDistribution)`](@ref)
-- [`StatsBase.kurtosis(d::Distribution, ::Bool)`](@ref)
-- [`StatsBase.entropy(d::UnivariateDistribution, ::Real)`](@ref)
+- [`skewness(d::UnivariateDistribution)`](@ref)
+- [`kurtosis(d::Distribution, ::Bool)`](@ref)
+- [`entropy(d::UnivariateDistribution, ::Real)`](@ref)
 - [`mgf(d::UnivariateDistribution, ::Any)`](@ref)
 - [`cf(d::UnivariateDistribution, ::Any)`](@ref)
 

--- a/docs/src/multivariate.md
+++ b/docs/src/multivariate.md
@@ -89,7 +89,6 @@ location!{D<:Distributions.AbstractMvLogNormal}(::Type{D},s::Symbol,m::AbstractV
 scale{D<:Distributions.AbstractMvLogNormal}(::Type{D},s::Symbol,m::AbstractVector,S::AbstractMatrix)
 scale!{D<:Distributions.AbstractMvLogNormal}(::Type{D},s::Symbol,m::AbstractVector,S::AbstractMatrix,Σ::AbstractMatrix)
 params{D<:Distributions.AbstractMvLogNormal}(::Type{D},m::AbstractVector,S::AbstractMatrix)
-params{D<:Distributions.AbstractMvLogNormal}(::Type{D},m::AbstractVector,S::AbstractMatrix)
 ```
 
 ## Internal Methods (for creating you own multivariate distribution)

--- a/docs/src/truncate.md
+++ b/docs/src/truncate.md
@@ -1,6 +1,6 @@
 # Truncated Distributions
 
-The package provides a type, named `Truncated`, to represented truncated distributions, which is defined as below:
+The package provides the `Truncated` type to represented truncated distributions, which is defined as below:
 
 ```julia
 struct Truncated{D<:UnivariateDistribution,S<:ValueSupport} <: Distribution{Univariate,S}

--- a/docs/src/univariate.md
+++ b/docs/src/univariate.md
@@ -11,14 +11,18 @@ const ContinuousUnivariateDistribution = Distribution{Univariate, Continuous}
 
 ## Common Interface
 
-A series of methods are implemented for each univariate distribution, which provide useful functionalities such as moment computation, pdf evaluation, and sampling (*i.e.* random number generation).
+A series of methods are implemented for each univariate distribution, which provide
+useful functionalities such as moment computation, pdf evaluation, and sampling
+(*i.e.* random number generation).
 
 ### Parameter Retrieval
 
+**Note:** `params` are defined for all univariate distributions, while other parameter
+retrieval methods are only defined for those distributions for which these parameters make sense.
+See below for details.
+
 ```@docs
 params(::UnivariateDistribution)
-succprob(::UnivariateDistribution)
-failprob(::UnivariateDistribution)
 scale(::UnivariateDistribution)
 location(::UnivariateDistribution)
 shape(::UnivariateDistribution)
@@ -27,9 +31,6 @@ ncategories(::UnivariateDistribution)
 ntrials(::UnivariateDistribution)
 dof(::UnivariateDistribution)
 ```
-
-**Note:** `params` are defined for all univariate distributions, while other parameter retrieval methods are only defined for those distributions for which these parameters make sense. See below for details.
-
 
 ### Computation of statistics
 
@@ -69,24 +70,6 @@ cquantile(::UnivariateDistribution, ::Real)
 invlogcdf(::UnivariateDistribution, ::Real)
 invlogccdf(::UnivariateDistribution, ::Real)
 ```
-
-### Vectorized evaluation
-
-Vectorized computation and inplace vectorized computation are supported for the following functions:
-
-* [`pdf`](@ref)
-* [`logpdf`](@ref)
-* [`cdf`](@ref)
-* [`logcdf`](@ref)
-* [`ccdf`](@ref)
-* [`logccdf`](@ref)
-* [`quantile`](@ref)
-* [`cquantile`](@ref)
-* [`invlogcdf`](@ref)
-* [`invlogccdf`](@ref)
-
-For example, when `x` is an array, then `r = pdf(d, x)` returns an array `r` of the same size, such that `r[i] = pdf(d, x[i])`. One can also use `pdf!` to write results to pre-allocated storage, as `pdf!(r, d, x)`.
-
 
 ### Sampling (Random number generation)
 ```@docs
@@ -146,6 +129,8 @@ Weibull
 
 ```@docs
 Bernoulli
+succprob
+failprob
 BetaBinomial
 Binomial
 Categorical
@@ -157,3 +142,7 @@ Poisson
 PoissonBinomial
 Skellam
 ```
+
+### Vectorized evaluation
+
+Vectorized computation and inplace vectorized computation have been deprecated.

--- a/docs/src/univariate.md
+++ b/docs/src/univariate.md
@@ -32,6 +32,14 @@ ntrials(::UnivariateDistribution)
 dof(::UnivariateDistribution)
 ```
 
+For distributions for which success and failure have a meaning,
+the following methods are defined:
+```@docs
+succprob(::DiscreteUnivariateDistribution)
+failprob(::DiscreteUnivariateDistribution)
+```
+
+
 ### Computation of statistics
 
 ```@docs

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -13,7 +13,7 @@ using Random
 import Random: GLOBAL_RNG, RangeGenerator, rand!, SamplerRangeInt
 
 import Statistics: mean, median, quantile, std, var, cov, cor
-import StatsBase: kurtosis, skewness, entropy, mode, modes, 
+import StatsBase: kurtosis, skewness, entropy, mode, modes,
                   fit, kldivergence, loglikelihood, dof, span,
                   params, params!
 

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -13,8 +13,10 @@ using Random
 import Random: GLOBAL_RNG, RangeGenerator, rand!, SamplerRangeInt
 
 import Statistics: mean, median, quantile, std, var, cov, cor
-import StatsBase: kurtosis, skewness, entropy, mode, modes, fit, kldivergence
-import StatsBase: loglikelihood, dof, span, params, params!
+import StatsBase: kurtosis, skewness, entropy, mode, modes, 
+                  fit, kldivergence, loglikelihood, dof, span,
+                  params, params!
+
 import PDMats: dim, PDMat, invquad
 
 using SpecialFunctions

--- a/src/common.jl
+++ b/src/common.jl
@@ -91,3 +91,17 @@ abstract type IncompleteDistribution end
 
 const DistributionType{D<:Distribution} = Type{D}
 const IncompleteFormulation = Union{DistributionType,IncompleteDistribution}
+
+"""
+    succprob(d::DiscreteUnivariateDistribution)
+
+Get the probability of success.
+"""
+succprob(d::DiscreteUnivariateDistribution)
+
+"""
+    failprob(d::DiscreteUnivariateDistribution)
+
+Get the probability of failure.
+"""
+failprob(d::DiscreteUnivariateDistribution)

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -28,20 +28,6 @@ will construct exactly the same distribution as ``d``.
 params(d::UnivariateDistribution)
 
 """
-    succprob(d::UnivariateDistribution)
-
-Get the probability of success.
-"""
-succprob(d::UnivariateDistribution)
-
-"""
-    failprob(d::UnivariateDistribution)
-
-Get the probability of failure.
-"""
-failprob(d::UnivariateDistribution)
-
-"""
     scale(d::UnivariateDistribution)
 
 Get the scale parameter.

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -255,7 +255,7 @@ isleptokurtic(d::UnivariateDistribution) = kurtosis(d) < 0.0
 
 Return whether `d` is mesokurtic (*i.e* `kurtosis(d) == 0`).
 """
-ismesokurtic(d::UnivariateDistribution) = kurtosis(d) == 0.0
+ismesokurtic(d::UnivariateDistribution) = kurtosis(d) ≈ 0.0
 
 """
     kurtosis(d::UnivariateDistribution)


### PR DESCRIPTION
Add a link to stable documentation, it avoids mismatch between online doc and usage.
Fixes #749 #747 

