### PR TITLE
Add DiscreteNonParametric NoArgCheck method

### DIFF
--- a/src/univariate/discrete/discretenonparametric.jl
+++ b/src/univariate/discrete/discretenonparametric.jl
@@ -39,6 +39,10 @@ DiscreteNonParametric(vs::Ts, ps::Ps) where {
     T<:Real,P<:Real,Ts<:AbstractVector{T},Ps<:AbstractVector{P}} =
     DiscreteNonParametric{T,P,Ts,Ps}(vs, ps)
 
+DiscreteNonParametric(vs::Ts, ps::Ps, a::NoArgCheck) where {
+    T<:Real,P<:Real,Ts<:AbstractVector{T},Ps<:AbstractVector{P}} =
+    DiscreteNonParametric{T,P,Ts,Ps}(vs, ps, a)
+
 eltype(d::DiscreteNonParametric{T}) where T = T
 
 # Conversion

--- a/src/univariate/discrete/discretenonparametric.jl
+++ b/src/univariate/discrete/discretenonparametric.jl
@@ -70,6 +70,10 @@ probs(d::DiscreteNonParametric)  = d.p
     (support(c1) == support(c2) || all(support(c1) .== support(c2))) &&
     (probs(c1) == probs(c2) || all(probs(c1) .== probs(c2)))
 
+Base.isapprox(c1::D, c2::D) where D<:DiscreteNonParametric =
+    (support(c1) ≈ support(c2) || all(support(c1) .≈ support(c2))) &&
+    (probs(c1) ≈ probs(c2) || all(probs(c1) .≈ probs(c2)))
+
 # Sampling
 
 function rand(d::DiscreteNonParametric{T,P}) where {T,P}

--- a/test/discretenonparametric.jl
+++ b/test/discretenonparametric.jl
@@ -3,6 +3,15 @@ import StatsBase: ProbabilityWeights
 d = DiscreteNonParametric([40., 80., 120., -60.], [.4, .3, .1,  .2])
 println("    testing $d")
 
+@test !(d ≈ DiscreteNonParametric([40., 80, 120, -60], [.4, .3, .1, .2], Distributions.NoArgCheck()))
+@test d ≈ DiscreteNonParametric([-60., 40., 80, 120], [.2, .4, .3, .1], Distributions.NoArgCheck())
+
+# Invalid probability
+@test_throws ArgumentError DiscreteNonParametric([40., 80, 120, -60], [.5, .3, .1, .2])
+
+# Invalid probability, but no arg check
+DiscreteNonParametric([40., 80, 120, -60], [.5, .3, .1, .2], Distributions.NoArgCheck())
+
 Distributions.test_range(d)
 vs = Distributions.get_evalsamples(d, 0.00001)
 Distributions.test_evaluation(d, vs, true)


### PR DESCRIPTION
This allows calling `DiscreteNonParametric(xs, ps, NoArgCheck())` without providing explicit type parameters. My understanding is that we need to keep the type parameters on the inner constructors to support `Categorical` type aliasing.