### PR TITLE
Add constructors for MvNormal with Symmetric and Diagonal matrices.

### DIFF
--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -206,6 +206,8 @@ function MvNormal(Σ::Cov) where Cov<:AbstractPDMat
 end
 
 MvNormal(μ::Vector{T}, Σ::Matrix{T}) where {T<:Real} = MvNormal(μ, PDMat(Σ))
+MvNormal(μ::Vector{T}, Σ::Union{Symmetric{T}, Hermitian{T}}) where {T<:Real} = MvNormal(μ, PDMat(Σ))
+MvNormal(μ::Vector{T}, Σ::Diagonal{T}) where {T<:Real} = MvNormal(μ, PDiagMat(diag(Σ)))
 MvNormal(μ::Vector{T}, σ::Vector{T}) where {T<:Real} = MvNormal(μ, PDiagMat(abs2.(σ)))
 MvNormal(μ::Vector{T}, σ::T) where {T<:Real} = MvNormal(μ, ScalMat(length(μ), abs2(σ)))
 

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -76,7 +76,6 @@ function test_mvnormal(g::AbstractMvNormal, n_tsamples::Int=10^6)
     @test loglikelihood(g, X) ≈ sum([Distributions._logpdf(g, X[:,i]) for i in 1:size(X, 2)])
 end
 
-
 ###### General Testing
 
 mu = [1., 2., 3.]
@@ -99,7 +98,9 @@ for (T, g, μ, Σ) in [
     (DiagNormalCanon, MvNormalCanon(h, dv), h ./ dv, Matrix(Diagonal(inv.(dv)))),
     (ZeroMeanDiagNormalCanon, MvNormalCanon(dv), zeros(3), Matrix(Diagonal(inv.(dv)))),
     (FullNormalCanon, MvNormalCanon(h, J), J \ h, inv(J)),
-    (ZeroMeanFullNormalCanon, MvNormalCanon(J), zeros(3), inv(J)) ]
+    (ZeroMeanFullNormalCanon, MvNormalCanon(J), zeros(3), inv(J)),
+    (FullNormal, MvNormal(mu, Symmetric(C)), mu, Matrix(Symmetric(C))),
+    (DiagNormal, MvNormal(mu, Diagonal(dv)), mu, Matrix(Diagonal(dv))) ]
 
     println("    testing $(distrname(g))")
 


### PR DESCRIPTION
Fixes #652.