### PR TITLE
complete docstrings

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -14,6 +14,12 @@ Base.eltype(::Type{Continuous}) = Float64
 
 ## Sampleable
 
+"""
+	`Sampleable` is any type able to produce random values.
+	Parametrized by a `VariateForm` defining the dimension of samples
+	and a `ValueSupport` defining the domain of possibly sampled values.
+	Any `Sampleable` implements the `Base.rand` method.
+"""
 abstract type Sampleable{F<:VariateForm,S<:ValueSupport} end
 
 """
@@ -49,8 +55,8 @@ Base.eltype(s::Sampleable{F,Continuous}) where {F} = Float64
 """
     nsamples(s::Sampleable)
 
-The number of samples contained in `A`. Multiple samples are often organized into an array,
-depending on the variate form.
+The number of values contained in one sample of `s`. Multiple samples are often organized
+into an array, depending on the variate form.
 """
 nsamples(t::Type{Sampleable}, x::Any)
 nsamples(::Type{D}, x::Number) where {D<:Sampleable{Univariate}} = 1
@@ -62,6 +68,12 @@ nsamples(::Type{D}, x::Array{Matrix{T}}) where {D<:Sampleable{Matrixvariate},T<:
 
 ## Distribution <: Sampleable
 
+"""
+	`Distribution` is a `Sampleable` generating random values from a probability
+	distribution. Distributions define a Probability Distribution Function (PDF)
+	to implement with `pdf` and a Cumulated Distribution Function (CDF) to implement
+	with `cdf`.
+"""
 abstract type Distribution{F<:VariateForm,S<:ValueSupport} <: Sampleable{F,S} end
 
 const UnivariateDistribution{S<:ValueSupport}   = Distribution{Univariate,S}

--- a/src/common.jl
+++ b/src/common.jl
@@ -15,10 +15,12 @@ Base.eltype(::Type{Continuous}) = Float64
 ## Sampleable
 
 """
-	`Sampleable` is any type able to produce random values.
-	Parametrized by a `VariateForm` defining the dimension of samples
-	and a `ValueSupport` defining the domain of possibly sampled values.
-	Any `Sampleable` implements the `Base.rand` method.
+    `Sampleable{F<:VariateForm,S<:ValueSupport}`
+
+`Sampleable` is any type able to produce random values.
+Parametrized by a `VariateForm` defining the dimension of samples
+and a `ValueSupport` defining the domain of possibly sampled values.
+Any `Sampleable` implements the `Base.rand` method.
 """
 abstract type Sampleable{F<:VariateForm,S<:ValueSupport} end
 
@@ -66,13 +68,13 @@ nsamples(::Type{D}, x::AbstractMatrix) where {D<:Sampleable{Multivariate}} = siz
 nsamples(::Type{D}, x::Number) where {D<:Sampleable{Matrixvariate}} = 1
 nsamples(::Type{D}, x::Array{Matrix{T}}) where {D<:Sampleable{Matrixvariate},T<:Number} = length(x)
 
-## Distribution <: Sampleable
-
 """
-	`Distribution` is a `Sampleable` generating random values from a probability
-	distribution. Distributions define a Probability Distribution Function (PDF)
-	to implement with `pdf` and a Cumulated Distribution Function (CDF) to implement
-	with `cdf`.
+    Distribution{F<:VariateForm,S<:ValueSupport} <: Sampleable{F,S}
+
+`Distribution` is a `Sampleable` generating random values from a probability
+distribution. Distributions define a Probability Distribution Function (PDF)
+to implement with `pdf` and a Cumulated Distribution Function (CDF) to implement
+with `cdf`.
 """
 abstract type Distribution{F<:VariateForm,S<:ValueSupport} <: Sampleable{F,S} end
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -15,7 +15,7 @@ Base.eltype(::Type{Continuous}) = Float64
 ## Sampleable
 
 """
-    `Sampleable{F<:VariateForm,S<:ValueSupport}`
+    Sampleable{F<:VariateForm,S<:ValueSupport}
 
 `Sampleable` is any type able to produce random values.
 Parametrized by a `VariateForm` defining the dimension of samples


### PR DESCRIPTION
Complete some lacking docstring, especially in the `common.jl` interface, core info should be available from the REPL. Fixes #744 