### PR TITLE
Base.extrema methods for UnivariateDistribution and for RealInterval (take 2)

### DIFF
--- a/docs/src/univariate.md
+++ b/docs/src/univariate.md
@@ -45,6 +45,7 @@ failprob(::DiscreteUnivariateDistribution)
 ```@docs
 maximum(::UnivariateDistribution)
 minimum(::UnivariateDistribution)
+extrema(::UnivariateDistribution)
 mean(::UnivariateDistribution)
 var(::UnivariateDistribution)
 std(::UnivariateDistribution)

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -4,7 +4,7 @@ using StatsBase, PDMats, StatsFuns, Statistics
 
 import QuadGK: quadgk
 import Base: size, eltype, length, convert, show, getindex, rand
-import Base: sum, maximum, minimum, +, -
+import Base: sum, maximum, minimum, extrema, +, -
 import Base.Math: @horner
 
 using LinearAlgebra, Printf

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -9,6 +9,7 @@ end
 
 minimum(r::RealInterval) = r.lb
 maximum(r::RealInterval) = r.ub
+extrema(r::RealInterval) = (r.lb, r.ub)
 in(x::Real, r::RealInterval) = (r.lb <= Float64(x) <= r.ub)
 
 isbounded(d::Union{D,Type{D}}) where {D<:UnivariateDistribution} = isupperbounded(d) && islowerbounded(d)
@@ -77,18 +78,25 @@ Get the degrees of freedom.
 dof(d::UnivariateDistribution)
 
 """
-    minimum(d::Distribution)
+    minimum(d::UnivariateDistribution)
 
 Return the minimum of the support of `d`.
 """
 minimum(d::UnivariateDistribution)
 
 """
-    maximum(d::Distribution)
+    maximum(d::UnivariateDistribution)
 
 Return the maximum of the support of `d`.
 """
 maximum(d::UnivariateDistribution)
+
+"""
+    extrema(d::UnivariateDistribution)
+
+Return the minimum and maximum of the support of `d` as a 2-tuple.
+"""
+extrema(d::UnivariateDistribution) = (minimum(d), maximum(d))
 
 """
     insupport(d::UnivariateDistribution, x::Any)

--- a/test/categorical.jl
+++ b/test/categorical.jl
@@ -15,6 +15,7 @@ for p in Vector{Float64}[
     @test probs(d) == p
     @test minimum(d) == 1
     @test maximum(d) == k
+    @test extrema(d) == (1, k)
     @test ncategories(d) == k
 
     c = 0.0
@@ -44,6 +45,7 @@ end
 d = Categorical(4)
 @test minimum(d) == 1
 @test maximum(d) == 4
+@test extrema(d) == (1, 4)
 @test probs(d) == [0.25, 0.25, 0.25, 0.25]
 
 p = ones(10^6) * 1.0e-6

--- a/test/locationscale.jl
+++ b/test/locationscale.jl
@@ -11,6 +11,7 @@ function test_location_scale_normal(μ::Float64,σ::Float64,μD::Float64,σD::Fl
 
     @test minimum(d) == minimum(dref)
     @test maximum(d) == maximum(dref)
+    @test extrema(d) == (minimum(d), maximum(d))
 
     #### Conversions
 

--- a/test/mixture.jl
+++ b/test/mixture.jl
@@ -151,10 +151,12 @@ test_mixture(g_u, 1000, 10^6)
 test_params(g_u)
 @test minimum(g_u) == -Inf
 @test maximum(g_u) == Inf
+@test extrema(g_u) == (-Inf, Inf)
 
 g_u = MixtureModel([TriangularDist(-1,2,0),TriangularDist(-.5,3,1),TriangularDist(-2,0,-1)])
 @test minimum(g_u) == -2.0
 @test maximum(g_u) == 3.0
+@test extrema(g_u) == (-2.0, 3.0)
 @test insupport(g_u, 2.5) == true
 @test insupport(g_u, 3.5) == false
 
@@ -165,6 +167,7 @@ test_mixture(g_u, 1000, 10^6)
 test_params(g_u)
 @test minimum(g_u) == -Inf
 @test maximum(g_u) == Inf
+@test extrema(g_u) == (-Inf, Inf)
 
 println("    testing MultivariateMixture")
 g_m = MixtureModel(

--- a/test/poissonbinomial.jl
+++ b/test/poissonbinomial.jl
@@ -14,6 +14,7 @@ for (p, n) in [(0.8, 6), (0.5, 10), (0.04, 20)]
     @test isa(d, PoissonBinomial)
     @test minimum(d) == 0
     @test maximum(d) == n
+    @test extrema(d) == (0, n)
     @test ntrials(d) == n
     @test entropy(d)  ≈ entropy(dref)
     @test median(d)   ≈ median(dref)

--- a/test/semicircle.jl
+++ b/test/semicircle.jl
@@ -7,6 +7,7 @@ d = Semicircle(2.0)
 
 @test minimum(d) == -2.0
 @test maximum(d) == +2.0
+@test extrema(d) == (-2.0, 2.0)
 
 @test mean(d)     ==  .0
 @test var(d)      == 1.0

--- a/test/truncate.jl
+++ b/test/truncate.jl
@@ -64,6 +64,7 @@ function verify_and_test(d::UnivariateDistribution, dct::Dict, n_tsamples::Int)
     # verify stats
     @test minimum(d) ≈ max(_json_value(dct["minimum"]),d.lower)
     @test maximum(d) ≈ min(_json_value(dct["maximum"]),d.upper)
+    @test extrema(d) == (minimum(d), maximum(d))
 
     # verify logpdf and cdf at certain points
     pts = dct["points"]

--- a/test/univariates.jl
+++ b/test/univariates.jl
@@ -86,6 +86,7 @@ function verify_and_test(D::Union{Type,Function}, d::UnivariateDistribution, dct
         @assert isa(f, Function)
         @test isapprox(f(d), expect_v; atol=1e-12, rtol=1e-8, nans=true)
     end
+    @test extrema(d) == (minimum(d), maximum(d))
 
     # verify logpdf and cdf at certain points
     pts = dct["points"]

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -6,6 +6,7 @@ using Test, LinearAlgebra
 r = RealInterval(1.5, 4.0)
 @test minimum(r) == 1.5
 @test maximum(r) == 4.0
+@test extrema(r) == (1.5, 4.0)
 
 @test partype(Gamma(1, 2)) == Float64
 @test partype(Gamma(1.1, 2)) == Float64


### PR DESCRIPTION
Replaces #756, which needlessly created methods for specific `UnivariateDistribution` types.
Includes tests and docs.