### PR TITLE
fix missing broadcast sqrt in MvTDist rand

### DIFF
--- a/src/multivariate/mvtdist.jl
+++ b/src/multivariate/mvtdist.jl
@@ -173,7 +173,7 @@ function _rand!(d::GenericMvTDist, x::AbstractMatrix{T}) where T<:Real
     y = Matrix{T}(undef, 1, cols)
     unwhiten!(d.Σ, randn!(x))
     rand!(chisqd, y)
-    y = sqrt(y/(d.df))
+    y = sqrt.(y/(d.df))
     broadcast!(/, x, x, y)
     if !d.zeromean
         broadcast!(+, x, x, d.μ)

--- a/test/mvtdist.jl
+++ b/test/mvtdist.jl
@@ -41,3 +41,6 @@ d = GenericMvTDist(1, Array{Float32}(mu), PDMat(Array{Float32}(Sigma)))
 @test typeof(convert(GenericMvTDist{Float64}, d)) == typeof(GenericMvTDist(1, mu, PDMat(Sigma)))
 @test typeof(convert(GenericMvTDist{Float64}, d.df, d.dim, d.zeromean, d.μ, d.Σ)) == typeof(GenericMvTDist(1, mu, PDMat(Sigma)))
 @test partype(d) == Float32
+
+@test size(rand(MvTDist(1., mu, Sigma))) == (2,)
+@test size(rand(MvTDist(1., mu, Sigma), 10)) == (2,10)


### PR DESCRIPTION
This adds tests for `rand` for `MvTDist` (the size of the result at least) and fixes a bug in the MvTDist rand method where `sqrt(::Vector)` should be `sqrt.(::Vector)`.