### PR TITLE
Replace equality with approximate equality in qq tests

### DIFF
--- a/test/qq.jl
+++ b/test/qq.jl
@@ -2,13 +2,13 @@ using Distributions
 using Test
 
 a = qqbuild(collect(1:10), collect(1:10))
-@test a.qx == collect(1.0:10)
-@test a.qy == collect(1.0:10)
+@test a.qx ≈ collect(1.0:10)
+@test a.qy ≈ collect(1.0:10)
 
 a = qqbuild(collect(1:10), Uniform(1,10))
-@test a.qx == collect(2.0:9)
-@test a.qy == collect(2.0:9)
+@test a.qx ≈ collect(2.0:9)
+@test a.qy ≈ collect(2.0:9)
 
 a = qqbuild(Uniform(1,10), collect(1:10))
-@test a.qx == collect(2.0:9)
-@test a.qy == collect(2.0:9)
+@test a.qx ≈ collect(2.0:9)
+@test a.qy ≈ collect(2.0:9)


### PR DESCRIPTION
These tests were failing on my local machine even though the array elements were printing as identical, presumably an issue with floating point rounding error. Replacing `==` with `≈` fixed the problem.