### PR TITLE
Make the cdf of an EmpiricalUnivariateDistribution an ECDF

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.7
 PDMats 0.9.0
 StatsFuns 0.3.1
-StatsBase 0.23.0
+StatsBase 0.26.0
 QuadGK 0.1.1
 SpecialFunctions 0.6.0

--- a/src/empirical.jl
+++ b/src/empirical.jl
@@ -7,7 +7,7 @@
 struct EmpiricalUnivariateDistribution <: ContinuousUnivariateDistribution
     values::Vector{Float64}
     support::Vector{Float64}
-    cdf::Function
+    cdf::ECDF
     entropy::Float64
     kurtosis::Float64
     mean::Float64


### PR DESCRIPTION
The `ecdf` function in StatsBase was changed in v0.26.0 to return a callable `ECDF` object rather than a function, but this distribution assumes that the result is a function.

Bandaid fix for #797 pending something more complete like #661.