### PR TITLE
Update NegativeBinomial external link in docstring

### DIFF
--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -24,7 +24,8 @@ failprob(d)     # Get the failure rate, i.e. 1 - p
 
 External links:
 
-* [Negative binomial distribution on Wikipedia](http://en.wikipedia.org/wiki/Negative_binomial_distribution)
+* [Negative binomial distribution on Wolfram](https://reference.wolfram.com/language/ref/NegativeBinomialDistribution.html)
+Note: The definition of the negative binomial distribution in Wolfram is different from the Wikipedia definition.
 
 """
 struct NegativeBinomial{T<:Real} <: DiscreteUnivariateDistribution

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -25,7 +25,7 @@ failprob(d)     # Get the failure rate, i.e. 1 - p
 External links:
 
 * [Negative binomial distribution on Wolfram](https://reference.wolfram.com/language/ref/NegativeBinomialDistribution.html)
-Note: The definition of the negative binomial distribution in Wolfram is different from the Wikipedia definition.
+Note: The definition of the negative binomial distribution in Wolfram is different from the [Wikipedia definition](http://en.wikipedia.org/wiki/Negative_binomial_distribution). In Wikipedia, `r` is the number of failures and `k` is the number of successes.
 
 """
 struct NegativeBinomial{T<:Real} <: DiscreteUnivariateDistribution


### PR DESCRIPTION
As highlighted in #474, the Wikipedia definition of the negative binomial distribution, linked in the docstring, is not consistent with the definition used in Julia. In this PR, I attempt to remove the source of confusion.