### PR TITLE
Allow providing an RNG for DiscreteNonParametric sampling

### DIFF
--- a/src/samplers/aliastable.jl
+++ b/src/samplers/aliastable.jl
@@ -15,8 +15,8 @@ function AliasTable(probs::AbstractVector{T}) where T<:Real
 end
 
 function rand(rng::AbstractRNG, s::AliasTable)
-    i = rand(GLOBAL_RNG, s.isampler) % Int
-    u = rand()
+    i = rand(rng, s.isampler) % Int
+    u = rand(rng)
     @inbounds r = u < s.accept[i] ? i : s.alias[i]
     r
 end

--- a/src/samplers/discretenonparametric.jl
+++ b/src/samplers/discretenonparametric.jl
@@ -15,5 +15,7 @@ end
 DiscreteNonParametricSampler(support::S, probs::AbstractVector{<:Real}) where {T<:Real,S<:AbstractVector{T}} =
     DiscreteNonParametricSampler{T,S}(support, probs)
 
-rand(s::DiscreteNonParametricSampler) =
-    (@inbounds v = s.support[rand(s.aliastable)]; v)
+rand(rng::AbstractRNG, s::DiscreteNonParametricSampler) =
+    (@inbounds v = s.support[rand(rng, s.aliastable)]; v)
+
+rand(s::DiscreteNonParametricSampler) = rand(Random.GLOBAL_RNG, s)

--- a/src/samplers/discretenonparametric.jl
+++ b/src/samplers/discretenonparametric.jl
@@ -4,15 +4,19 @@
 Data structure for efficiently sampling from an arbitrary probability mass
 function defined by support `xs` and probabilities `ps`.
 """
-struct DiscreteNonParametricSampler{T<:Real, S<:AbstractVector{T}} <: Sampleable{Univariate,Discrete}
+struct DiscreteNonParametricSampler{T<:Real, S<:AbstractVector{T}, A<:AliasTable} <: Sampleable{Univariate,Discrete}
     support::S
-    aliastable::AliasTable
+    aliastable::A
 
-    DiscreteNonParametricSampler{T,S}(support::S, probs::AbstractVector{<:Real}) where {T<:Real,S<:AbstractVector{T}} =
-        new(support, AliasTable(probs))
+    function DiscreteNonParametricSampler{T,S}(support::S, probs::AbstractVector{<:Real}
+    ) where {T<:Real,S<:AbstractVector{T}}
+        aliastable = AliasTable(probs)
+        new{T,S,typeof(aliastable)}(support, aliastable)
+    end
 end
 
-DiscreteNonParametricSampler(support::S, probs::AbstractVector{<:Real}) where {T<:Real,S<:AbstractVector{T}} =
+DiscreteNonParametricSampler(support::S, probs::AbstractVector{<:Real}
+    ) where {T<:Real,S<:AbstractVector{T}} =
     DiscreteNonParametricSampler{T,S}(support, probs)
 
 rand(rng::AbstractRNG, s::DiscreteNonParametricSampler) =

--- a/src/univariate/discrete/discretenonparametric.jl
+++ b/src/univariate/discrete/discretenonparametric.jl
@@ -68,10 +68,10 @@ probs(d::DiscreteNonParametric)  = d.p
 
 # Sampling
 
-function rand(d::DiscreteNonParametric{T,P}) where {T,P}
+function rand(rng::AbstractRNG, d::DiscreteNonParametric{T,P}) where {T,P}
     x = support(d)
     p = probs(d)
-    draw = rand(P)
+    draw = rand(rng, P)
     cp = zero(P)
     i = 0
     while cp < draw
@@ -79,6 +79,8 @@ function rand(d::DiscreteNonParametric{T,P}) where {T,P}
     end
     x[i]
 end
+
+rand(d::DiscreteNonParametric) = rand(Random.GLOBAL_RNG, d)
 
 sampler(d::DiscreteNonParametric) =
     DiscreteNonParametricSampler(support(d), probs(d))


### PR DESCRIPTION
Enables
```julia
rand(::AbstractRNG, ::DiscreteNonParametric)
rand(::AbstractRNG, ::DiscreteNonParametricSampler)
```
 in addition to the existing methods that default to using `Random.GLOBAL_RNG`.