### PR TITLE
MvNormal mean vector type constraints

### DIFF
--- a/src/multivariate/mvlognormal.jl
+++ b/src/multivariate/mvlognormal.jl
@@ -161,7 +161,7 @@ Mean vector ``\\boldsymbol{\\mu}`` and covariance matrix ``\\boldsymbol{\\Sigma}
 underlying normal distribution are known as the *location* and *scale*
 parameters of the corresponding lognormal distribution.
 """
-struct MvLogNormal{T<:Real,Cov<:AbstractPDMat,Mean<:Union{Vector, ZeroVector}} <: AbstractMvLogNormal
+struct MvLogNormal{T<:Real,Cov<:AbstractPDMat,Mean<:Union{AbstractVector, ZeroVector}} <: AbstractMvLogNormal
     normal::MvNormal{T,Cov,Mean}
 end
 

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -174,7 +174,7 @@ isotropic covariance as `abs2(sig) * eye(d)`.
 **Note:** The constructor will choose an appropriate covariance form internally, so that
 special structure of the covariance can be exploited.
 """
-struct MvNormal{T<:Real,Cov<:AbstractPDMat,Mean<:Union{Vector, ZeroVector}} <: AbstractMvNormal
+struct MvNormal{T<:Real,Cov<:AbstractPDMat,Mean<:Union{AbstractVector, ZeroVector}} <: AbstractMvNormal
     μ::Mean
     Σ::Cov
 end

--- a/src/multivariate/mvnormalcanon.jl
+++ b/src/multivariate/mvnormalcanon.jl
@@ -63,7 +63,7 @@ Construct a multivariate normal distribution of dimension `d`, with zero mean an
 
 **Note:** `MvNormalCanon` share the same set of methods as `MvNormal`.
 """
-struct MvNormalCanon{T<:Real,P<:AbstractPDMat,V<:Union{Vector,ZeroVector}} <: AbstractMvNormal
+struct MvNormalCanon{T<:Real,P<:AbstractPDMat,V<:Union{AbstractVector,ZeroVector}} <: AbstractMvNormal
     μ::V    # the mean vector
     h::V    # potential vector, i.e. inv(Σ) * μ
     J::P    # precision matrix, i.e. inv(Σ)


### PR DESCRIPTION
This PR simply changes the type constraints on mean vector of `MvNormal`, `MvLogNormal`, and `MvNormalCanon` from `Union{Vector, ZeroVector}` to `Union{AbstractVector, ZeroVector}`. This proposal is motivated by some AD-related headaches caused by the current constraints.