### PR TITLE
Add support for LinearAlgebra.I fixes #784

### DIFF
--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -219,7 +219,10 @@ function MvNormal(μ::Vector{T}, σ::Real) where T<:Real
     R = Base.promote_eltype(μ, σ)
     MvNormal(convert(AbstractArray{R}, μ), R(σ))
 end
-
+function MvNormal(μ::Vector{T}, σ::UniformScaling{S}) where {T<:Real,S<:Real}
+    R = Base.promote_eltype(μ, σ.λ)
+    MvNormal(convert(AbstractArray{R}, μ), R(σ.λ))
+end
 MvNormal(Σ::Matrix{T}) where {T<:Real} = MvNormal(PDMat(Σ))
 MvNormal(σ::Vector{T}) where {T<:Real} = MvNormal(PDiagMat(abs2.(σ)))
 MvNormal(d::Int, σ::Real) = MvNormal(ScalMat(d, abs2(σ)))

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -150,6 +150,9 @@ d = MvNormalCanon(Array{Float32}(mu), Array{Float32}(h), PDMat(Array{Float32}(J)
 @test typeof(convert(MvNormalCanon{Float64}, d)) == typeof(MvNormalCanon(mu, h, PDMat(J)))
 @test typeof(convert(MvNormalCanon{Float64}, d.μ, d.h, d.J)) == typeof(MvNormalCanon(mu, h, PDMat(J)))
 
+@test typeof(MvNormal(mu, I)) == typeof(MvNormal(mu, 1))
+@test typeof(MvNormal(mu, 3 * I)) == typeof(MvNormal(mu, 3))
+@test typeof(MvNormal(mu, 0.1f0 * I)) == typeof(MvNormal(mu, 0.1))
 ##### MLE
 
 # a slow but safe way to implement MLE for verification


### PR DESCRIPTION
gives a simple constructor overload for `MvNormal` to support `LinearAlgebra.I` for setting the sigma matrix.