### PR TITLE
Allow alternate RNGs to be used on all distributions

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -122,6 +122,16 @@ Get the probability of failure.
 failprob(d::DiscreteUnivariateDistribution)
 
 # Temporary fix to handle RFunctions dependencies
+"""
+    @rand_rdist(::Distribution)
+
+Mark a `Distribution` subtype as requiring RFunction calls. Since these calls
+cannot accept an arbitrary random number generator as an input, this macro
+creates new `rand(::Distribution, n::Int)` and
+`rand!(::Distribution, X::AbstractArray)` functions that call the relevant
+RFunction. Calls using another random number generator still work, but rely on
+a quantile function to operate.
+"""
 macro rand_rdist(D)
     esc(quote
         function rand(d::$D, n::Int)

--- a/src/common.jl
+++ b/src/common.jl
@@ -120,3 +120,17 @@ succprob(d::DiscreteUnivariateDistribution)
 Get the probability of failure.
 """
 failprob(d::DiscreteUnivariateDistribution)
+
+# Temporary fix to identify Rfunctions
+abstract type DiscreteUnivariateRDist <: DiscreteUnivariateDistribution end
+abstract type ContinuousUnivariateRDist <: ContinuousUnivariateDistribution end
+function rand(d::Union{DiscreteUnivariateRDist, ContinuousUnivariateRDist}, n::Int)
+    [rand(d) for i in Base.OneTo(n)]
+end
+function rand!(d::Union{DiscreteUnivariateRDist, ContinuousUnivariateRDist},
+               X::AbstractArray)
+    for i in eachindex(X)
+        X[i] = rand(d)
+    end
+    return X
+end

--- a/src/common.jl
+++ b/src/common.jl
@@ -122,15 +122,16 @@ Get the probability of failure.
 failprob(d::DiscreteUnivariateDistribution)
 
 # Temporary fix to handle RFunctions dependencies
-abstract type DiscreteUnivariateRDist <: DiscreteUnivariateDistribution end
-abstract type ContinuousUnivariateRDist <: ContinuousUnivariateDistribution end
-function rand(d::Union{DiscreteUnivariateRDist, ContinuousUnivariateRDist}, n::Int)
-    [rand(d) for i in Base.OneTo(n)]
-end
-function rand!(d::Union{DiscreteUnivariateRDist, ContinuousUnivariateRDist},
-               X::AbstractArray)
-    for i in eachindex(X)
-        X[i] = rand(d)
-    end
-    return X
+macro rand_rdist(D)
+    esc(quote
+        function rand(d::$D, n::Int)
+            [rand(d) for i in Base.OneTo(n)]
+        end
+        function rand!(d::$D, X::AbstractArray)
+            for i in eachindex(X)
+                X[i] = rand(d)
+            end
+            return X
+        end
+    end)
 end

--- a/src/common.jl
+++ b/src/common.jl
@@ -121,7 +121,7 @@ Get the probability of failure.
 """
 failprob(d::DiscreteUnivariateDistribution)
 
-# Temporary fix to identify Rfunctions
+# Temporary fix to handle RFunctions dependencies
 abstract type DiscreteUnivariateRDist <: DiscreteUnivariateDistribution end
 abstract type ContinuousUnivariateRDist <: ContinuousUnivariateDistribution end
 function rand(d::Union{DiscreteUnivariateRDist, ContinuousUnivariateRDist}, n::Int)

--- a/src/genericrand.jl
+++ b/src/genericrand.jl
@@ -38,13 +38,25 @@ function _rand!(s::Sampleable{Univariate}, A::AbstractArray)
     end
     return A
 end
+function _rand!(rng::AbstractRNG, s::Sampleable{Univariate}, A::AbstractArray)
+    for i in 1:length(A)
+        @inbounds A[i] = rand(rng, s)
+    end
+    return A
+end
 rand!(s::Sampleable{Univariate}, A::AbstractArray) = _rand!(s, A)
+rand!(rng::AbstractRNG, s::Sampleable{Univariate}, A::AbstractArray) =
+    _rand!(rng, s, A)
 
 rand(s::Sampleable{Univariate}, dims::Dims) =
     _rand!(s, Array{eltype(s)}(undef, dims))
+rand(rng::AbstractRNG, s::Sampleable{Univariate}, dims::Dims) =
+    _rand!(rng, s, Array{eltype(s)}(undef, dims))
 
 rand(s::Sampleable{Univariate}, dims::Int...) =
     _rand!(s, Array{eltype(s)}(undef, dims))
+rand(rng::AbstractRNG, s::Sampleable{Univariate}, dims::Int...) =
+    _rand!(rng, s, Array{eltype(s)}(undef, dims))
 
 
 # multivariate
@@ -55,17 +67,33 @@ function _rand!(s::Sampleable{Multivariate}, A::AbstractMatrix)
     end
     return A
 end
+function _rand!(rng::AbstractRNG, s::Sampleable{Multivariate}, A::AbstractMatrix)
+    for i = 1:size(A,2)
+        _rand!(rng, s, view(A,:,i))
+    end
+    return A
+end
 
 function rand!(s::Sampleable{Multivariate}, A::AbstractVector)
     length(A) == length(s) ||
         throw(DimensionMismatch("Output size inconsistent with sample length."))
     _rand!(s, A)
 end
+function rand!(rng::AbstractRNG, s::Sampleable{Multivariate}, A::AbstractVector)
+    length(A) == length(s) ||
+        throw(DimensionMismatch("Output size inconsistent with sample length."))
+    _rand!(rng, s, A)
+end
 
 function rand!(s::Sampleable{Multivariate}, A::AbstractMatrix)
     size(A,1) == length(s) ||
         throw(DimensionMismatch("Output size inconsistent with sample length."))
     _rand!(s, A)
+end
+function rand!(rng::AbstractRNG, s::Sampleable{Multivariate}, A::AbstractMatrix)
+    size(A,1) == length(s) ||
+        throw(DimensionMismatch("Output size inconsistent with sample length."))
+    _rand!(rng, s, A)
 end
 
 rand(s::Sampleable{Multivariate}) =

--- a/src/genericrand.jl
+++ b/src/genericrand.jl
@@ -1,22 +1,33 @@
 ### Generic rand methods
 
 """
-    rand(s::Sampleable)
+    rand([rng::AbstractRNG,] s::Sampleable)
 
 Generate one sample for `s`.
 
-    rand(s::Sampleable, n::Int)
+    rand([rng::AbstractRNG,] s::Sampleable, n::Int)
 
 Generate `n` samples from `s`. The form of the returned object depends on the variate form of `s`:
 
 - When `s` is univariate, it returns a vector of length `n`.
 - When `s` is multivariate, it returns a matrix with `n` columns.
 - When `s` is matrix-variate, it returns an array, where each element is a sample matrix.
+
+    rand([rng::AbstractRNG,] s::Sampleable, dim1::Int, dim2::Int...)
+    rand([rng::AbstractRNG,] s::Sampleable, dims::Dims)
+
+Generate an array of samples from `s` whose shape is determined by the given
+dimensions.
 """
-rand(s::Sampleable)
+rand(s::Sampleable) = rand(GLOBAL_RNG, s)
+rand(s::Sampleable, dims::Dims) = rand(GLOBAL_RNG, s, dims)
+rand(s::Sampleable, dim1::Int, moredims::Int...) =
+    rand(GLOBAL_RNG, s, (dim1, moredims...))
+rand(rng::AbstractRNG, s::Sampleable, dim1::Int, moredims::Int...) =
+    rand(rng, s, (dim1, moredims...))
 
 """
-    rand!(s::Sampleable, A::AbstractArray)
+    rand!([rng::AbstractRNG,] s::Sampleable, A::AbstractArray)
 
 Generate one or multiple samples from `s` to a pre-allocated array `A`. `A` should be in the
 form as specified above. The rules are summarized as below:
@@ -28,101 +39,17 @@ form as specified above. The rules are summarized as below:
 - When `s` is matrix-variate, `A` can be a matrix to store one sample, or an array of
   matrices with each element for a sample matrix.
 """
-rand!(s::Sampleable, A::AbstractArray)
-
-# univariate
-
-function _rand!(s::Sampleable{Univariate}, A::AbstractArray)
-    for i in 1:length(A)
-        @inbounds A[i] = rand(s)
-    end
-    return A
-end
-function _rand!(rng::AbstractRNG, s::Sampleable{Univariate}, A::AbstractArray)
-    for i in 1:length(A)
-        @inbounds A[i] = rand(rng, s)
-    end
-    return A
-end
-rand!(s::Sampleable{Univariate}, A::AbstractArray) = _rand!(s, A)
-rand!(rng::AbstractRNG, s::Sampleable{Univariate}, A::AbstractArray) =
-    _rand!(rng, s, A)
-
-rand(s::Sampleable{Univariate}, dims::Dims) =
-    _rand!(s, Array{eltype(s)}(undef, dims))
-rand(rng::AbstractRNG, s::Sampleable{Univariate}, dims::Dims) =
-    _rand!(rng, s, Array{eltype(s)}(undef, dims))
-
-rand(s::Sampleable{Univariate}, dims::Int...) =
-    _rand!(s, Array{eltype(s)}(undef, dims))
-rand(rng::AbstractRNG, s::Sampleable{Univariate}, dims::Int...) =
-    _rand!(rng, s, Array{eltype(s)}(undef, dims))
-
-
-# multivariate
-
-function _rand!(s::Sampleable{Multivariate}, A::AbstractMatrix)
-    for i = 1:size(A,2)
-        _rand!(s, view(A,:,i))
-    end
-    return A
-end
-function _rand!(rng::AbstractRNG, s::Sampleable{Multivariate}, A::AbstractMatrix)
-    for i = 1:size(A,2)
-        _rand!(rng, s, view(A,:,i))
-    end
-    return A
-end
-
-function rand!(s::Sampleable{Multivariate}, A::AbstractVector)
-    length(A) == length(s) ||
-        throw(DimensionMismatch("Output size inconsistent with sample length."))
-    _rand!(s, A)
-end
-function rand!(rng::AbstractRNG, s::Sampleable{Multivariate}, A::AbstractVector)
-    length(A) == length(s) ||
-        throw(DimensionMismatch("Output size inconsistent with sample length."))
-    _rand!(rng, s, A)
-end
-
-function rand!(s::Sampleable{Multivariate}, A::AbstractMatrix)
-    size(A,1) == length(s) ||
-        throw(DimensionMismatch("Output size inconsistent with sample length."))
-    _rand!(s, A)
-end
-function rand!(rng::AbstractRNG, s::Sampleable{Multivariate}, A::AbstractMatrix)
-    size(A,1) == length(s) ||
-        throw(DimensionMismatch("Output size inconsistent with sample length."))
-    _rand!(rng, s, A)
-end
-
-rand(s::Sampleable{Multivariate}) =
-    _rand!(s, Vector{eltype(s)}(undef, length(s)))
-
-rand(s::Sampleable{Multivariate}, n::Int) =
-    _rand!(s, Matrix{eltype(s)}(undef, length(s), n))
-
-
-# matrix-variate
-
-function _rand!(s::Sampleable{Matrixvariate}, X::AbstractArray{M}) where M<:Matrix
-    for i in 1:length(X)
-        X[i] = rand(s)
-    end
-    return X
-end
-
-rand!(s::Sampleable{Matrixvariate}, X::AbstractArray{M}) where {M<:Matrix} =
-    _rand!(s, X)
-
-rand(s::Sampleable{Matrixvariate}, n::Int) =
-    rand!(s, Vector{Matrix{eltype(s)}}(n))
+function rand! end
+rand!(s::Sampleable, X::AbstractArray) = rand!(GLOBAL_RNG, s, X)
+rand!(rng::AbstractRNG, s::Sampleable, X::AbstractArray) = _rand!(rng, s, X)
 
 """
     sampler(d::Distribution) -> Sampleable
+    sampler(s::Sampleable) -> s
 
-Samplers can often rely on pre-computed quantities (that are not parameters themselves) to improve efficiency.
-If such a sampler exists, it can be provide with this `sampler` method, which would be used for batch sampling.
+Samplers can often rely on pre-computed quantities (that are not parameters
+themselves) to improve efficiency. If such a sampler exists, it can be provided
+with this `sampler` method, which would be used for batch sampling.
 The general fallback is `sampler(d::Distribution) = d`.
 """
-sampler(d::Distribution) = d
+sampler(s::Sampleable) = s

--- a/src/genericrand.jl
+++ b/src/genericrand.jl
@@ -40,9 +40,11 @@ form as specified above. The rules are summarized as below:
   matrices with each element for a sample matrix.
 """
 function rand! end
-rand!(s::Sampleable, X::AbstractArray{<:AbstractArray};
+rand!(s::Sampleable, X::AbstractArray{<:AbstractMatrix};
       allocate::Union{Bool, Missing} = missing) =
     rand!(GLOBAL_RNG, s, X; allocate = allocate)
+rand!(s::Sampleable, X::AbstractArray{<:AbstractArray};
+      allocate::Bool = false) = rand!(GLOBAL_RNG, s, X; allocate = allocate)
 rand!(s::Sampleable, X::AbstractArray) = rand!(GLOBAL_RNG, s, X)
 rand!(rng::AbstractRNG, s::Sampleable, X::AbstractArray) = _rand!(rng, s, X)
 

--- a/src/genericrand.jl
+++ b/src/genericrand.jl
@@ -40,11 +40,8 @@ form as specified above. The rules are summarized as below:
   matrices with each element for a sample matrix.
 """
 function rand! end
-rand!(s::Sampleable, X::AbstractArray{<:AbstractMatrix};
-      allocate::Union{Bool, Missing} = missing) =
-    rand!(GLOBAL_RNG, s, X; allocate = allocate)
-rand!(s::Sampleable, X::AbstractArray{<:AbstractArray};
-      allocate::Bool = false) = rand!(GLOBAL_RNG, s, X; allocate = allocate)
+rand!(s::Sampleable, X::AbstractArray{<:AbstractArray}, allocate::Bool) =
+    rand!(GLOBAL_RNG, s, X, allocate)
 rand!(s::Sampleable, X::AbstractArray) = rand!(GLOBAL_RNG, s, X)
 rand!(rng::AbstractRNG, s::Sampleable, X::AbstractArray) = _rand!(rng, s, X)
 

--- a/src/genericrand.jl
+++ b/src/genericrand.jl
@@ -40,6 +40,9 @@ form as specified above. The rules are summarized as below:
   matrices with each element for a sample matrix.
 """
 function rand! end
+rand!(s::Sampleable, X::AbstractArray{<:AbstractArray};
+      allocate::Union{Bool, Missing} = missing) =
+    rand!(GLOBAL_RNG, s, X; allocate = allocate)
 rand!(s::Sampleable, X::AbstractArray) = rand!(GLOBAL_RNG, s, X)
 rand!(rng::AbstractRNG, s::Sampleable, X::AbstractArray) = _rand!(rng, s, X)
 

--- a/src/matrix/inversewishart.jl
+++ b/src/matrix/inversewishart.jl
@@ -45,6 +45,7 @@ insupport(d::InverseWishart, X::Matrix) = size(X) == size(d) && isposdef(X)
 
 dim(d::InverseWishart) = dim(d.Ψ)
 size(d::InverseWishart) = (p = dim(d); (p, p))
+size(d::InverseWishart, i) = size(d)[i]
 params(d::InverseWishart) = (d.df, d.Ψ, d.c0)
 @inline partype(d::InverseWishart{T}) where {T<:Real} = T
 
@@ -94,4 +95,4 @@ end
 #### Sampling
 
 _rand!(rng::AbstractRNG, d::InverseWishart, A::AbstractMatrix) =
-    inv(cholesky!(_rand!(rng, Wishart(d.df, inv(d.Ψ)), A)))
+    (A .= inv(cholesky!(_rand!(rng, Wishart(d.df, inv(d.Ψ)), A))))

--- a/src/matrix/inversewishart.jl
+++ b/src/matrix/inversewishart.jl
@@ -93,12 +93,5 @@ end
 
 #### Sampling
 
-rand(d::InverseWishart) = inv(cholesky!(rand(Wishart(d.df, inv(d.Ψ)))))
-
-function _rand!(d::InverseWishart, X::AbstractArray{M}) where M<:Matrix
-    wd = Wishart(d.df, inv(d.Ψ))
-    for i in 1:length(X)
-        X[i] = inv(cholesky!(rand(wd)))
-    end
-    return X
-end
+_rand!(rng::AbstractRNG, d::InverseWishart, A::AbstractMatrix) =
+    inv(cholesky!(_rand!(rng, Wishart(d.df, inv(d.Ψ)), A)))

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -108,7 +108,7 @@ end
 
 #### Sampling
 function _rand!(rng::AbstractRNG, d::Wishart, A::AbstractMatrix)
-    Z = unwhiten!(d.S, _wishart_genA(dim(d), d.df, A))
+    Z = unwhiten!(d.S, _wishart_genA!(dim(d), d.df, A))
     return Z * Z'
 end
 

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -124,7 +124,7 @@ function _wishart_genA!(rng::AbstractRNG, p::Int, df::Real, A::AbstractMatrix)
     #
     A .= zero(eltype(A))
     for i = 1:p
-        @inbounds A[i,i] = _rand(rng, Chi(df - i + 1.0))
+        @inbounds A[i,i] = rand(rng, Chi(df - i + 1.0))
     end
     for j in 1:p-1, i in j+1:p
         @inbounds A[i,j] = randn(rng)

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -112,7 +112,6 @@ function _rand!(rng::AbstractRNG, d::Wishart, A::AbstractMatrix)
     return Z * Z'
 end
 
-#danger
 function _wishart_genA!(rng::AbstractRNG, p::Int, df::Real, A::AbstractMatrix)
     # Generate the matrix A in the Bartlett decomposition
     #
@@ -123,7 +122,7 @@ function _wishart_genA!(rng::AbstractRNG, p::Int, df::Real, A::AbstractMatrix)
     #
     A .= zero(eltype(A))
     for i = 1:p
-        @inbounds A[i,i] = rand(Chi(df - i + 1.0))
+        @inbounds A[i,i] = _rand!(rng, Chi(df - i + 1.0))
     end
     for j in 1:p-1, i in j+1:p
         @inbounds A[i,j] = randn(rng)

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -49,6 +49,7 @@ insupport(d::Wishart, X::Matrix) = size(X) == size(d) && isposdef(X)
 
 dim(d::Wishart) = dim(d.S)
 size(d::Wishart) = (p = dim(d); (p, p))
+size(d::Wishart, i) = size(d)[i]
 params(d::Wishart) = (d.df, d.S, d.c0)
 @inline partype(d::Wishart{T}) where {T<:Real} = T
 
@@ -108,8 +109,9 @@ end
 
 #### Sampling
 function _rand!(rng::AbstractRNG, d::Wishart, A::AbstractMatrix)
-    Z = unwhiten!(d.S, _wishart_genA!(rng, dim(d), d.df, A))
-    return Z * Z'
+    _wishart_genA!(rng, dim(d), d.df, A)
+    unwhiten!(d.S, A)
+    A .= A * A'
 end
 
 function _wishart_genA!(rng::AbstractRNG, p::Int, df::Real, A::AbstractMatrix)
@@ -127,5 +129,4 @@ function _wishart_genA!(rng::AbstractRNG, p::Int, df::Real, A::AbstractMatrix)
     for j in 1:p-1, i in j+1:p
         @inbounds A[i,j] = randn(rng)
     end
-    return A
 end

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -108,11 +108,12 @@ end
 
 #### Sampling
 function _rand!(rng::AbstractRNG, d::Wishart, A::AbstractMatrix)
-    Z = unwhiten!(d.S, _wishart_genA!(dim(d), d.df, A))
+    Z = unwhiten!(d.S, _wishart_genA!(rng, dim(d), d.df, A))
     return Z * Z'
 end
 
-function _wishart_genA!(p::Int, df::Real, A::AbstractMatrix)
+#danger
+function _wishart_genA!(rng::AbstractRNG, p::Int, df::Real, A::AbstractMatrix)
     # Generate the matrix A in the Bartlett decomposition
     #
     #   A is a lower triangular matrix, with
@@ -120,11 +121,12 @@ function _wishart_genA!(p::Int, df::Real, A::AbstractMatrix)
     #       A(i, j) ~ sqrt of Chisq(df - i + 1) when i == j
     #               ~ Normal()                  when i > j
     #
+    A .= zero(eltype(A))
     for i = 1:p
-        @inbounds A[i,i] = sqrt(rand(Chisq(df - i + 1.0)))
+        @inbounds A[i,i] = rand(Chi(df - i + 1.0))
     end
-    for j = 1:p-1, i = j+1:p
-        @inbounds A[i,j] = randn()
+    for j in 1:p-1, i in j+1:p
+        @inbounds A[i,j] = randn(rng)
     end
     return A
 end

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -107,13 +107,12 @@ function _logpdf(d::Wishart, X::AbstractMatrix)
 end
 
 #### Sampling
-
-function rand(d::Wishart)
-    Z = unwhiten!(d.S, _wishart_genA(dim(d), d.df))
-    Z * Z'
+function _rand!(rng::AbstractRNG, d::Wishart, A::AbstractMatrix)
+    Z = unwhiten!(d.S, _wishart_genA(dim(d), d.df, A))
+    return Z * Z'
 end
 
-function _wishart_genA(p::Int, df::Real)
+function _wishart_genA!(p::Int, df::Real, A::AbstractMatrix)
     # Generate the matrix A in the Bartlett decomposition
     #
     #   A is a lower triangular matrix, with
@@ -121,7 +120,6 @@ function _wishart_genA(p::Int, df::Real)
     #       A(i, j) ~ sqrt of Chisq(df - i + 1) when i == j
     #               ~ Normal()                  when i > j
     #
-    A = zeros(p, p)
     for i = 1:p
         @inbounds A[i,i] = sqrt(rand(Chisq(df - i + 1.0)))
     end

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -124,7 +124,7 @@ function _wishart_genA!(rng::AbstractRNG, p::Int, df::Real, A::AbstractMatrix)
     #
     A .= zero(eltype(A))
     for i = 1:p
-        @inbounds A[i,i] = _rand!(rng, Chi(df - i + 1.0))
+        @inbounds A[i,i] = _rand(rng, Chi(df - i + 1.0))
     end
     for j in 1:p-1, i in j+1:p
         @inbounds A[i,j] = randn(rng)

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -525,14 +525,14 @@ function MixtureSampler(d::MixtureModel{VF,VS}) where {VF,VS}
     MixtureSampler{VF,VS,eltype(csamplers)}(csamplers, psampler)
 end
 
-_rand!(rng::AbstractRNG, s::MixtureSampler{Univariate}) =
-    _rand!(rng, s.csamplers[_rand!(rng, s.psampler)])
-_rand!(rng::AbstractRNG, d::MixtureModel) =
-    _rand!(rng, component(d, _rand!(rng, d.prior)))
+_rand(rng::AbstractRNG, s::MixtureSampler{Univariate}) =
+    _rand(rng, s.csamplers[_rand(rng, s.psampler)])
+_rand(rng::AbstractRNG, d::MixtureModel{Univariate}) =
+    _rand(rng, component(d, _rand(rng, d.prior)))
 
 # multivariate mixture sampler for a vector
 _rand!(rng::AbstractRNG, s::MixtureSampler{Multivariate}, x::AbstractVector) =
-    _rand!(rng, s.csamplers[_rand!(rng, s.psampler)], x)
+    _rand!(rng, s.csamplers[_rand(rng, s.psampler)], x)
 _rand!(rng::AbstractRNG, s::MixtureModel{Multivariate}, x::AbstractVector) =
     _rand!(rng, sampler(s), x)
 

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -525,10 +525,15 @@ function MixtureSampler(d::MixtureModel{VF,VS}) where {VF,VS}
     MixtureSampler{VF,VS,eltype(csamplers)}(csamplers, psampler)
 end
 
+_rand!(rng::AbstractRNG, s::MixtureSampler{Univariate}) =
+    _rand!(rng, s.csamplers[_rand!(rng, s.psampler)])
 _rand!(rng::AbstractRNG, d::MixtureModel) =
     _rand!(rng, component(d, _rand!(rng, d.prior)))
 
+# multivariate mixture sampler for a vector
 _rand!(rng::AbstractRNG, s::MixtureSampler{Multivariate}, x::AbstractVector) =
     _rand!(rng, s.csamplers[_rand!(rng, s.psampler)], x)
+_rand!(rng::AbstractRNG, s::MixtureModel{Multivariate}, x::AbstractVector) =
+    _rand!(rng, sampler(s), x)
 
 sampler(d::MixtureModel) = MixtureSampler(d)

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -525,14 +525,14 @@ function MixtureSampler(d::MixtureModel{VF,VS}) where {VF,VS}
     MixtureSampler{VF,VS,eltype(csamplers)}(csamplers, psampler)
 end
 
-_rand(rng::AbstractRNG, s::MixtureSampler{Univariate}) =
-    _rand(rng, s.csamplers[_rand(rng, s.psampler)])
-_rand(rng::AbstractRNG, d::MixtureModel{Univariate}) =
-    _rand(rng, component(d, _rand(rng, d.prior)))
+rand(rng::AbstractRNG, s::MixtureSampler{Univariate}) =
+    rand(rng, s.csamplers[rand(rng, s.psampler)])
+rand(rng::AbstractRNG, d::MixtureModel{Univariate}) =
+    rand(rng, component(d, rand(rng, d.prior)))
 
 # multivariate mixture sampler for a vector
 _rand!(rng::AbstractRNG, s::MixtureSampler{Multivariate}, x::AbstractVector) =
-    _rand!(rng, s.csamplers[_rand(rng, s.psampler)], x)
+    _rand!(rng, s.csamplers[rand(rng, s.psampler)], x)
 _rand!(rng::AbstractRNG, s::MixtureModel{Multivariate}, x::AbstractVector) =
     _rand!(rng, sampler(s), x)
 

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -525,9 +525,10 @@ function MixtureSampler(d::MixtureModel{VF,VS}) where {VF,VS}
     MixtureSampler{VF,VS,eltype(csamplers)}(csamplers, psampler)
 end
 
-rand(d::MixtureModel) = rand(component(d, rand(d.prior)))
+_rand!(rng::AbstractRNG, d::MixtureModel) =
+    _rand!(rng, component(d, _rand!(rng, d.prior)))
 
-rand(s::MixtureSampler) = rand(s.csamplers[rand(s.psampler)])
-_rand!(s::MixtureSampler{Multivariate}, x::AbstractVector) = _rand!(s.csamplers[rand(s.psampler)], x)
+_rand!(rng::AbstractRNG, s::MixtureSampler{Multivariate}, x::AbstractVector) =
+    _rand!(rng, s.csamplers[_rand!(rng, s.psampler)], x)
 
 sampler(d::MixtureModel) = MixtureSampler(d)

--- a/src/mixtures/unigmm.jl
+++ b/src/mixtures/unigmm.jl
@@ -25,7 +25,8 @@ probs(d::UnivariateGMM) = probs(d.prior)
 
 mean(d::UnivariateGMM) = dot(d.means, probs(d))
 
-rand(d::UnivariateGMM) = (k = rand(d.prior); d.means[k] + randn() * d.stds[k])
+_rand!(rng::AbstractRNG, d::UnivariateGMM) =
+    (k = _rand!(rng, d.prior); d.means[k] + randn(rng) * d.stds[k])
 
 params(d::UnivariateGMM) = (d.means, d.stds, d.prior)
 
@@ -35,5 +36,6 @@ struct UnivariateGMMSampler <: Sampleable{Univariate,Continuous}
     psampler::AliasTable
 end
 
-rand(s::UnivariateGMMSampler) = (k = rand(s.psampler); s.means[k] + randn() * s.stds[k])
+_rand!(rng::AbstractRNG, s::UnivariateGMMSampler) =
+    (k = _rand!(rng, s.psampler); s.means[k] + randn(rng) * s.stds[k])
 sampler(d::UnivariateGMM) = UnivariateGMMSampler(d.means, d.stds, sampler(d.prior))

--- a/src/mixtures/unigmm.jl
+++ b/src/mixtures/unigmm.jl
@@ -25,8 +25,8 @@ probs(d::UnivariateGMM) = probs(d.prior)
 
 mean(d::UnivariateGMM) = dot(d.means, probs(d))
 
-_rand!(rng::AbstractRNG, d::UnivariateGMM) =
-    (k = _rand!(rng, d.prior); d.means[k] + randn(rng) * d.stds[k])
+_rand(rng::AbstractRNG, d::UnivariateGMM) =
+    (k = _rand(rng, d.prior); d.means[k] + randn(rng) * d.stds[k])
 
 params(d::UnivariateGMM) = (d.means, d.stds, d.prior)
 
@@ -36,6 +36,6 @@ struct UnivariateGMMSampler <: Sampleable{Univariate,Continuous}
     psampler::AliasTable
 end
 
-_rand!(rng::AbstractRNG, s::UnivariateGMMSampler) =
-    (k = _rand!(rng, s.psampler); s.means[k] + randn(rng) * s.stds[k])
+_rand(rng::AbstractRNG, s::UnivariateGMMSampler) =
+    (k = _rand(rng, s.psampler); s.means[k] + randn(rng) * s.stds[k])
 sampler(d::UnivariateGMM) = UnivariateGMMSampler(d.means, d.stds, sampler(d.prior))

--- a/src/mixtures/unigmm.jl
+++ b/src/mixtures/unigmm.jl
@@ -25,8 +25,8 @@ probs(d::UnivariateGMM) = probs(d.prior)
 
 mean(d::UnivariateGMM) = dot(d.means, probs(d))
 
-_rand(rng::AbstractRNG, d::UnivariateGMM) =
-    (k = _rand(rng, d.prior); d.means[k] + randn(rng) * d.stds[k])
+rand(rng::AbstractRNG, d::UnivariateGMM) =
+    (k = rand(rng, d.prior); d.means[k] + randn(rng) * d.stds[k])
 
 params(d::UnivariateGMM) = (d.means, d.stds, d.prior)
 
@@ -36,6 +36,6 @@ struct UnivariateGMMSampler <: Sampleable{Univariate,Continuous}
     psampler::AliasTable
 end
 
-_rand(rng::AbstractRNG, s::UnivariateGMMSampler) =
-    (k = _rand(rng, s.psampler); s.means[k] + randn(rng) * s.stds[k])
+rand(rng::AbstractRNG, s::UnivariateGMMSampler) =
+    (k = rand(rng, s.psampler); s.means[k] + randn(rng) * s.stds[k])
 sampler(d::UnivariateGMM) = UnivariateGMMSampler(d.means, d.stds, sampler(d.prior))

--- a/src/multivariate/dirichlet.jl
+++ b/src/multivariate/dirichlet.jl
@@ -179,24 +179,14 @@ end
 
 # sampling
 
-function _rand!(d::Union{Dirichlet,DirichletCanon},
-                x::AbstractVector{T}) where T<:Real
+function _rand!(rng::AbstractRNG,
+                d::Union{Dirichlet,DirichletCanon},
+                x::AbstractVector{<:Real})
     s = 0.0
     n = length(x)
     α = d.alpha
     for i in 1:n
-        @inbounds s += (x[i] = rand(Gamma(α[i])))
-    end
-    multiply!(x, inv(s)) # this returns x
-end
-
-function _rand!(rng::AbstractRNG, d::Union{Dirichlet,DirichletCanon},
-                x::AbstractVector{T}) where T<:Real
-    s = 0.0
-    n = length(x)
-    α = d.alpha
-    for i in 1:n
-        @inbounds s += (x[i] = rand(rng, Gamma(α[i])))
+        @inbounds s += (x[i] = _rand!(rng, Gamma(α[i])))
     end
     multiply!(x, inv(s)) # this returns x
 end

--- a/src/multivariate/dirichlet.jl
+++ b/src/multivariate/dirichlet.jl
@@ -186,7 +186,7 @@ function _rand!(rng::AbstractRNG,
     n = length(x)
     α = d.alpha
     for i in 1:n
-        @inbounds s += (x[i] = _rand(rng, Gamma(α[i])))
+        @inbounds s += (x[i] = rand(rng, Gamma(α[i])))
     end
     multiply!(x, inv(s)) # this returns x
 end

--- a/src/multivariate/dirichlet.jl
+++ b/src/multivariate/dirichlet.jl
@@ -186,7 +186,7 @@ function _rand!(rng::AbstractRNG,
     n = length(x)
     α = d.alpha
     for i in 1:n
-        @inbounds s += (x[i] = _rand!(rng, Gamma(α[i])))
+        @inbounds s += (x[i] = _rand(rng, Gamma(α[i])))
     end
     multiply!(x, inv(s)) # this returns x
 end

--- a/src/multivariate/dirichlet.jl
+++ b/src/multivariate/dirichlet.jl
@@ -30,7 +30,8 @@ struct Dirichlet{T<:Real} <: ContinuousMultivariateDistribution
         lmnB::T = zero(T)
         for i in 1:length(alpha)
             ai = alpha[i]
-            ai > 0 || throw(ArgumentError("Dirichlet: alpha must be a positive vector."))
+            ai > 0 ||
+                throw(ArgumentError("Dirichlet: alpha must be a positive vector."))
             alpha0 += ai
             lmnB += lgamma(ai)
         end
@@ -46,7 +47,8 @@ end
 
 Dirichlet(alpha::Vector{T}) where {T<:Real} = Dirichlet{T}(alpha)
 Dirichlet(d::Integer, alpha::T) where {T<:Real} = Dirichlet{T}(d, alpha)
-Dirichlet(alpha::Vector{T}) where {T<:Integer} = Dirichlet{Float64}(convert(Vector{Float64},alpha))
+Dirichlet(alpha::Vector{T}) where {T<:Integer} =
+    Dirichlet{Float64}(convert(Vector{Float64},alpha))
 Dirichlet(d::Integer, alpha::Integer) = Dirichlet{Float64}(d, Float64(alpha))
 
 struct DirichletCanon
@@ -57,8 +59,10 @@ length(d::DirichletCanon) = length(d.alpha)
 
 #### Conversions
 convert(::Type{Dirichlet{Float64}}, cf::DirichletCanon) = Dirichlet(cf.alpha)
-convert(::Type{Dirichlet{T}}, alpha::Vector{S}) where {T<:Real, S<:Real} = Dirichlet(convert(Vector{T}, alpha))
-convert(::Type{Dirichlet{T}}, d::Dirichlet{S}) where {T<:Real, S<:Real} = Dirichlet(convert(Vector{T}, d.alpha))
+convert(::Type{Dirichlet{T}}, alpha::Vector{S}) where {T<:Real, S<:Real} =
+    Dirichlet(convert(Vector{T}, alpha))
+convert(::Type{Dirichlet{T}}, d::Dirichlet{S}) where {T<:Real, S<:Real} =
+    Dirichlet(convert(Vector{T}, d.alpha))
 
 
 
@@ -175,12 +179,24 @@ end
 
 # sampling
 
-function _rand!(d::Union{Dirichlet,DirichletCanon}, x::AbstractVector{T}) where T<:Real
+function _rand!(d::Union{Dirichlet,DirichletCanon},
+                x::AbstractVector{T}) where T<:Real
     s = 0.0
     n = length(x)
     α = d.alpha
     for i in 1:n
         @inbounds s += (x[i] = rand(Gamma(α[i])))
+    end
+    multiply!(x, inv(s)) # this returns x
+end
+
+function _rand!(rng::AbstractRNG, d::Union{Dirichlet,DirichletCanon},
+                x::AbstractVector{T}) where T<:Real
+    s = 0.0
+    n = length(x)
+    α = d.alpha
+    for i in 1:n
+        @inbounds s += (x[i] = rand(rng, Gamma(α[i])))
     end
     multiply!(x, inv(s)) # this returns x
 end
@@ -214,7 +230,8 @@ function suffstats(::Type{Dirichlet}, P::AbstractMatrix{Float64})
     DirichletStats(slogp, n)
 end
 
-function suffstats(::Type{Dirichlet}, P::AbstractMatrix{Float64}, w::AbstractArray{Float64})
+function suffstats(::Type{Dirichlet}, P::AbstractMatrix{Float64},
+                   w::AbstractArray{Float64})
     K = size(P, 1)
     n = size(P, 2)
     if length(w) != n
@@ -384,7 +401,8 @@ function fit_mle(::Type{Dirichlet}, P::AbstractMatrix{Float64};
     fit_dirichlet!(elogp, α; maxiter=maxiter, tol=tol)
 end
 
-function fit_mle(::Type{Dirichlet}, P::AbstractMatrix{Float64}, w::AbstractArray{Float64};
+function fit_mle(::Type{Dirichlet}, P::AbstractMatrix{Float64},
+                 w::AbstractArray{Float64};
     init::Vector{Float64}=Float64[], maxiter::Int=25, tol::Float64=1.0e-12)
 
     n = size(P, 2)

--- a/src/multivariate/dirichletmultinomial.jl
+++ b/src/multivariate/dirichletmultinomial.jl
@@ -66,9 +66,10 @@ end
 
 
 # Sampling
-function _rand!(d::DirichletMultinomial, x::AbstractVector{T}) where T<:Real
+_rand!(d::DirichletMultinomial, x::AbstractVector{T}) where T<:Real =
     multinom_rand!(ntrials(d), rand(Dirichlet(d.α)), x)
-end
+_rand!(rng::AbstractRNG, d::DirichletMultinomial, x::AbstractVector{T}) where T<:Real =
+    multinom_rand!(rng, ntrials(d), rand(rng, Dirichlet(d.α)), x)
 
 
 # Fit Model

--- a/src/multivariate/dirichletmultinomial.jl
+++ b/src/multivariate/dirichletmultinomial.jl
@@ -66,11 +66,8 @@ end
 
 
 # Sampling
-_rand!(d::DirichletMultinomial, x::AbstractVector{T}) where T<:Real =
-    multinom_rand!(ntrials(d), rand(Dirichlet(d.α)), x)
-_rand!(rng::AbstractRNG, d::DirichletMultinomial, x::AbstractVector{T}) where T<:Real =
+_rand!(rng::AbstractRNG, d::DirichletMultinomial, x::AbstractVector{<:Real}) =
     multinom_rand!(rng, ntrials(d), rand(rng, Dirichlet(d.α)), x)
-
 
 # Fit Model
 # Using https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2945396/pdf/nihms205488.pdf

--- a/src/multivariate/multinomial.jl
+++ b/src/multivariate/multinomial.jl
@@ -158,7 +158,10 @@ end
 
 # Sampling
 
-_rand!(d::Multinomial, x::AbstractVector{T}) where {T<:Real} = multinom_rand!(ntrials(d), probs(d), x)
+_rand!(d::Multinomial, x::AbstractVector{T}) where T<:Real =
+    multinom_rand!(ntrials(d), probs(d), x)
+_rand!(rng::AbstractRNG, d::Multinomial, x::AbstractVector{T}) where T<:Real =
+    multinom_rand!(rng, ntrials(d), probs(d), x)
 
 sampler(d::Multinomial) = MultinomialSampler(ntrials(d), probs(d))
 

--- a/src/multivariate/multinomial.jl
+++ b/src/multivariate/multinomial.jl
@@ -152,7 +152,7 @@ function _logpdf(d::Multinomial, x::AbstractVector{T}) where T<:Real
         @inbounds p_i = p[i]
         s -= R(lgamma(R(xi) + 1))
         s += xlogy(xi, p_i)
-    end    
+    end
     return s
 end
 

--- a/src/multivariate/mvlognormal.jl
+++ b/src/multivariate/mvlognormal.jl
@@ -227,7 +227,9 @@ var(d::MvLogNormal) = diag(cov(d))
 entropy(d::MvLogNormal) = length(d)*(1+log2π)/2 + logdetcov(d.normal)/2 + sum(mean(d.normal))
 
 #See https://en.wikipedia.org/wiki/Log-normal_distribution
-_rand!(d::MvLogNormal, x::AbstractVecOrMat{T}) where {T<:Real} = exp!(_rand!(d.normal, x))
+_rand!(rng::AbstractRNG, d::MvLogNormal, x::AbstractVecOrMat{<:Real}) =
+    exp!(_rand!(rng, d.normal, x))
+
 _logpdf(d::MvLogNormal, x::AbstractVecOrMat{T}) where {T<:Real} = insupport(d, x) ? (_logpdf(d.normal, log.(x)) - sum(log.(x))) : -Inf
 _pdf(d::MvLogNormal, x::AbstractVecOrMat{T}) where {T<:Real} = insupport(d,x) ? _pdf(d.normal, log.(x))/prod(x) : 0.0
 

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -272,7 +272,7 @@ gradlogpdf(d::MvNormal, x::Vector) = -(d.Σ \ broadcast(-, x, d.μ))
 
 # Sampling (for GenericMvNormal)
 
-_rand!(d::MvNormal, x::VecOrMat) = _rand!(Random.GLOBAL_RNG, d, x)
+_rand!(d::MvNormal, x::VecOrMat) = _rand!(GLOBAL_RNG, d, x)
 _rand!(rng::AbstractRNG, d::MvNormal, x::VecOrMat) = add!(unwhiten!(d.Σ, randn!(rng, x)), d.μ)
 
 
@@ -283,13 +283,13 @@ function _rand_abstr!(rng::AbstractRNG, d::MvNormal, x::AbstractVecOrMat)
     end
     add!(unwhiten!(d.Σ, x), d.μ)
 end
-_rand_abstr!(d::MvNormal, x::AbstractVecOrMat) = _rand_abstr!(Random.GLOBAL_RNG, d, x)
+_rand_abstr!(d::MvNormal, x::AbstractVecOrMat) = _rand_abstr!(GLOBAL_RNG, d, x)
 # define these separately to avoid ambiguity with
 # _rand(d::Multivariate, x::AbstractMatrix)
 _rand!(rng::AbstractRNG, d::MvNormal, x::AbstractMatrix) = _rand_abstr!(rng, d, x)
-_rand!(d::MvNormal, x::AbstractMatrix) = _rand!(Random.GLOBAL_RNG, d, x)
+_rand!(d::MvNormal, x::AbstractMatrix) = _rand!(GLOBAL_RNG, d, x)
 _rand!(rng::AbstractRNG, d::MvNormal, x::AbstractVector) = _rand_abstr!(rng, d, x)
-_rand!(d::MvNormal, x::AbstractVector) = _rand!(Random.GLOBAL_RNG, d, x)
+_rand!(d::MvNormal, x::AbstractVector) = _rand!(GLOBAL_RNG, d, x)
 
 ###########################################################
 #

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -123,18 +123,6 @@ end
 
 _pdf!(r::AbstractArray, d::AbstractMvNormal, x::AbstractMatrix) = exp!(_logpdf!(r, d, x))
 
-# Sampling with designated rng
-"""
-    rand(rng::AbstractRNG, d::AbstractMvNormal)
-    rand(rng::AbstractRNG, d::AbstractMvNormal, n::Int)
-    rand!(rng::AbstractRNG, d::AbstractMvNormal, x::AbstractArray)
-
-Sample from distribution `d` using the random number generator `rng`.
-"""
-rand(rng::AbstractRNG, d::AbstractMvNormal) = _rand!(rng, d, Vector{eltype(d)}(undef, length(d)))
-rand!(rng::AbstractRNG, d::AbstractMvNormal, x::VecOrMat) = _rand!(rng, d, x)
-rand(rng::AbstractRNG, d::AbstractMvNormal, n::Integer) = _rand!(rng, d, Matrix{eltype(d)}(undef, length(d), n))
-
 ###########################################################
 #
 #   MvNormal
@@ -272,24 +260,16 @@ gradlogpdf(d::MvNormal, x::Vector) = -(d.Σ \ broadcast(-, x, d.μ))
 
 # Sampling (for GenericMvNormal)
 
-_rand!(d::MvNormal, x::VecOrMat) = _rand!(GLOBAL_RNG, d, x)
-_rand!(rng::AbstractRNG, d::MvNormal, x::VecOrMat) = add!(unwhiten!(d.Σ, randn!(rng, x)), d.μ)
-
+_rand!(rng::AbstractRNG, d::MvNormal, x::VecOrMat) =
+    add!(unwhiten!(d.Σ, randn!(rng, x)), d.μ)
 
 # Workaround: randn! only works for Array, but not generally for AbstractArray
-function _rand_abstr!(rng::AbstractRNG, d::MvNormal, x::AbstractVecOrMat)
-    for i = 1:length(x)
-        @inbounds x[i] = randn()
+function _rand!(rng::AbstractRNG, d::MvNormal, x::AbstractVector)
+    for i in eachindex(x)
+        @inbounds x[i] = randn(rng)
     end
     add!(unwhiten!(d.Σ, x), d.μ)
 end
-_rand_abstr!(d::MvNormal, x::AbstractVecOrMat) = _rand_abstr!(GLOBAL_RNG, d, x)
-# define these separately to avoid ambiguity with
-# _rand(d::Multivariate, x::AbstractMatrix)
-_rand!(rng::AbstractRNG, d::MvNormal, x::AbstractMatrix) = _rand_abstr!(rng, d, x)
-_rand!(d::MvNormal, x::AbstractMatrix) = _rand!(GLOBAL_RNG, d, x)
-_rand!(rng::AbstractRNG, d::MvNormal, x::AbstractVector) = _rand_abstr!(rng, d, x)
-_rand!(d::MvNormal, x::AbstractVector) = _rand!(GLOBAL_RNG, d, x)
 
 ###########################################################
 #

--- a/src/multivariate/mvnormalcanon.jl
+++ b/src/multivariate/mvnormalcanon.jl
@@ -178,6 +178,6 @@ unwhiten_winv!(J::PDiagMat, x::AbstractVecOrMat) = whiten!(J, x)
 unwhiten_winv!(J::ScalMat, x::AbstractVecOrMat) = whiten!(J, x)
 
 _rand!(rng::AbstractRNG, d::MvNormalCanon, x::AbstractMatrix) = add!(unwhiten_winv!(d.J, randn!(rng,x)), d.μ)
-_rand!(d::MvNormalCanon, x::AbstractMatrix) = _rand!(Random.GLOBAL_RNG, d, x)
+_rand!(d::MvNormalCanon, x::AbstractMatrix) = _rand!(GLOBAL_RNG, d, x)
 _rand!(rng::AbstractRNG, d::MvNormalCanon, x::AbstractVector) = add!(unwhiten_winv!(d.J, randn!(rng,x)), d.μ)
-_rand!(d::MvNormalCanon, x::AbstractVector) = _rand!(Random.GLOBAL_RNG, d, x)
+_rand!(d::MvNormalCanon, x::AbstractVector) = _rand!(GLOBAL_RNG, d, x)

--- a/src/multivariate/mvnormalcanon.jl
+++ b/src/multivariate/mvnormalcanon.jl
@@ -177,7 +177,7 @@ unwhiten_winv!(J::AbstractPDMat, x::AbstractVecOrMat) = unwhiten!(inv(J), x)
 unwhiten_winv!(J::PDiagMat, x::AbstractVecOrMat) = whiten!(J, x)
 unwhiten_winv!(J::ScalMat, x::AbstractVecOrMat) = whiten!(J, x)
 
-_rand!(rng::AbstractRNG, d::MvNormalCanon, x::AbstractMatrix) = add!(unwhiten_winv!(d.J, randn!(rng,x)), d.μ)
-_rand!(d::MvNormalCanon, x::AbstractMatrix) = _rand!(GLOBAL_RNG, d, x)
-_rand!(rng::AbstractRNG, d::MvNormalCanon, x::AbstractVector) = add!(unwhiten_winv!(d.J, randn!(rng,x)), d.μ)
-_rand!(d::MvNormalCanon, x::AbstractVector) = _rand!(GLOBAL_RNG, d, x)
+_rand!(rng::AbstractRNG, d::MvNormalCanon, x::AbstractVector) =
+    add!(unwhiten_winv!(d.J, randn!(rng,x)), d.μ)
+_rand!(rng::AbstractRNG, d::MvNormalCanon, x::AbstractMatrix) =
+    add!(unwhiten_winv!(d.J, randn!(rng,x)), d.μ)

--- a/src/multivariate/mvtdist.jl
+++ b/src/multivariate/mvtdist.jl
@@ -157,7 +157,7 @@ end
 # Sampling (for GenericMvTDist)
 function _rand!(rng::AbstractRNG, d::GenericMvTDist, x::AbstractVector{<:Real})
     chisqd = Chisq(d.df)
-    y = sqrt(_rand(rng, chisqd)/(d.df))
+    y = sqrt(rand(rng, chisqd)/(d.df))
     unwhiten!(d.Σ, randn!(rng, x))
     broadcast!(/, x, x, y)
     if !d.zeromean

--- a/src/multivariate/mvtdist.jl
+++ b/src/multivariate/mvtdist.jl
@@ -155,11 +155,10 @@ function gradlogpdf(d::GenericMvTDist, x::AbstractVector{T}) where T<:Real
 end
 
 # Sampling (for GenericMvTDist)
-
-function _rand!(d::GenericMvTDist, x::AbstractVector{T}) where T<:Real
+function _rand!(rng::AbstractRNG, d::GenericMvTDist, x::AbstractVector{<:Real})
     chisqd = Chisq(d.df)
-    y = sqrt(rand(chisqd)/(d.df))
-    unwhiten!(d.Σ, randn!(x))
+    y = sqrt(_rand!(rng, chisqd)/(d.df))
+    unwhiten!(d.Σ, randn!(rng, x))
     broadcast!(/, x, x, y)
     if !d.zeromean
         broadcast!(+, x, x, d.μ)
@@ -167,12 +166,12 @@ function _rand!(d::GenericMvTDist, x::AbstractVector{T}) where T<:Real
     x
 end
 
-function _rand!(d::GenericMvTDist, x::AbstractMatrix{T}) where T<:Real
+function _rand!(rng::AbstractRNG, d::GenericMvTDist, x::AbstractMatrix{T}) where T<:Real
     cols = size(x,2)
     chisqd = Chisq(d.df)
     y = Matrix{T}(undef, 1, cols)
-    unwhiten!(d.Σ, randn!(x))
-    rand!(chisqd, y)
+    unwhiten!(d.Σ, randn!(rng, x))
+    rand!(rng, chisqd, y)
     y = sqrt.(y/(d.df))
     broadcast!(/, x, x, y)
     if !d.zeromean

--- a/src/multivariate/mvtdist.jl
+++ b/src/multivariate/mvtdist.jl
@@ -157,7 +157,7 @@ end
 # Sampling (for GenericMvTDist)
 function _rand!(rng::AbstractRNG, d::GenericMvTDist, x::AbstractVector{<:Real})
     chisqd = Chisq(d.df)
-    y = sqrt(_rand!(rng, chisqd)/(d.df))
+    y = sqrt(_rand(rng, chisqd)/(d.df))
     unwhiten!(d.Σ, randn!(rng, x))
     broadcast!(/, x, x, y)
     if !d.zeromean

--- a/src/multivariate/product.jl
+++ b/src/multivariate/product.jl
@@ -24,8 +24,10 @@ struct Product{
     end
 end
 length(d::Product) = length(d.v)
-_rand!(d::Product, x::AbstractVector{<:Real}) = broadcast!(dn->rand(dn), x, d.v)
-_logpdf(d::Product, x::AbstractVector{<:Real}) = sum(n->logpdf(d.v[n], x[n]), 1:length(d))
+_rand!(rng::AbstractRNG, d::Product, x::AbstractVector{<:Real}) =
+    broadcast!(dn->rand(rng, dn), x, d.v)
+_logpdf(d::Product, x::AbstractVector{<:Real}) =
+    sum(n->logpdf(d.v[n], x[n]), 1:length(d))
 
 mean(d::Product) = mean.(d.v)
 var(d::Product) = var.(d.v)

--- a/src/multivariate/vonmisesfisher.jl
+++ b/src/multivariate/vonmisesfisher.jl
@@ -73,8 +73,10 @@ _logpdf(d::VonMisesFisher, x::AbstractVector{T}) where {T<:Real} = d.logCκ + d.
 
 sampler(d::VonMisesFisher) = VonMisesFisherSampler(d.μ, d.κ)
 
-_rand!(d::VonMisesFisher, x::AbstractVector) = _rand!(sampler(d), x)
-_rand!(d::VonMisesFisher, x::AbstractMatrix) = _rand!(sampler(d), x)
+_rand!(rng::AbstractRNG, d::VonMisesFisher, x::AbstractVector) =
+    _rand!(rng, sampler(d), x)
+_rand!(rng::AbstractRNG, d::VonMisesFisher, x::AbstractMatrix) =
+    _rand!(rng, sampler(d), x)
 
 
 ### Estimation

--- a/src/multivariates.jl
+++ b/src/multivariates.jl
@@ -18,9 +18,10 @@ size(d::MultivariateDistribution)
 
 """
     rand!(d::MultivariateDistribution, x::AbstractArray)
+    rand!(rng::AbstractRNG, d::MultivariateDistribution, x::AbstractArray)
 
-Draw samples and output them to a pre-allocated array x. Here, x can be either a vector of
-length `dim(d)` or a matrix with `dim(d)` rows.
+Draw samples and output them to a pre-allocated array x. Here, x can be either
+a vector of length `dim(d)` or a matrix with `dim(d)` rows.
 """
 rand!(d::MultivariateDistribution, x::AbstractArray)
 
@@ -29,25 +30,44 @@ function rand!(d::MultivariateDistribution, x::AbstractVector)
         throw(DimensionMismatch("Output size inconsistent with sample length."))
     _rand!(d, x)
 end
-
 function rand!(d::MultivariateDistribution, A::AbstractMatrix)
     size(A,1) == length(d) ||
         throw(DimensionMismatch("Output size inconsistent with sample length."))
     _rand!(sampler(d), A)
 end
 
+function rand!(rng::AbstractRNG, d::MultivariateDistribution, x::AbstractVector)
+    length(x) == length(d) ||
+        throw(DimensionMismatch("Output size inconsistent with sample length."))
+    _rand!(rng, d, x)
+end
+function rand!(rng::AbstractRNG, d::MultivariateDistribution, A::AbstractMatrix)
+    size(A,1) == length(d) ||
+        throw(DimensionMismatch("Output size inconsistent with sample length."))
+    _rand!(rng, sampler(d), A)
+end
+
 """
     rand(d::MultivariateDistribution)
+    rand(rng::AbstractRNG, d::MultivariateDistribution)
 
-Sample a vector from the distribution `d`.
+Sample a vector from the distribution `d` using random number generator `rng`.
 
     rand(d::MultivariateDistribution, n::Int) -> Vector
+    rand(rng::AbstractRNG, d::MultivariateDistribution, n::Int) -> Vector
 
-Sample n vectors from the distribution `d`. This returns a matrix of size `(dim(d), n)`,
-where each column is a sample.
+Sample n vectors from the distribution `d` using random number generator `rng`.
+This returns a matrix of size `(dim(d), n)`, where each column is a sample.
 """
-rand(d::MultivariateDistribution) = _rand!(d, Vector{eltype(d)}(undef, length(d)))
-rand(d::MultivariateDistribution, n::Int) = _rand!(sampler(d), Matrix{eltype(d)}(undef, length(d), n))
+rand(d::MultivariateDistribution) =
+    _rand!(d, Vector{eltype(d)}(undef, length(d)))
+rand(d::MultivariateDistribution, n::Int) =
+    _rand!(sampler(d), Matrix{eltype(d)}(undef, length(d), n))
+
+rand(rng::AbstractRNG, d::MultivariateDistribution) =
+    _rand!(rng, d, Vector{eltype(d)}(undef, length(d)))
+rand(rng::AbstractRNG, d::MultivariateDistribution, n::Int) =
+    _rand!(rng, sampler(d), Matrix{eltype(d)}(undef, length(d), n))
 
 """
     _rand!(d::MultivariateDistribution, x::AbstractArray)

--- a/src/multivariates.jl
+++ b/src/multivariates.jl
@@ -17,64 +17,51 @@ size(d::MultivariateDistribution)
 ## sampling
 
 """
-    rand!(d::MultivariateDistribution, x::AbstractArray)
-    rand!(rng::AbstractRNG, d::MultivariateDistribution, x::AbstractArray)
+    rand!([rng::AbstractRNG,] d::MultivariateDistribution, x::AbstractArray)
 
 Draw samples and output them to a pre-allocated array x. Here, x can be either
 a vector of length `dim(d)` or a matrix with `dim(d)` rows.
 """
 rand!(d::MultivariateDistribution, x::AbstractArray)
 
-function rand!(d::MultivariateDistribution, x::AbstractVector)
-    length(x) == length(d) ||
+# multivariate with pre-allocated array
+function _rand!(rng::AbstractRNG, s::Sampleable{Multivariate}, m::AbstractMatrix)
+    size(m, 1) == length(s) ||
         throw(DimensionMismatch("Output size inconsistent with sample length."))
-    _rand!(d, x)
-end
-function rand!(d::MultivariateDistribution, A::AbstractMatrix)
-    size(A,1) == length(d) ||
-        throw(DimensionMismatch("Output size inconsistent with sample length."))
-    _rand!(sampler(d), A)
-end
-
-function rand!(rng::AbstractRNG, d::MultivariateDistribution, x::AbstractVector)
-    length(x) == length(d) ||
-        throw(DimensionMismatch("Output size inconsistent with sample length."))
-    _rand!(rng, d, x)
-end
-function rand!(rng::AbstractRNG, d::MultivariateDistribution, A::AbstractMatrix)
-    size(A,1) == length(d) ||
-        throw(DimensionMismatch("Output size inconsistent with sample length."))
-    _rand!(rng, sampler(d), A)
+    smp = sampler(s)
+    for i in Base.OneTo(size(m,2))
+        _rand!(rng, smp, view(m,:,i))
+    end
+    return m
 end
 
-"""
-    rand(d::MultivariateDistribution)
-    rand(rng::AbstractRNG, d::MultivariateDistribution)
+# single multivariate with pre-allocated vector
+function rand!(rng::AbstractRNG, s::Sampleable{Multivariate}, v::AbstractVector)
+    length(v) == length(s) ||
+        throw(DimensionMismatch("Output size inconsistent with sample length."))
+    _rand!(rng, s, v)
+end
 
-Sample a vector from the distribution `d` using random number generator `rng`.
+# multiple multivariates with pre-allocated array
+function rand(rng::AbstractRNG, s::Sampleable{Multivariate},
+              X::AbstractArray{V}) where V <: AbstractVector
+    smp = sampler(s)
+    for i in eachindex(X)
+        X[i] = _rand!(rng, smp, V(undef, length(s)))
+    end
+    return X
+end
 
-    rand(d::MultivariateDistribution, n::Int) -> Vector
-    rand(rng::AbstractRNG, d::MultivariateDistribution, n::Int) -> Vector
+# multiple multivariate, must allocate matrix or array of vectors
+rand(s::Sampleable{Multivariate}, n::Int) = rand(GLOBAL_RNG, s, n)
+rand(rng::AbstractRNG, s::Sampleable{Multivariate}, n::Int) =
+    _rand!(rng, s, Matrix{eltype(s)}(undef, length(s), n))
+rand(rng::AbstractRNG, s::Sampleable{Multivariate}, dims::Dims) =
+    rand(rng, s, Array{Vector{eltype(s)}}(undef, dims))
 
-Sample n vectors from the distribution `d` using random number generator `rng`.
-This returns a matrix of size `(dim(d), n)`, where each column is a sample.
-"""
-rand(d::MultivariateDistribution) =
-    _rand!(d, Vector{eltype(d)}(undef, length(d)))
-rand(d::MultivariateDistribution, n::Int) =
-    _rand!(sampler(d), Matrix{eltype(d)}(undef, length(d), n))
-
-rand(rng::AbstractRNG, d::MultivariateDistribution) =
-    _rand!(rng, d, Vector{eltype(d)}(undef, length(d)))
-rand(rng::AbstractRNG, d::MultivariateDistribution, n::Int) =
-    _rand!(rng, sampler(d), Matrix{eltype(d)}(undef, length(d), n))
-
-"""
-    _rand!(d::MultivariateDistribution, x::AbstractArray)
-
-Generate a vector sample to `x`. This function does not need to perform dimension checking.
-"""
-_rand!(d::MultivariateDistribution, x::AbstractArray)
+# single multivariate, must allocate vector
+rand(rng::AbstractRNG, s::Sampleable{Multivariate}) =
+    _rand!(rng, s, Vector{eltype(s)}(undef, length(s)))
 
 ## domain
 

--- a/src/samplers/aliastable.jl
+++ b/src/samplers/aliastable.jl
@@ -14,7 +14,7 @@ function AliasTable(probs::AbstractVector{T}) where T<:Real
     AliasTable(accp, alias, Random.RangeGenerator(1:n))
 end
 
-function _rand!(rng::AbstractRNG, s::AliasTable)
+function _rand(rng::AbstractRNG, s::AliasTable)
     i = rand(rng, s.isampler) % Int
     u = rand(rng)
     @inbounds r = u < s.accept[i] ? i : s.alias[i]

--- a/src/samplers/aliastable.jl
+++ b/src/samplers/aliastable.jl
@@ -14,12 +14,11 @@ function AliasTable(probs::AbstractVector{T}) where T<:Real
     AliasTable(accp, alias, Random.RangeGenerator(1:n))
 end
 
-function rand(rng::AbstractRNG, s::AliasTable)
+function _rand!(rng::AbstractRNG, s::AliasTable)
     i = rand(rng, s.isampler) % Int
     u = rand(rng)
     @inbounds r = u < s.accept[i] ? i : s.alias[i]
     r
 end
-rand(s::AliasTable) = rand(GLOBAL_RNG, s)
 
 show(io::IO, s::AliasTable) = @printf(io, "AliasTable with %d entries", ncategories(s))

--- a/src/samplers/aliastable.jl
+++ b/src/samplers/aliastable.jl
@@ -20,6 +20,6 @@ function rand(rng::AbstractRNG, s::AliasTable)
     @inbounds r = u < s.accept[i] ? i : s.alias[i]
     r
 end
-rand(s::AliasTable) = rand(Random.GLOBAL_RNG, s)
+rand(s::AliasTable) = rand(GLOBAL_RNG, s)
 
 show(io::IO, s::AliasTable) = @printf(io, "AliasTable with %d entries", ncategories(s))

--- a/src/samplers/aliastable.jl
+++ b/src/samplers/aliastable.jl
@@ -14,7 +14,7 @@ function AliasTable(probs::AbstractVector{T}) where T<:Real
     AliasTable(accp, alias, Random.RangeGenerator(1:n))
 end
 
-function _rand(rng::AbstractRNG, s::AliasTable)
+function rand(rng::AbstractRNG, s::AliasTable)
     i = rand(rng, s.isampler) % Int
     u = rand(rng)
     @inbounds r = u < s.accept[i] ? i : s.alias[i]

--- a/src/samplers/binomial.jl
+++ b/src/samplers/binomial.jl
@@ -44,7 +44,7 @@ function BinomialGeomSampler(n::Int, prob::Float64)
     BinomialGeomSampler(comp, n, scale)
 end
 
-function _rand!(rng::AbstractRNG, s::BinomialGeomSampler)
+function _rand(rng::AbstractRNG, s::BinomialGeomSampler)
     y = 0
     x = 0
     n = s.n
@@ -129,7 +129,7 @@ function BinomialTPESampler(n::Int, prob::Float64)
                        xM,xL,xR,c,λL,λR)
 end
 
-function _rand!(rng::AbstractRNG, s::BinomialTPESampler)
+function _rand(rng::AbstractRNG, s::BinomialTPESampler)
     y = 0
     while true
         # Step 1
@@ -231,7 +231,7 @@ end
 
 BinomialAliasSampler(n::Int, p::Float64) = BinomialAliasSampler(AliasTable(binompvec(n, p)))
 
-_rand!(rng::AbstractRNG, s::BinomialAliasSampler) = rand(rng, s.table) - 1
+_rand(rng::AbstractRNG, s::BinomialAliasSampler) = rand(rng, s.table) - 1
 
 
 # Integrated Polyalgorithm sampler that automatically chooses the proper one
@@ -260,5 +260,5 @@ end
 
 BinomialPolySampler(n::Real, p::Real) = BinomialPolySampler(round(Int, n), Float64(p))
 
-_rand!(rng::AbstractRNG, s::BinomialPolySampler) =
-    s.use_btpe ? _rand!(rng, s.btpe_sampler) : _rand!(rng, s.geom_sampler)
+_rand(rng::AbstractRNG, s::BinomialPolySampler) =
+    s.use_btpe ? _rand(rng, s.btpe_sampler) : _rand(rng, s.geom_sampler)

--- a/src/samplers/binomial.jl
+++ b/src/samplers/binomial.jl
@@ -29,8 +29,8 @@ end
 
 # Geometric method:
 #
-#   Devroye. L. 
-#   "Generating the maximum of independent identically  distributed random variables" 
+#   Devroye. L.
+#   "Generating the maximum of independent identically  distributed random variables"
 #   Computers and Marhemafics with Applicalions 6, 1960, 305-315.
 #
 struct BinomialGeomSampler <: Sampleable{Univariate,Discrete}
@@ -60,7 +60,7 @@ function rand(s::BinomialGeomSampler)
         er = randexp()
         v = er * s.scale
         if v > n  # in case when v is very large or infinity
-            break 
+            break
         end
         y += ceil(Int,v)
         if y > n
@@ -74,9 +74,9 @@ end
 
 # BTPE algorithm from:
 #
-#   Kachitvichyanukul, V.; Schmeiser, B. W. 
-#   "Binomial random variate generation." 
-#   Comm. ACM 31 (1988), no. 2, 216–222. 
+#   Kachitvichyanukul, V.; Schmeiser, B. W.
+#   "Binomial random variate generation."
+#   Comm. ACM 31 (1988), no. 2, 216–222.
 #
 # Note: only use this sampler when n * min(p, 1-p) is large enough
 #       e.g., it is greater than 20.
@@ -101,8 +101,8 @@ struct BinomialTPESampler <: Sampleable{Univariate,Discrete}
     λR::Float64
 end
 
-BinomialTPESampler() = 
-    BinomialTPESampler(false, 0, 0., 0., 0., 0., 0, 
+BinomialTPESampler() =
+    BinomialTPESampler(false, 0, 0., 0., 0., 0., 0,
                        0., 0., 0., 0., 0., 0., 0., 0., 0., 0.)
 
 function BinomialTPESampler(n::Int, prob::Float64)
@@ -134,7 +134,7 @@ function BinomialTPESampler(n::Int, prob::Float64)
     p4 = p3 + c/λR
 
     BinomialTPESampler(comp,n,r,q,nrq,M,Mi,p1,p2,p3,p4,
-                        xM,xL,xR,c,λL,λR)
+                       xM,xL,xR,c,λL,λR)
 end
 
 function rand(s::BinomialTPESampler)

--- a/src/samplers/binomial.jl
+++ b/src/samplers/binomial.jl
@@ -44,7 +44,7 @@ function BinomialGeomSampler(n::Int, prob::Float64)
     BinomialGeomSampler(comp, n, scale)
 end
 
-function _rand(rng::AbstractRNG, s::BinomialGeomSampler)
+function rand(rng::AbstractRNG, s::BinomialGeomSampler)
     y = 0
     x = 0
     n = s.n
@@ -129,7 +129,7 @@ function BinomialTPESampler(n::Int, prob::Float64)
                        xM,xL,xR,c,λL,λR)
 end
 
-function _rand(rng::AbstractRNG, s::BinomialTPESampler)
+function rand(rng::AbstractRNG, s::BinomialTPESampler)
     y = 0
     while true
         # Step 1
@@ -231,7 +231,7 @@ end
 
 BinomialAliasSampler(n::Int, p::Float64) = BinomialAliasSampler(AliasTable(binompvec(n, p)))
 
-_rand(rng::AbstractRNG, s::BinomialAliasSampler) = rand(rng, s.table) - 1
+rand(rng::AbstractRNG, s::BinomialAliasSampler) = rand(rng, s.table) - 1
 
 
 # Integrated Polyalgorithm sampler that automatically chooses the proper one
@@ -260,5 +260,5 @@ end
 
 BinomialPolySampler(n::Real, p::Real) = BinomialPolySampler(round(Int, n), Float64(p))
 
-_rand(rng::AbstractRNG, s::BinomialPolySampler) =
-    s.use_btpe ? _rand(rng, s.btpe_sampler) : _rand(rng, s.geom_sampler)
+rand(rng::AbstractRNG, s::BinomialPolySampler) =
+    s.use_btpe ? rand(rng, s.btpe_sampler) : rand(rng, s.geom_sampler)

--- a/src/samplers/binomial.jl
+++ b/src/samplers/binomial.jl
@@ -52,12 +52,13 @@ function BinomialGeomSampler(n::Int, prob::Float64)
     BinomialGeomSampler(comp, n, scale)
 end
 
-function rand(s::BinomialGeomSampler)
+rand(s::BinomialGeomSampler) = rand(GLOBAL_RNG, s)
+function rand(rng::AbstractRNG, s::BinomialGeomSampler)
     y = 0
     x = 0
     n = s.n
     while true
-        er = randexp()
+        er = randexp(rng)
         v = er * s.scale
         if v > n  # in case when v is very large or infinity
             break
@@ -137,12 +138,13 @@ function BinomialTPESampler(n::Int, prob::Float64)
                        xM,xL,xR,c,λL,λR)
 end
 
-function rand(s::BinomialTPESampler)
+rand(s::BinomialTPESampler) = rand(GLOBAL_RNG, s)
+function rand(rng::AbstractRNG, s::BinomialTPESampler)
     y = 0
     while true
         # Step 1
-        u = s.p4*rand()
-        v = rand()
+        u = s.p4*rand(rng)
+        v = rand(rng)
         if u <= s.p1
             y = floor(Int,s.xM-s.p1*v+u)
             # Goto 6
@@ -268,6 +270,6 @@ end
 
 BinomialPolySampler(n::Real, p::Real) = BinomialPolySampler(round(Int, n), Float64(p))
 
-rand(s::BinomialPolySampler) = s.use_btpe ? rand(s.btpe_sampler) : rand(s.geom_sampler)
-
-
+rand(s::BinomialPolySampler) = rand(GLOBAL_RNG, s)
+rand(rng::AbstractRNG, s::BinomialPolySampler) =
+    s.use_btpe ? rand(rng, s.btpe_sampler) : rand(rng, s.geom_sampler)

--- a/src/samplers/binomial.jl
+++ b/src/samplers/binomial.jl
@@ -1,12 +1,4 @@
 
-struct BinomialRmathSampler <: Sampleable{Univariate,Discrete}
-    n::Int
-    prob::Float64
-end
-
-rand(s::BinomialRmathSampler) = round(Int, StatsFuns.RFunctions.binomrand(s.n, s.prob))
-
-
 # compute probability vector of a Binomial distribution
 function binompvec(n::Int, p::Float64)
     pv = Vector{Float64}(undef, n+1)
@@ -52,8 +44,7 @@ function BinomialGeomSampler(n::Int, prob::Float64)
     BinomialGeomSampler(comp, n, scale)
 end
 
-rand(s::BinomialGeomSampler) = rand(GLOBAL_RNG, s)
-function rand(rng::AbstractRNG, s::BinomialGeomSampler)
+function _rand!(rng::AbstractRNG, s::BinomialGeomSampler)
     y = 0
     x = 0
     n = s.n
@@ -138,8 +129,7 @@ function BinomialTPESampler(n::Int, prob::Float64)
                        xM,xL,xR,c,λL,λR)
 end
 
-rand(s::BinomialTPESampler) = rand(GLOBAL_RNG, s)
-function rand(rng::AbstractRNG, s::BinomialTPESampler)
+function _rand!(rng::AbstractRNG, s::BinomialTPESampler)
     y = 0
     while true
         # Step 1
@@ -241,7 +231,7 @@ end
 
 BinomialAliasSampler(n::Int, p::Float64) = BinomialAliasSampler(AliasTable(binompvec(n, p)))
 
-rand(s::BinomialAliasSampler) = rand(s.table) - 1
+_rand!(rng::AbstractRNG, s::BinomialAliasSampler) = rand(rng, s.table) - 1
 
 
 # Integrated Polyalgorithm sampler that automatically chooses the proper one
@@ -270,6 +260,5 @@ end
 
 BinomialPolySampler(n::Real, p::Real) = BinomialPolySampler(round(Int, n), Float64(p))
 
-rand(s::BinomialPolySampler) = rand(GLOBAL_RNG, s)
-rand(rng::AbstractRNG, s::BinomialPolySampler) =
-    s.use_btpe ? rand(rng, s.btpe_sampler) : rand(rng, s.geom_sampler)
+_rand!(rng::AbstractRNG, s::BinomialPolySampler) =
+    s.use_btpe ? _rand!(rng, s.btpe_sampler) : _rand!(rng, s.geom_sampler)

--- a/src/samplers/categorical.jl
+++ b/src/samplers/categorical.jl
@@ -15,12 +15,12 @@ CategoricalDirectSampler(p::Ts) where {T<:Real,Ts<:AbstractVector{T}} =
 
 ncategories(s::CategoricalDirectSampler) = length(s.prob)
 
-function rand(s::CategoricalDirectSampler)
+function _rand!(rng::AbstractRNG, s::CategoricalDirectSampler)
     p = s.prob
     n = length(p)
     i = 1
     c = p[1]
-    u = rand()
+    u = rand(rng)
     while c < u && i < n
         c += p[i += 1]
     end

--- a/src/samplers/categorical.jl
+++ b/src/samplers/categorical.jl
@@ -15,7 +15,7 @@ CategoricalDirectSampler(p::Ts) where {T<:Real,Ts<:AbstractVector{T}} =
 
 ncategories(s::CategoricalDirectSampler) = length(s.prob)
 
-function _rand(rng::AbstractRNG, s::CategoricalDirectSampler)
+function rand(rng::AbstractRNG, s::CategoricalDirectSampler)
     p = s.prob
     n = length(p)
     i = 1

--- a/src/samplers/categorical.jl
+++ b/src/samplers/categorical.jl
@@ -15,7 +15,7 @@ CategoricalDirectSampler(p::Ts) where {T<:Real,Ts<:AbstractVector{T}} =
 
 ncategories(s::CategoricalDirectSampler) = length(s.prob)
 
-function _rand!(rng::AbstractRNG, s::CategoricalDirectSampler)
+function _rand(rng::AbstractRNG, s::CategoricalDirectSampler)
     p = s.prob
     n = length(p)
     i = 1

--- a/src/samplers/discretenonparametric.jl
+++ b/src/samplers/discretenonparametric.jl
@@ -19,5 +19,5 @@ DiscreteNonParametricSampler(support::S, probs::AbstractVector{<:Real}
     ) where {T<:Real,S<:AbstractVector{T}} =
     DiscreteNonParametricSampler{T,S}(support, probs)
 
-_rand(rng::AbstractRNG, s::DiscreteNonParametricSampler) =
-    (@inbounds v = s.support[_rand(rng, s.aliastable)]; v)
+rand(rng::AbstractRNG, s::DiscreteNonParametricSampler) =
+    (@inbounds v = s.support[rand(rng, s.aliastable)]; v)

--- a/src/samplers/discretenonparametric.jl
+++ b/src/samplers/discretenonparametric.jl
@@ -19,5 +19,5 @@ DiscreteNonParametricSampler(support::S, probs::AbstractVector{<:Real}
     ) where {T<:Real,S<:AbstractVector{T}} =
     DiscreteNonParametricSampler{T,S}(support, probs)
 
-_rand!(rng::AbstractRNG, s::DiscreteNonParametricSampler) =
-    (@inbounds v = s.support[_rand!(rng, s.aliastable)]; v)
+_rand(rng::AbstractRNG, s::DiscreteNonParametricSampler) =
+    (@inbounds v = s.support[_rand(rng, s.aliastable)]; v)

--- a/src/samplers/discretenonparametric.jl
+++ b/src/samplers/discretenonparametric.jl
@@ -19,7 +19,5 @@ DiscreteNonParametricSampler(support::S, probs::AbstractVector{<:Real}
     ) where {T<:Real,S<:AbstractVector{T}} =
     DiscreteNonParametricSampler{T,S}(support, probs)
 
-rand(rng::AbstractRNG, s::DiscreteNonParametricSampler) =
-    (@inbounds v = s.support[rand(rng, s.aliastable)]; v)
-
-rand(s::DiscreteNonParametricSampler) = rand(GLOBAL_RNG, s)
+_rand!(rng::AbstractRNG, s::DiscreteNonParametricSampler) =
+    (@inbounds v = s.support[_rand!(rng, s.aliastable)]; v)

--- a/src/samplers/discretenonparametric.jl
+++ b/src/samplers/discretenonparametric.jl
@@ -22,4 +22,4 @@ DiscreteNonParametricSampler(support::S, probs::AbstractVector{<:Real}
 rand(rng::AbstractRNG, s::DiscreteNonParametricSampler) =
     (@inbounds v = s.support[rand(rng, s.aliastable)]; v)
 
-rand(s::DiscreteNonParametricSampler) = rand(Random.GLOBAL_RNG, s)
+rand(s::DiscreteNonParametricSampler) = rand(GLOBAL_RNG, s)

--- a/src/samplers/exponential.jl
+++ b/src/samplers/exponential.jl
@@ -2,12 +2,10 @@ struct ExponentialSampler <: Sampleable{Univariate,Continuous}
     scale::Float64
 end
 
-rand(s::ExponentialSampler) = rand(GLOBAL_RNG, s)
-rand(rng::AbstractRNG, s::ExponentialSampler) = s.scale * randexp(rng)
+_rand!(rng::AbstractRNG, s::ExponentialSampler) = s.scale * randexp(rng)
 
 struct ExponentialLogUSampler <: Sampleable{Univariate,Continuous}
     scale::Float64
 end
 
-rand(s::ExponentialLogUSampler) = rand(GLOBAL_RNG, s)
-rand(rng::AbstractRNG, s::ExponentialLogUSampler) = -s.scale * log(rand(rng))
+_rand!(rng::AbstractRNG, s::ExponentialLogUSampler) = -s.scale * log(rand(rng))

--- a/src/samplers/exponential.jl
+++ b/src/samplers/exponential.jl
@@ -2,10 +2,10 @@ struct ExponentialSampler <: Sampleable{Univariate,Continuous}
     scale::Float64
 end
 
-_rand!(rng::AbstractRNG, s::ExponentialSampler) = s.scale * randexp(rng)
+_rand(rng::AbstractRNG, s::ExponentialSampler) = s.scale * randexp(rng)
 
 struct ExponentialLogUSampler <: Sampleable{Univariate,Continuous}
     scale::Float64
 end
 
-_rand!(rng::AbstractRNG, s::ExponentialLogUSampler) = -s.scale * log(rand(rng))
+_rand(rng::AbstractRNG, s::ExponentialLogUSampler) = -s.scale * log(rand(rng))

--- a/src/samplers/exponential.jl
+++ b/src/samplers/exponential.jl
@@ -2,10 +2,10 @@ struct ExponentialSampler <: Sampleable{Univariate,Continuous}
     scale::Float64
 end
 
-_rand(rng::AbstractRNG, s::ExponentialSampler) = s.scale * randexp(rng)
+rand(rng::AbstractRNG, s::ExponentialSampler) = s.scale * randexp(rng)
 
 struct ExponentialLogUSampler <: Sampleable{Univariate,Continuous}
     scale::Float64
 end
 
-_rand(rng::AbstractRNG, s::ExponentialLogUSampler) = -s.scale * log(rand(rng))
+rand(rng::AbstractRNG, s::ExponentialLogUSampler) = -s.scale * log(rand(rng))

--- a/src/samplers/gamma.jl
+++ b/src/samplers/gamma.jl
@@ -65,14 +65,15 @@ function GammaGDSampler(g::Gamma)
     GammaGDSampler(a,s2,s,i2s,d,q0,b,σ,c,scale(g))
 end
 
-function rand(s::GammaGDSampler)
+rand(s::GammaGDSampler) = rand(GLOBAL_RNG, s)
+function rand(rng::AbstractRNG, s::GammaGDSampler)
     # Step 2
-    t = randn()
+    t = randn(rng)
     x = s.s + 0.5t
     t >= 0.0 && return x*x*s.scale
 
     # Step 3
-    u = rand()
+    u = rand(rng)
     s.d*u <= t*t*t && return x*x*s.scale
 
     # Step 5
@@ -100,8 +101,8 @@ function rand(s::GammaGDSampler)
 
     # Step 8
     @label step8
-    e = randexp()
-    u = 2.0rand() - 1.0
+    e = randexp(rng)
+    u = 2.0rand(rng) - 1.0
     t = s.b + e*s.σ*sign(u)
 
     # Step 9
@@ -152,11 +153,12 @@ function GammaGSSampler(d::Gamma)
     GammaGSSampler(a, ia, b, scale(d))
 end
 
-function rand(s::GammaGSSampler)
+rand(s::GammaGSSampler) = rand(GLOBAL_RNG, s)
+function rand(rng::AbstractRNG, s::GammaGSSampler)
     while true
         # step 1
-        p = s.b*rand()
-        e = randexp()
+        p = s.b*rand(rng)
+        e = randexp(rng)
         if p <= 1.0
             # step 2
             x = exp(log(p)*s.ia)
@@ -189,16 +191,17 @@ function GammaMTSampler(g::Gamma)
     GammaMTSampler(d, c, κ)
 end
 
-function rand(s::GammaMTSampler)
+rand(s::GammaMTSampler) = rand(GLOBAL_RNG, s)
+function rand(rng::AbstractRNG, s::GammaMTSampler)
     while true
-        x = randn()
+        x = randn(rng)
         v = 1.0 + s.c * x
         while v <= 0.0
-            x = randn()
+            x = randn(rng)
             v = 1.0 + s.c * x
         end
         v *= (v * v)
-        u = rand()
+        u = rand(rng)
         x2 = x * x
         if u < 1.0 - 0.331 * abs2(x2) || log(u) < 0.5 * x2 + s.d * (1.0 - v + log(v))
             return v*s.κ
@@ -218,9 +221,10 @@ function GammaIPSampler(d::Gamma,::Type{S}) where S<:Sampleable
 end
 GammaIPSampler(d::Gamma) = GammaIPSampler(d,GammaMTSampler)
 
-function rand(s::GammaIPSampler)
-    x = rand(s.s)
-    e = randexp()
+rand(s::GammaIPSampler) = rand(GLOBAL_RNG, s)
+function rand(rng::AbstractRNG, s::GammaIPSampler)
+    x = rand(rng, s.s)
+    e = randexp(rng)
     x*exp(s.nia*e)
 end
 

--- a/src/samplers/gamma.jl
+++ b/src/samplers/gamma.jl
@@ -58,7 +58,7 @@ function GammaGDSampler(g::Gamma)
     GammaGDSampler(a,s2,s,i2s,d,q0,b,σ,c,scale(g))
 end
 
-function _rand!(rng::AbstractRNG, s::GammaGDSampler)
+function _rand(rng::AbstractRNG, s::GammaGDSampler)
     # Step 2
     t = randn(rng)
     x = s.s + 0.5t
@@ -145,7 +145,7 @@ function GammaGSSampler(d::Gamma)
     GammaGSSampler(a, ia, b, scale(d))
 end
 
-function _rand!(rng::AbstractRNG, s::GammaGSSampler)
+function _rand(rng::AbstractRNG, s::GammaGSSampler)
     while true
         # step 1
         p = s.b*rand(rng)
@@ -182,7 +182,7 @@ function GammaMTSampler(g::Gamma)
     GammaMTSampler(d, c, κ)
 end
 
-function _rand!(rng::AbstractRNG, s::GammaMTSampler)
+function _rand(rng::AbstractRNG, s::GammaMTSampler)
     while true
         x = randn(rng)
         v = 1.0 + s.c * x
@@ -211,8 +211,8 @@ function GammaIPSampler(d::Gamma,::Type{S}) where S<:Sampleable
 end
 GammaIPSampler(d::Gamma) = GammaIPSampler(d,GammaMTSampler)
 
-function _rand!(rng::AbstractRNG, s::GammaIPSampler)
-    x = _rand!(rng, s.s)
+function _rand(rng::AbstractRNG, s::GammaIPSampler)
+    x = _rand(rng, s.s)
     e = randexp(rng)
     x*exp(s.nia*e)
 end

--- a/src/samplers/gamma.jl
+++ b/src/samplers/gamma.jl
@@ -76,7 +76,7 @@ function calc_q(s::GammaGDSampler, t)
     end
 end
 
-function _rand(rng::AbstractRNG, s::GammaGDSampler)
+function rand(rng::AbstractRNG, s::GammaGDSampler)
     # Step 2
     t = randn(rng)
     x = s.s + 0.5t
@@ -139,7 +139,7 @@ function GammaGSSampler(d::Gamma)
     GammaGSSampler(a, ia, b, scale(d))
 end
 
-function _rand(rng::AbstractRNG, s::GammaGSSampler)
+function rand(rng::AbstractRNG, s::GammaGSSampler)
     while true
         # step 1
         p = s.b*rand(rng)
@@ -176,7 +176,7 @@ function GammaMTSampler(g::Gamma)
     GammaMTSampler(d, c, κ)
 end
 
-function _rand(rng::AbstractRNG, s::GammaMTSampler)
+function rand(rng::AbstractRNG, s::GammaMTSampler)
     while true
         x = randn(rng)
         v = 1.0 + s.c * x
@@ -205,8 +205,8 @@ function GammaIPSampler(d::Gamma,::Type{S}) where S<:Sampleable
 end
 GammaIPSampler(d::Gamma) = GammaIPSampler(d,GammaMTSampler)
 
-function _rand(rng::AbstractRNG, s::GammaIPSampler)
-    x = _rand(rng, s.s)
+function rand(rng::AbstractRNG, s::GammaIPSampler)
+    x = rand(rng, s.s)
     e = randexp(rng)
     x*exp(s.nia*e)
 end

--- a/src/samplers/gamma.jl
+++ b/src/samplers/gamma.jl
@@ -1,11 +1,4 @@
 
-struct GammaRmathSampler <: Sampleable{Univariate,Continuous}
-    d::Gamma
-end
-
-rand(s::GammaRmathSampler) = StatsFuns.RFunctions.gammarand(shape(s.d), scale(s.d))
-
-
 # "Generating gamma variates by a modified rejection technique"
 # J.H. Ahrens, U. Dieter
 # Communications of the ACM, Vol 25(1), 1982, pp 47-54
@@ -65,8 +58,7 @@ function GammaGDSampler(g::Gamma)
     GammaGDSampler(a,s2,s,i2s,d,q0,b,σ,c,scale(g))
 end
 
-rand(s::GammaGDSampler) = rand(GLOBAL_RNG, s)
-function rand(rng::AbstractRNG, s::GammaGDSampler)
+function _rand!(rng::AbstractRNG, s::GammaGDSampler)
     # Step 2
     t = randn(rng)
     x = s.s + 0.5t
@@ -153,8 +145,7 @@ function GammaGSSampler(d::Gamma)
     GammaGSSampler(a, ia, b, scale(d))
 end
 
-rand(s::GammaGSSampler) = rand(GLOBAL_RNG, s)
-function rand(rng::AbstractRNG, s::GammaGSSampler)
+function _rand!(rng::AbstractRNG, s::GammaGSSampler)
     while true
         # step 1
         p = s.b*rand(rng)
@@ -191,8 +182,7 @@ function GammaMTSampler(g::Gamma)
     GammaMTSampler(d, c, κ)
 end
 
-rand(s::GammaMTSampler) = rand(GLOBAL_RNG, s)
-function rand(rng::AbstractRNG, s::GammaMTSampler)
+function _rand!(rng::AbstractRNG, s::GammaMTSampler)
     while true
         x = randn(rng)
         v = 1.0 + s.c * x
@@ -221,9 +211,8 @@ function GammaIPSampler(d::Gamma,::Type{S}) where S<:Sampleable
 end
 GammaIPSampler(d::Gamma) = GammaIPSampler(d,GammaMTSampler)
 
-rand(s::GammaIPSampler) = rand(GLOBAL_RNG, s)
-function rand(rng::AbstractRNG, s::GammaIPSampler)
-    x = rand(rng, s.s)
+function _rand!(rng::AbstractRNG, s::GammaIPSampler)
+    x = _rand!(rng, s.s)
     e = randexp(rng)
     x*exp(s.nia*e)
 end
@@ -238,5 +227,3 @@ end
 #         GammaGDSampler(d)
 #     end
 # end
-
-# rand(d::Gamma) = rand(sampler(d))

--- a/src/samplers/multinomial.jl
+++ b/src/samplers/multinomial.jl
@@ -79,14 +79,14 @@ function multinom_rand!(rng::AbstractRNG, n::Int, p::Vector{Float64},
     return x
 end
 
-struct MultinomialSampler <: Sampleable{Multivariate,Discrete}
+struct MultinomialSampler{T<:Real} <: Sampleable{Multivariate,Discrete}
     n::Int
-    prob::Vector{Float64}
+    prob::Vector{T}
     alias::AliasTable
 end
 
-MultinomialSampler(n::Int, prob::Vector{Float64}) =
-    MultinomialSampler(n, prob, AliasTable(prob))
+MultinomialSampler(n::Int, prob::Vector{T}) where T<:Real =
+    MultinomialSampler{T}(n, prob, AliasTable(prob))
 
 _rand!(s::MultinomialSampler, x::AbstractVector{T}) where T<:Real =
     _rand!(GLOBAL_RNG, s, x)

--- a/src/samplers/multinomial.jl
+++ b/src/samplers/multinomial.jl
@@ -1,5 +1,6 @@
 
-function multinom_rand!(n::Int, p::Vector{Float64}, x::AbstractVector{T}) where T<:Real
+function multinom_rand!(n::Int, p::Vector{Float64},
+                        x::AbstractVector{T}) where T<:Real
     k = length(p)
     length(x) == k || throw(DimensionMismatch("Invalid argument dimension."))
 
@@ -10,15 +11,15 @@ function multinom_rand!(n::Int, p::Vector{Float64}, x::AbstractVector{T}) where 
     while i < km1 && n > 0
         i += 1
         @inbounds pi = p[i]
-        if pi < rp            
+        if pi < rp
             xi = rand(Binomial(n, pi / rp))
             @inbounds x[i] = xi
             n -= xi
             rp -= pi
-        else 
+        else
             # In this case, we don't even have to sample
             # from Binomial. Just assign remaining counts
-            # to xi. 
+            # to xi.
 
             @inbounds x[i] = n
             n = 0
@@ -35,7 +36,47 @@ function multinom_rand!(n::Int, p::Vector{Float64}, x::AbstractVector{T}) where 
         end
     end
 
-    return x  
+    return x
+end
+
+function multinom_rand!(rng::AbstractRNG, n::Int, p::Vector{Float64},
+                        x::AbstractVector{T}) where T<:Real
+    k = length(p)
+    length(x) == k || throw(DimensionMismatch("Invalid argument dimension."))
+
+    rp = 1.0  # remaining total probability
+    i = 0
+    km1 = k - 1
+
+    while i < km1 && n > 0
+        i += 1
+        @inbounds pi = p[i]
+        if pi < rp
+            xi = rand(rng, Binomial(n, pi / rp))
+            @inbounds x[i] = xi
+            n -= xi
+            rp -= pi
+        else
+            # In this case, we don't even have to sample
+            # from Binomial. Just assign remaining counts
+            # to xi.
+
+            @inbounds x[i] = n
+            n = 0
+            # rp = 0.0 (no need for this, as rp is no longer needed)
+        end
+    end
+
+    if i == km1
+        @inbounds x[k] = n
+    else  # n must have been zero
+        z = zero(T)
+        for j = i+1 : k
+            @inbounds x[j] = z
+        end
+    end
+
+    return x
 end
 
 struct MultinomialSampler <: Sampleable{Multivariate,Discrete}
@@ -44,25 +85,26 @@ struct MultinomialSampler <: Sampleable{Multivariate,Discrete}
     alias::AliasTable
 end
 
-MultinomialSampler(n::Int, prob::Vector{Float64}) = 
+MultinomialSampler(n::Int, prob::Vector{Float64}) =
     MultinomialSampler(n, prob, AliasTable(prob))
 
-function _rand!(s::MultinomialSampler, x::AbstractVector{T}) where T<:Real
+_rand!(s::MultinomialSampler, x::AbstractVector{T}) where T<:Real =
+    _rand!(GLOBAL_RNG, s, x)
+function _rand!(rng::AbstractRNG, s::MultinomialSampler,
+                x::AbstractVector{T}) where T<:Real
     n = s.n
     k = length(s)
-    if n^2 > k      
-        multinom_rand!(n, s.prob, x)
+    if n^2 > k
+        multinom_rand!(rng, n, s.prob, x)
     else
         # Use an alias table
         fill!(x, zero(T))
         a = s.alias
         for i = 1:n
-            x[rand(a)] += 1
+            x[rand(rng, a)] += 1
         end
     end
     return x
 end
 
 length(s::MultinomialSampler) = length(s.prob)
-
-

--- a/src/samplers/poisson.jl
+++ b/src/samplers/poisson.jl
@@ -17,7 +17,7 @@ struct PoissonCountSampler <: Sampleable{Univariate,Discrete}
     μ::Float64
 end
 
-function _rand!(rng::AbstractRNG, s::PoissonCountSampler)
+function _rand(rng::AbstractRNG, s::PoissonCountSampler)
     μ = s.μ
     n = 0
     c = randexp(rng)
@@ -46,7 +46,7 @@ end
 PoissonADSampler(μ::Float64) =
     PoissonADSampler(μ,sqrt(μ),6.0*μ^2,floor(Int,μ-1.1484))
 
-function _rand!(rng::AbstractRNG, s::PoissonADSampler)
+function _rand(rng::AbstractRNG, s::PoissonADSampler)
     # Step N
     G = s.μ + s.s*randn(rng)
 

--- a/src/samplers/poisson.jl
+++ b/src/samplers/poisson.jl
@@ -17,7 +17,7 @@ struct PoissonCountSampler <: Sampleable{Univariate,Discrete}
     μ::Float64
 end
 
-function _rand(rng::AbstractRNG, s::PoissonCountSampler)
+function rand(rng::AbstractRNG, s::PoissonCountSampler)
     μ = s.μ
     n = 0
     c = randexp(rng)
@@ -46,7 +46,7 @@ end
 PoissonADSampler(μ::Float64) =
     PoissonADSampler(μ,sqrt(μ),6.0*μ^2,floor(Int,μ-1.1484))
 
-function _rand(rng::AbstractRNG, s::PoissonADSampler)
+function rand(rng::AbstractRNG, s::PoissonADSampler)
     # Step N
     G = s.μ + s.s*randn(rng)
 

--- a/src/samplers/poissonbinomial.jl
+++ b/src/samplers/poissonbinomial.jl
@@ -4,5 +4,4 @@ end
 
 PoissBinAliasSampler(d::PoissonBinomial) = PoissBinAliasSampler(AliasTable(d.pmf))
 
-rand(s::PoissBinAliasSampler) = rand(s.table) - 1
-
+_rand!(rng::AbstractRNG, s::PoissBinAliasSampler) = _rand!(rng, s.table) - 1

--- a/src/samplers/poissonbinomial.jl
+++ b/src/samplers/poissonbinomial.jl
@@ -4,4 +4,4 @@ end
 
 PoissBinAliasSampler(d::PoissonBinomial) = PoissBinAliasSampler(AliasTable(d.pmf))
 
-_rand(rng::AbstractRNG, s::PoissBinAliasSampler) = _rand(rng, s.table) - 1
+rand(rng::AbstractRNG, s::PoissBinAliasSampler) = rand(rng, s.table) - 1

--- a/src/samplers/poissonbinomial.jl
+++ b/src/samplers/poissonbinomial.jl
@@ -4,4 +4,4 @@ end
 
 PoissBinAliasSampler(d::PoissonBinomial) = PoissBinAliasSampler(AliasTable(d.pmf))
 
-_rand!(rng::AbstractRNG, s::PoissBinAliasSampler) = _rand!(rng, s.table) - 1
+_rand(rng::AbstractRNG, s::PoissBinAliasSampler) = _rand(rng, s.table) - 1

--- a/src/samplers/vonmises.jl
+++ b/src/samplers/vonmises.jl
@@ -4,7 +4,7 @@ struct VonMisesSampler <: Sampleable{Univariate,Continuous}
     κ::Float64
     r::Float64
 
-    function VonMisesSampler(μ::Float64, κ::Float64) 
+    function VonMisesSampler(μ::Float64, κ::Float64)
         τ = 1.0 + sqrt(1.0 + 4 * abs2(κ))
         ρ = (τ - sqrt(2.0 * τ)) / (2.0 * κ)
         new(μ, κ, (1.0 + abs2(ρ)) / (2.0 * ρ))
@@ -15,17 +15,17 @@ end
 #     DJ Best & NI Fisher (1979). Efficient Simulation of the von Mises
 #     Distribution. Journal of the Royal Statistical Society. Series C
 #     (Applied Statistics), 28(2), 152-157.
-function rand(s::VonMisesSampler)
+function _rand!(rng::AbstractRNG, s::VonMisesSampler)
     f = 0.0
     local x::Float64
     if s.κ > 700.0
-        x = s.μ + randn() / sqrt(s.κ)
+        x = s.μ + randn(rng) / sqrt(s.κ)
     else
         while true
             t, u = 0.0, 0.0
             while true
-                d = abs2(rand() - 0.5)
-                e = abs2(rand() - 0.5)
+                d = abs2(rand(rng) - 0.5)
+                e = abs2(rand(rng) - 0.5)
                 if d + e <= 0.25
                     t = d / e
                     u = 4 * (d + e)
@@ -40,7 +40,7 @@ function rand(s::VonMisesSampler)
             end
         end
         acf = acos(f)
-        x = s.μ + (rand(Bool) ? acf : -acf)
+        x = s.μ + (rand(rng, Bool) ? acf : -acf)
     end
     return x
 end

--- a/src/samplers/vonmisesfisher.jl
+++ b/src/samplers/vonmisesfisher.jl
@@ -64,10 +64,10 @@ function _vmf_genw(rng::AbstractRNG, p, b, x0, c, κ)
 
     r = (p - 1) / 2.0
     betad = Beta(r, r)
-    z = _rand(rng, betad)
+    z = rand(rng, betad)
     w = (1.0 - (1.0 + b) * z) / (1.0 - (1.0 - b) * z)
     while κ * w + (p - 1) * log(1 - x0 * w) - c < log(rand(rng))
-        z = _rand(rng, betad)
+        z = rand(rng, betad)
         w = (1.0 - (1.0 + b) * z) / (1.0 - (1.0 - b) * z)
     end
     return w::Float64

--- a/src/samplers/vonmisesfisher.jl
+++ b/src/samplers/vonmisesfisher.jl
@@ -64,10 +64,10 @@ function _vmf_genw(rng::AbstractRNG, p, b, x0, c, κ)
 
     r = (p - 1) / 2.0
     betad = Beta(r, r)
-    z = _rand!(rng, betad)
+    z = _rand(rng, betad)
     w = (1.0 - (1.0 + b) * z) / (1.0 - (1.0 - b) * z)
-    while κ * w + (p - 1) * log(1 - x0 * w) - c < log(rand())
-        z = _rand!(rng, betad)
+    while κ * w + (p - 1) * log(1 - x0 * w) - c < log(rand(rng))
+        z = _rand(rng, betad)
         w = (1.0 - (1.0 + b) * z) / (1.0 - (1.0 - b) * z)
     end
     return w::Float64

--- a/src/testutils.jl
+++ b/src/testutils.jl
@@ -119,7 +119,7 @@ function test_samples(s::Sampleable{Univariate, Discrete},      # the sampleable
         @assert cub[i] >= clb[i]
     end
 
-    # generate samples using global RNG
+    # generate samples using RNG passed or global RNG
     samples = ismissing(rng) ? rand(s, n) : rand(rng, s, n)
     @assert length(samples) == n
 

--- a/src/testutils.jl
+++ b/src/testutils.jl
@@ -44,7 +44,7 @@ end
 # testing the implementation of a continuous univariate distribution
 #
 function test_distr(distr::ContinuousUnivariateDistribution, n::Int;
-                    testquan::Bool=true)
+                    testquan::Bool=true, rng::AbstractRNG=MersenneTwister(123))
     test_range(distr)
     vs = get_evalsamples(distr, 0.01, 2000)
 
@@ -56,7 +56,7 @@ function test_distr(distr::ContinuousUnivariateDistribution, n::Int;
     end
     xs = test_samples(distr, n)
     allow_test_stats(distr) && test_stats(distr, xs)
-    xs = test_samples(distr, n, rng=MersenneTwister())
+    xs = test_samples(distr, n, rng=rng)
     allow_test_stats(distr) && test_stats(distr, xs)
     test_params(distr)
 end

--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -79,17 +79,17 @@ logccdf(d::Truncated, x::T) where {T<:Real} =
 
 ## random number generation
 
-function rand(d::Truncated)
+function _rand!(rng::AbstractRNG, d::Truncated)
     d0 = d.untruncated
     if d.tp > 0.25
         while true
-            r = rand(d0)
+            r = _rand!(rng, d0)
             if d.lower <= r <= d.upper
                 return r
             end
         end
     else
-        return quantile(d0, d.lcdf + rand() * d.tp)
+        return quantile(d0, d.lcdf + rand(rng) * d.tp)
     end
 end
 

--- a/src/truncated/normal.jl
+++ b/src/truncated/normal.jl
@@ -147,7 +147,7 @@ end
 ## Use specialized sampler, as quantile-based method is inaccurate in
 ## tail regions of the Normal, issue #343
 
-function _rand(rng::AbstractRNG, d::Truncated{Normal{T},Continuous}) where T <: Real
+function rand(rng::AbstractRNG, d::Truncated{Normal{T},Continuous}) where T <: Real
     d0 = d.untruncated
     μ = mean(d0)
     σ = std(d0)
@@ -175,7 +175,7 @@ function randnt(rng::AbstractRNG, lb::Float64, ub::Float64, tp::Float64)
         if lb > 0 && span > 2.0 / (lb + sqrt(lb^2 + 4.0)) * exp((lb^2 - lb * sqrt(lb^2 + 4.0)) / 4.0)
             a = (lb + sqrt(lb^2 + 4.0))/2.0
             while true
-                r = _rand(rng, Exponential(1.0 / a)) + lb
+                r = rand(rng, Exponential(1.0 / a)) + lb
                 u = rand(rng)
                 if u < exp(-0.5 * (r - a)^2) && r < ub
                     return r
@@ -184,7 +184,7 @@ function randnt(rng::AbstractRNG, lb::Float64, ub::Float64, tp::Float64)
         elseif ub < 0 && ub - lb > 2.0 / (-ub + sqrt(ub^2 + 4.0)) * exp((ub^2 + ub * sqrt(ub^2 + 4.0)) / 4.0)
             a = (-ub + sqrt(ub^2 + 4.0)) / 2.0
             while true
-                r = _rand(rng, Exponential(1.0 / a)) - ub
+                r = rand(rng, Exponential(1.0 / a)) - ub
                 u = rand(rng)
                 if u < exp(-0.5 * (r - a)^2) && r < -lb
                     return -r

--- a/src/truncated/normal.jl
+++ b/src/truncated/normal.jl
@@ -147,13 +147,13 @@ end
 ## Use specialized sampler, as quantile-based method is inaccurate in
 ## tail regions of the Normal, issue #343
 
-function rand(d::Truncated{Normal{T},Continuous}) where T <: Real
+function _rand(rng::AbstractRNG, d::Truncated{Normal{T},Continuous}) where T <: Real
     d0 = d.untruncated
     μ = mean(d0)
     σ = std(d0)
     a = (d.lower - μ) / σ
     b = (d.upper - μ) / σ
-    z = randnt(a, b, d.tp)
+    z = randnt(rng, a, b, d.tp)
     return μ + σ * z
 end
 
@@ -161,12 +161,12 @@ end
 #
 #  - Available at http://arxiv.org/abs/0907.4010
 
-function randnt(lb::Float64, ub::Float64, tp::Float64)
+function randnt(rng::AbstractRNG, lb::Float64, ub::Float64, tp::Float64)
     local r::Float64
     if tp > 0.3   # has considerable chance of falling in [lb, ub]
-        r = randn()
+        r = randn(rng)
         while r < lb || r > ub
-            r = randn()
+            r = randn(rng)
         end
         return r
 
@@ -175,8 +175,8 @@ function randnt(lb::Float64, ub::Float64, tp::Float64)
         if lb > 0 && span > 2.0 / (lb + sqrt(lb^2 + 4.0)) * exp((lb^2 - lb * sqrt(lb^2 + 4.0)) / 4.0)
             a = (lb + sqrt(lb^2 + 4.0))/2.0
             while true
-                r = rand(Exponential(1.0 / a)) + lb
-                u = rand()
+                r = _rand(rng, Exponential(1.0 / a)) + lb
+                u = rand(rng)
                 if u < exp(-0.5 * (r - a)^2) && r < ub
                     return r
                 end
@@ -184,16 +184,16 @@ function randnt(lb::Float64, ub::Float64, tp::Float64)
         elseif ub < 0 && ub - lb > 2.0 / (-ub + sqrt(ub^2 + 4.0)) * exp((ub^2 + ub * sqrt(ub^2 + 4.0)) / 4.0)
             a = (-ub + sqrt(ub^2 + 4.0)) / 2.0
             while true
-                r = rand(Exponential(1.0 / a)) - ub
-                u = rand()
+                r = _rand(rng, Exponential(1.0 / a)) - ub
+                u = rand(rng)
                 if u < exp(-0.5 * (r - a)^2) && r < -lb
                     return -r
                 end
             end
         else
             while true
-                r = lb + rand() * (ub - lb)
-                u = rand()
+                r = lb + rand(rng) * (ub - lb)
+                u = rand(rng)
                 if lb > 0
                     rho = exp((lb^2 - r^2) * 0.5)
                 elseif ub < 0

--- a/src/univariate/continuous/arcsine.jl
+++ b/src/univariate/continuous/arcsine.jl
@@ -84,9 +84,3 @@ cdf(d::Arcsine{T}, x::Real) where {T<:Real} = x < d.a ? zero(T) :
                               0.636619772367581343 * asin(sqrt((x - d.a) / (d.b - d.a)))
 
 quantile(d::Arcsine, p::Real) = location(d) + abs2(sin(halfπ * p)) * scale(d)
-
-
-### Sampling
-
-rand(d::Arcsine) = rand(GLOBAL_RNG, d)
-rand(rng::AbstractRNG, d::Arcsine) = quantile(d, rand(rng))

--- a/src/univariate/continuous/beta.jl
+++ b/src/univariate/continuous/beta.jl
@@ -26,7 +26,7 @@ External links
 * [Beta distribution on Wikipedia](http://en.wikipedia.org/wiki/Beta_distribution)
 
 """
-struct Beta{T<:Real} <: ContinuousUnivariateDistribution
+struct Beta{T<:Real} <: ContinuousUnivariateRDist
     α::T
     β::T
 
@@ -117,7 +117,6 @@ gradlogpdf(d::Beta{T}, x::Real) where {T<:Real} =
 #### Sampling
 
 rand(d::Beta) = StatsFuns.RFunctions.betarand(d.α, d.β)
-
 
 #### Fit model
 

--- a/src/univariate/continuous/beta.jl
+++ b/src/univariate/continuous/beta.jl
@@ -139,10 +139,10 @@ function sampler(d::Beta{T}) where T
 end
 
 # From Knuth
-function _rand(rng::AbstractRNG, s::BetaSampler)
+function rand(rng::AbstractRNG, s::BetaSampler)
     if s.γ
-        g1 = _rand(rng, s.s1)
-        g2 = _rand(rng, s.s2)
+        g1 = rand(rng, s.s1)
+        g2 = rand(rng, s.s2)
         return g1 / (g1 + g2)
     else
         iα = s.iα
@@ -168,7 +168,7 @@ function _rand(rng::AbstractRNG, s::BetaSampler)
     end
 end
 
-function _rand(rng::AbstractRNG, d::Beta{T}) where T
+function rand(rng::AbstractRNG, d::Beta{T}) where T
     (α, β) = params(d)
     if (α ≤ 1.0) && (β ≤ 1.0)
         while true
@@ -190,8 +190,8 @@ function _rand(rng::AbstractRNG, d::Beta{T}) where T
             end
         end
     else
-        g1 = _rand(rng, Gamma(α, one(T)))
-        g2 = _rand(rng, Gamma(β, one(T)))
+        g1 = rand(rng, Gamma(α, one(T)))
+        g2 = rand(rng, Gamma(β, one(T)))
         return g1 / (g1 + g2)
     end
 end

--- a/src/univariate/continuous/beta.jl
+++ b/src/univariate/continuous/beta.jl
@@ -139,10 +139,10 @@ function sampler(d::Beta{T}) where T
 end
 
 # From Knuth
-function _rand!(rng::AbstractRNG, s::BetaSampler)
+function _rand(rng::AbstractRNG, s::BetaSampler)
     if s.γ
-        g1 = _rand!(rng, s.s1)
-        g2 = _rand!(rng, s.s2)
+        g1 = _rand(rng, s.s1)
+        g2 = _rand(rng, s.s2)
         return g1 / (g1 + g2)
     else
         iα = s.iα
@@ -168,7 +168,7 @@ function _rand!(rng::AbstractRNG, s::BetaSampler)
     end
 end
 
-function _rand!(rng::AbstractRNG, d::Beta{T}) where T
+function _rand(rng::AbstractRNG, d::Beta{T}) where T
     (α, β) = params(d)
     if (α ≤ 1.0) && (β ≤ 1.0)
         while true
@@ -190,8 +190,8 @@ function _rand!(rng::AbstractRNG, d::Beta{T}) where T
             end
         end
     else
-        g1 = _rand!(rng, Gamma(α, one(T)))
-        g2 = _rand!(rng, Gamma(β, one(T)))
+        g1 = _rand(rng, Gamma(α, one(T)))
+        g2 = _rand(rng, Gamma(β, one(T)))
         return g1 / (g1 + g2)
     end
 end

--- a/src/univariate/continuous/betaprime.jl
+++ b/src/univariate/continuous/betaprime.jl
@@ -109,7 +109,7 @@ invlogccdf(d::BetaPrime, p::Real) = (x = betainvlogccdf(d.α, d.β, p); x / (1 -
 
 #### Sampling
 
-function _rand!(rng::AbstractRNG, d::BetaPrime)
+function _rand(rng::AbstractRNG, d::BetaPrime)
     (α, β) = params(d)
     rand(rng, Gamma(α)) / rand(rng, Gamma(β))
 end

--- a/src/univariate/continuous/betaprime.jl
+++ b/src/univariate/continuous/betaprime.jl
@@ -109,7 +109,7 @@ invlogccdf(d::BetaPrime, p::Real) = (x = betainvlogccdf(d.α, d.β, p); x / (1 -
 
 #### Sampling
 
-function _rand(rng::AbstractRNG, d::BetaPrime)
+function rand(rng::AbstractRNG, d::BetaPrime)
     (α, β) = params(d)
     rand(rng, Gamma(α)) / rand(rng, Gamma(β))
 end

--- a/src/univariate/continuous/betaprime.jl
+++ b/src/univariate/continuous/betaprime.jl
@@ -109,7 +109,7 @@ invlogccdf(d::BetaPrime, p::Real) = (x = betainvlogccdf(d.α, d.β, p); x / (1 -
 
 #### Sampling
 
-function rand(d::BetaPrime)
+function _rand!(rng::AbstractRNG, d::BetaPrime)
     (α, β) = params(d)
-    rand(Gamma(α)) / rand(Gamma(β))
+    rand(rng, Gamma(α)) / rand(rng, Gamma(β))
 end

--- a/src/univariate/continuous/chi.jl
+++ b/src/univariate/continuous/chi.jl
@@ -96,4 +96,13 @@ invlogccdf(d::Chi, p::Real) = sqrt(chisqinvlogccdf(d.ν, p))
 #### Sampling
 
 _rand!(rng::AbstractRNG, d::Chi) =
-    sqrt(2 * _rand!(rng, Gamma(d.ν / 2, one(d.ν))))
+    (ν = d.ν; sqrt(_rand!(rng, Gamma(ν / 2.0, 2.0one(ν)))))
+
+struct ChiSampler{S <: Sampleable{Univariate,Continuous}} <:
+    Sampleable{Univariate,Continuous}
+    s::S
+end
+
+_rand!(rng::AbstractRNG, s::ChiSampler) = sqrt(_rand!(rng, s.s))
+
+sampler(d::Chi) = ChiSampler(sampler(Chisq(d.ν)))

--- a/src/univariate/continuous/chi.jl
+++ b/src/univariate/continuous/chi.jl
@@ -95,7 +95,5 @@ invlogccdf(d::Chi, p::Real) = sqrt(chisqinvlogccdf(d.ν, p))
 
 #### Sampling
 
-# Rfunctions
-rand(d::Chi) = sqrt(_chisq_rand(d.ν))
-
-_rand(rng::AbstractRNG, d::Chi) = sqrt(_chisq_rand(rng, d.ν))
+_rand!(rng::AbstractRNG, d::Chi) =
+    sqrt(2 * _rand!(rng, Gamma(d.ν / 2, one(d.ν))))

--- a/src/univariate/continuous/chi.jl
+++ b/src/univariate/continuous/chi.jl
@@ -95,14 +95,14 @@ invlogccdf(d::Chi, p::Real) = sqrt(chisqinvlogccdf(d.ν, p))
 
 #### Sampling
 
-_rand(rng::AbstractRNG, d::Chi) =
-    (ν = d.ν; sqrt(_rand(rng, Gamma(ν / 2.0, 2.0one(ν)))))
+rand(rng::AbstractRNG, d::Chi) =
+    (ν = d.ν; sqrt(rand(rng, Gamma(ν / 2.0, 2.0one(ν)))))
 
 struct ChiSampler{S <: Sampleable{Univariate,Continuous}} <:
     Sampleable{Univariate,Continuous}
     s::S
 end
 
-_rand(rng::AbstractRNG, s::ChiSampler) = sqrt(_rand(rng, s.s))
+rand(rng::AbstractRNG, s::ChiSampler) = sqrt(rand(rng, s.s))
 
 sampler(d::Chi) = ChiSampler(sampler(Chisq(d.ν)))

--- a/src/univariate/continuous/chi.jl
+++ b/src/univariate/continuous/chi.jl
@@ -95,14 +95,14 @@ invlogccdf(d::Chi, p::Real) = sqrt(chisqinvlogccdf(d.ν, p))
 
 #### Sampling
 
-_rand!(rng::AbstractRNG, d::Chi) =
-    (ν = d.ν; sqrt(_rand!(rng, Gamma(ν / 2.0, 2.0one(ν)))))
+_rand(rng::AbstractRNG, d::Chi) =
+    (ν = d.ν; sqrt(_rand(rng, Gamma(ν / 2.0, 2.0one(ν)))))
 
 struct ChiSampler{S <: Sampleable{Univariate,Continuous}} <:
     Sampleable{Univariate,Continuous}
     s::S
 end
 
-_rand!(rng::AbstractRNG, s::ChiSampler) = sqrt(_rand!(rng, s.s))
+_rand(rng::AbstractRNG, s::ChiSampler) = sqrt(_rand(rng, s.s))
 
 sampler(d::Chi) = ChiSampler(sampler(Chisq(d.ν)))

--- a/src/univariate/continuous/chi.jl
+++ b/src/univariate/continuous/chi.jl
@@ -95,4 +95,7 @@ invlogccdf(d::Chi, p::Real) = sqrt(chisqinvlogccdf(d.ν, p))
 
 #### Sampling
 
+# Rfunctions
 rand(d::Chi) = sqrt(_chisq_rand(d.ν))
+
+_rand(rng::AbstractRNG, d::Chi) = sqrt(_chisq_rand(rng, d.ν))

--- a/src/univariate/continuous/chisq.jl
+++ b/src/univariate/continuous/chisq.jl
@@ -81,7 +81,7 @@ gradlogpdf(d::Chisq{T}, x::Real) where {T<:Real} =  x > 0 ? (d.ν/2 - 1) / x - 1
 
 #### Sampling
 
-_rand(rng::AbstractRNG, d::Chisq) =
-    (ν = d.ν; _rand(rng, Gamma(ν / 2.0, 2.0one(ν))))
+rand(rng::AbstractRNG, d::Chisq) =
+    (ν = d.ν; rand(rng, Gamma(ν / 2.0, 2.0one(ν))))
 
 sampler(d::Chisq) = (ν = d.ν; sampler(Gamma(ν / 2.0, 2.0one(ν))))

--- a/src/univariate/continuous/chisq.jl
+++ b/src/univariate/continuous/chisq.jl
@@ -81,5 +81,7 @@ gradlogpdf(d::Chisq{T}, x::Real) where {T<:Real} =  x > 0 ? (d.ν/2 - 1) / x - 1
 
 #### Sampling
 
-# From GSL
-_rand!(rng::AbstractRNG, d::Chisq) = 2 * _rand!(rng, Gamma(d.ν / 2, one(d.ν)))
+_rand!(rng::AbstractRNG, d::Chisq) =
+    (ν = d.ν; _rand!(rng, Gamma(ν / 2.0, 2.0one(ν))))
+
+sampler(d::Chisq) = (ν = d.ν; sampler(Gamma(ν / 2.0, 2.0one(ν))))

--- a/src/univariate/continuous/chisq.jl
+++ b/src/univariate/continuous/chisq.jl
@@ -81,7 +81,7 @@ gradlogpdf(d::Chisq{T}, x::Real) where {T<:Real} =  x > 0 ? (d.ν/2 - 1) / x - 1
 
 #### Sampling
 
-_rand!(rng::AbstractRNG, d::Chisq) =
-    (ν = d.ν; _rand!(rng, Gamma(ν / 2.0, 2.0one(ν))))
+_rand(rng::AbstractRNG, d::Chisq) =
+    (ν = d.ν; _rand(rng, Gamma(ν / 2.0, 2.0one(ν))))
 
 sampler(d::Chisq) = (ν = d.ν; sampler(Gamma(ν / 2.0, 2.0one(ν))))

--- a/src/univariate/continuous/chisq.jl
+++ b/src/univariate/continuous/chisq.jl
@@ -20,7 +20,7 @@ External links
 
 * [Chi-squared distribution on Wikipedia](http://en.wikipedia.org/wiki/Chi-squared_distribution)
 """
-struct Chisq{T<:Real} <: ContinuousUnivariateRDist
+struct Chisq{T<:Real} <: ContinuousUnivariateDistribution
     ν::T
 
     Chisq{T}(ν::T) where {T} = (@check_args(Chisq, ν > zero(ν)); new{T}(ν))
@@ -81,7 +81,5 @@ gradlogpdf(d::Chisq{T}, x::Real) where {T<:Real} =  x > 0 ? (d.ν/2 - 1) / x - 1
 
 #### Sampling
 
-_chisq_rand(ν::Float64) = StatsFuns.RFunctions.chisqrand(ν)
-rand(d::Chisq) = _chisq_rand(d.ν)
-
-_rand(rng::AbstractRNG, d::Chisq) = _chisq_rand(rng, d.ν)
+# From GSL
+_rand!(rng::AbstractRNG, d::Chisq) = 2 * _rand!(rng, Gamma(d.ν / 2, one(d.ν)))

--- a/src/univariate/continuous/chisq.jl
+++ b/src/univariate/continuous/chisq.jl
@@ -20,7 +20,7 @@ External links
 
 * [Chi-squared distribution on Wikipedia](http://en.wikipedia.org/wiki/Chi-squared_distribution)
 """
-struct Chisq{T<:Real} <: ContinuousUnivariateDistribution
+struct Chisq{T<:Real} <: ContinuousUnivariateRDist
     ν::T
 
     Chisq{T}(ν::T) where {T} = (@check_args(Chisq, ν > zero(ν)); new{T}(ν))
@@ -83,3 +83,5 @@ gradlogpdf(d::Chisq{T}, x::Real) where {T<:Real} =  x > 0 ? (d.ν/2 - 1) / x - 1
 
 _chisq_rand(ν::Float64) = StatsFuns.RFunctions.chisqrand(ν)
 rand(d::Chisq) = _chisq_rand(d.ν)
+
+_rand(rng::AbstractRNG, d::Chisq) = _chisq_rand(rng, d.ν)

--- a/src/univariate/continuous/erlang.jl
+++ b/src/univariate/continuous/erlang.jl
@@ -72,5 +72,5 @@ cf(d::Erlang, t::Real)  = (1 - im * t * d.θ)^(-d.α)
 
 @_delegate_statsfuns Erlang gamma α θ
 
-_rand!(rng, ::AbstractRNG, d::Erlang) = _rand!(rng, Gamma(Float64(d.α), d.θ))
+_rand(rng, ::AbstractRNG, d::Erlang) = _rand(rng, Gamma(Float64(d.α), d.θ))
 sampler(d::Erlang) = Gamma(Float64(d.α), d.θ)

--- a/src/univariate/continuous/erlang.jl
+++ b/src/univariate/continuous/erlang.jl
@@ -72,5 +72,5 @@ cf(d::Erlang, t::Real)  = (1 - im * t * d.θ)^(-d.α)
 
 @_delegate_statsfuns Erlang gamma α θ
 
-_rand(rng, ::AbstractRNG, d::Erlang) = _rand(rng, Gamma(Float64(d.α), d.θ))
+rand(rng, ::AbstractRNG, d::Erlang) = rand(rng, Gamma(Float64(d.α), d.θ))
 sampler(d::Erlang) = Gamma(Float64(d.α), d.θ)

--- a/src/univariate/continuous/erlang.jl
+++ b/src/univariate/continuous/erlang.jl
@@ -72,4 +72,5 @@ cf(d::Erlang, t::Real)  = (1 - im * t * d.θ)^(-d.α)
 
 @_delegate_statsfuns Erlang gamma α θ
 
-rand(d::Erlang) = StatsFuns.RFunctions.gammarand(d.α, d.θ)
+_rand!(rng, ::AbstractRNG, d::Erlang) = _rand!(rng, Gamma(Float64(d.α), d.θ))
+sampler(d::Erlang) = Gamma(Float64(d.α), d.θ)

--- a/src/univariate/continuous/exponential.jl
+++ b/src/univariate/continuous/exponential.jl
@@ -87,7 +87,7 @@ cf(d::Exponential, t::Real) = 1/(1 - t * im * scale(d))
 
 
 #### Sampling
-_rand!(rng::AbstractRNG, d::Exponential) = xval(d, randexp(rng))
+_rand(rng::AbstractRNG, d::Exponential) = xval(d, randexp(rng))
 
 
 #### Fit model

--- a/src/univariate/continuous/exponential.jl
+++ b/src/univariate/continuous/exponential.jl
@@ -87,8 +87,7 @@ cf(d::Exponential, t::Real) = 1/(1 - t * im * scale(d))
 
 
 #### Sampling
-rand(d::Exponential) = rand(GLOBAL_RNG, d)
-rand(rng::AbstractRNG, d::Exponential) = xval(d, randexp(rng))
+_rand!(rng::AbstractRNG, d::Exponential) = xval(d, randexp(rng))
 
 
 #### Fit model

--- a/src/univariate/continuous/exponential.jl
+++ b/src/univariate/continuous/exponential.jl
@@ -87,7 +87,7 @@ cf(d::Exponential, t::Real) = 1/(1 - t * im * scale(d))
 
 
 #### Sampling
-_rand(rng::AbstractRNG, d::Exponential) = xval(d, randexp(rng))
+rand(rng::AbstractRNG, d::Exponential) = xval(d, randexp(rng))
 
 
 #### Fit model

--- a/src/univariate/continuous/fdist.jl
+++ b/src/univariate/continuous/fdist.jl
@@ -100,6 +100,6 @@ end
 
 @_delegate_statsfuns FDist fdist ν1 ν2
 
-_rand!(rng::AbstractRNG, d::FDist) =
+_rand(rng::AbstractRNG, d::FDist) =
     ((ν1, ν2) = params(d);
-     (ν2 * _rand!(rng, Chisq(ν1))) / (ν1 * _rand!(rng, Chisq(ν2))))
+     (ν2 * _rand(rng, Chisq(ν1))) / (ν1 * _rand(rng, Chisq(ν2))))

--- a/src/univariate/continuous/fdist.jl
+++ b/src/univariate/continuous/fdist.jl
@@ -22,7 +22,7 @@ External links
 
 * [F distribution on Wikipedia](http://en.wikipedia.org/wiki/F-distribution)
 """
-struct FDist{T<:Real} <: ContinuousUnivariateDistribution
+struct FDist{T<:Real} <: ContinuousUnivariateRDist
     ν1::T
     ν2::T
 

--- a/src/univariate/continuous/fdist.jl
+++ b/src/univariate/continuous/fdist.jl
@@ -100,6 +100,6 @@ end
 
 @_delegate_statsfuns FDist fdist ν1 ν2
 
-_rand(rng::AbstractRNG, d::FDist) =
+rand(rng::AbstractRNG, d::FDist) =
     ((ν1, ν2) = params(d);
-     (ν2 * _rand(rng, Chisq(ν1))) / (ν1 * _rand(rng, Chisq(ν2))))
+     (ν2 * rand(rng, Chisq(ν1))) / (ν1 * rand(rng, Chisq(ν2))))

--- a/src/univariate/continuous/fdist.jl
+++ b/src/univariate/continuous/fdist.jl
@@ -22,7 +22,7 @@ External links
 
 * [F distribution on Wikipedia](http://en.wikipedia.org/wiki/F-distribution)
 """
-struct FDist{T<:Real} <: ContinuousUnivariateRDist
+struct FDist{T<:Real} <: ContinuousUnivariateDistribution
     ν1::T
     ν2::T
 
@@ -100,4 +100,6 @@ end
 
 @_delegate_statsfuns FDist fdist ν1 ν2
 
-rand(d::FDist) = StatsFuns.RFunctions.fdistrand(d.ν1, d.ν2)
+_rand!(rng::AbstractRNG, d::FDist) =
+    ((ν1, ν2) = params(d);
+     (ν2 * _rand!(rng, Chisq(ν1))) / (ν1 * _rand!(rng, Chisq(ν2))))

--- a/src/univariate/continuous/frechet.jl
+++ b/src/univariate/continuous/frechet.jl
@@ -138,4 +138,4 @@ end
 
 ## Sampling
 
-_rand(rng::AbstractRNG, d::Frechet) = d.θ * randexp(rng) ^ (-1 / d.α)
+rand(rng::AbstractRNG, d::Frechet) = d.θ * randexp(rng) ^ (-1 / d.α)

--- a/src/univariate/continuous/frechet.jl
+++ b/src/univariate/continuous/frechet.jl
@@ -138,5 +138,4 @@ end
 
 ## Sampling
 
-rand(d::Frechet) = rand(GLOBAL_RNG, d)
-rand(rng::AbstractRNG, d::Frechet) = d.θ * randexp(rng) ^ (-1 / d.α)
+_rand!(rng::AbstractRNG, d::Frechet) = d.θ * randexp(rng) ^ (-1 / d.α)

--- a/src/univariate/continuous/frechet.jl
+++ b/src/univariate/continuous/frechet.jl
@@ -138,4 +138,4 @@ end
 
 ## Sampling
 
-_rand!(rng::AbstractRNG, d::Frechet) = d.θ * randexp(rng) ^ (-1 / d.α)
+_rand(rng::AbstractRNG, d::Frechet) = d.θ * randexp(rng) ^ (-1 / d.α)

--- a/src/univariate/continuous/gamma.jl
+++ b/src/univariate/continuous/gamma.jl
@@ -88,15 +88,14 @@ cf(d::Gamma, t::Real) = (1 - im * t * d.θ)^(-d.α)
 gradlogpdf(d::Gamma{T}, x::Real) where {T<:Real} =
     insupport(Gamma, x) ? (d.α - 1) / x - 1 / d.θ : zero(T)
 
-rand(d::Gamma) = StatsFuns.RFunctions.gammarand(d.α, d.θ)
-function rand(rng::AbstractRNG, d::Gamma)
+function _rand!(rng::AbstractRNG, d::Gamma)
     if shape(d) < 1.0
         # TODO: shape(d) = 0.5 : use scaled chisq
-        return rand(rng, GammaIPSampler(d))
+        return _rand!(rng, GammaIPSampler(d))
     elseif shape(d) == 1.0
-        return rand(rng, Exponential(d.scale))
+        return _rand!(rng, Exponential(d.θ))
     else
-        return rand(rng, GammaGDSampler(d))
+        return _rand!(rng, GammaGDSampler(d))
     end
 end
 

--- a/src/univariate/continuous/gamma.jl
+++ b/src/univariate/continuous/gamma.jl
@@ -88,14 +88,14 @@ cf(d::Gamma, t::Real) = (1 - im * t * d.θ)^(-d.α)
 gradlogpdf(d::Gamma{T}, x::Real) where {T<:Real} =
     insupport(Gamma, x) ? (d.α - 1) / x - 1 / d.θ : zero(T)
 
-function _rand(rng::AbstractRNG, d::Gamma)
+function rand(rng::AbstractRNG, d::Gamma)
     if shape(d) < 1.0
         # TODO: shape(d) = 0.5 : use scaled chisq
-        return _rand(rng, GammaIPSampler(d))
+        return rand(rng, GammaIPSampler(d))
     elseif shape(d) == 1.0
-        return _rand(rng, Exponential(d.θ))
+        return rand(rng, Exponential(d.θ))
     else
-        return _rand(rng, GammaGDSampler(d))
+        return rand(rng, GammaGDSampler(d))
     end
 end
 

--- a/src/univariate/continuous/gamma.jl
+++ b/src/univariate/continuous/gamma.jl
@@ -99,6 +99,17 @@ function _rand!(rng::AbstractRNG, d::Gamma)
     end
 end
 
+function sampler(d::Gamma)
+    if shape(d) < 1.0
+        # TODO: shape(d) = 0.5 : use scaled chisq
+        return GammaIPSampler(d)
+    elseif shape(d) == 1.0
+        return sampler(Exponential(d.θ))
+    else
+        return GammaGDSampler(d)
+    end
+end
+
 #### Fit model
 
 struct GammaStats <: SufficientStats

--- a/src/univariate/continuous/gamma.jl
+++ b/src/univariate/continuous/gamma.jl
@@ -88,14 +88,14 @@ cf(d::Gamma, t::Real) = (1 - im * t * d.θ)^(-d.α)
 gradlogpdf(d::Gamma{T}, x::Real) where {T<:Real} =
     insupport(Gamma, x) ? (d.α - 1) / x - 1 / d.θ : zero(T)
 
-function _rand!(rng::AbstractRNG, d::Gamma)
+function _rand(rng::AbstractRNG, d::Gamma)
     if shape(d) < 1.0
         # TODO: shape(d) = 0.5 : use scaled chisq
-        return _rand!(rng, GammaIPSampler(d))
+        return _rand(rng, GammaIPSampler(d))
     elseif shape(d) == 1.0
-        return _rand!(rng, Exponential(d.θ))
+        return _rand(rng, Exponential(d.θ))
     else
-        return _rand!(rng, GammaGDSampler(d))
+        return _rand(rng, GammaGDSampler(d))
     end
 end
 

--- a/src/univariate/continuous/gamma.jl
+++ b/src/univariate/continuous/gamma.jl
@@ -89,7 +89,16 @@ gradlogpdf(d::Gamma{T}, x::Real) where {T<:Real} =
     insupport(Gamma, x) ? (d.α - 1) / x - 1 / d.θ : zero(T)
 
 rand(d::Gamma) = StatsFuns.RFunctions.gammarand(d.α, d.θ)
-
+function rand(rng::AbstractRNG, d::Gamma)
+    if shape(d) < 1.0
+        # TODO: shape(d) = 0.5 : use scaled chisq
+        return rand(rng, GammaIPSampler(d))
+    elseif shape(d) == 1.0
+        return rand(rng, Exponential(d.scale))
+    else
+        return rand(rng, GammaGDSampler(d))
+    end
+end
 
 #### Fit model
 

--- a/src/univariate/continuous/generalizedextremevalue.jl
+++ b/src/univariate/continuous/generalizedextremevalue.jl
@@ -259,7 +259,7 @@ ccdf(d::GeneralizedExtremeValue, x::Real) = - expm1(logcdf(d, x))
 
 
 #### Sampling
-function _rand(rng::AbstractRNG, d::GeneralizedExtremeValue)
+function rand(rng::AbstractRNG, d::GeneralizedExtremeValue)
     (μ, σ, ξ) = params(d)
 
     # Generate a Float64 random number uniformly in (0,1].

--- a/src/univariate/continuous/generalizedextremevalue.jl
+++ b/src/univariate/continuous/generalizedextremevalue.jl
@@ -259,7 +259,7 @@ ccdf(d::GeneralizedExtremeValue, x::Real) = - expm1(logcdf(d, x))
 
 
 #### Sampling
-function _rand!(rng::AbstractRNG, d::GeneralizedExtremeValue)
+function _rand(rng::AbstractRNG, d::GeneralizedExtremeValue)
     (μ, σ, ξ) = params(d)
 
     # Generate a Float64 random number uniformly in (0,1].

--- a/src/univariate/continuous/generalizedextremevalue.jl
+++ b/src/univariate/continuous/generalizedextremevalue.jl
@@ -259,8 +259,7 @@ ccdf(d::GeneralizedExtremeValue, x::Real) = - expm1(logcdf(d, x))
 
 
 #### Sampling
-rand(d::GeneralizedExtremeValue) = rand(GLOBAL_RNG, d)
-function rand(rng::AbstractRNG, d::GeneralizedExtremeValue)
+function _rand!(rng::AbstractRNG, d::GeneralizedExtremeValue)
     (μ, σ, ξ) = params(d)
 
     # Generate a Float64 random number uniformly in (0,1].

--- a/src/univariate/continuous/generalizedpareto.jl
+++ b/src/univariate/continuous/generalizedpareto.jl
@@ -179,7 +179,7 @@ end
 
 #### Sampling
 
-function _rand!(rng::AbstractRNG, d::GeneralizedPareto)
+function _rand(rng::AbstractRNG, d::GeneralizedPareto)
     # Generate a Float64 random number uniformly in (0,1].
     u = 1 - rand(rng)
 

--- a/src/univariate/continuous/generalizedpareto.jl
+++ b/src/univariate/continuous/generalizedpareto.jl
@@ -179,7 +179,7 @@ end
 
 #### Sampling
 
-function _rand(rng::AbstractRNG, d::GeneralizedPareto)
+function rand(rng::AbstractRNG, d::GeneralizedPareto)
     # Generate a Float64 random number uniformly in (0,1].
     u = 1 - rand(rng)
 

--- a/src/univariate/continuous/generalizedpareto.jl
+++ b/src/univariate/continuous/generalizedpareto.jl
@@ -179,8 +179,7 @@ end
 
 #### Sampling
 
-rand(d::GeneralizedPareto) = rand(GLOBAL_RNG, d)
-function rand(rng::AbstractRNG, d::GeneralizedPareto)
+function _rand!(rng::AbstractRNG, d::GeneralizedPareto)
     # Generate a Float64 random number uniformly in (0,1].
     u = 1 - rand(rng)
 

--- a/src/univariate/continuous/gumbel.jl
+++ b/src/univariate/continuous/gumbel.jl
@@ -90,9 +90,3 @@ logcdf(d::Gumbel, x::Real) = -exp(-zval(d, x))
 quantile(d::Gumbel, p::Real) = d.μ - d.θ * log(-log(p))
 
 gradlogpdf(d::Gumbel, x::Real) = - (1 + exp((d.μ - x) / d.θ)) / d.θ
-
-
-#### Sampling
-
-rand(d::Gumbel) = rand(GLOBAL_RNG, d)
-rand(rng::AbstractRNG, d::Gumbel) = quantile(d, rand(rng))

--- a/src/univariate/continuous/inversegamma.jl
+++ b/src/univariate/continuous/inversegamma.jl
@@ -116,4 +116,4 @@ end
 
 #### Evaluation
 
-_rand(rng::AbstractRNG, d::InverseGamma) = 1 / rand(rng, d.invd)
+rand(rng::AbstractRNG, d::InverseGamma) = 1 / rand(rng, d.invd)

--- a/src/univariate/continuous/inversegamma.jl
+++ b/src/univariate/continuous/inversegamma.jl
@@ -116,13 +116,4 @@ end
 
 #### Evaluation
 
-rand(d::InverseGamma) = 1 / rand(d.invd)
-
-function _rand!(d::InverseGamma, A::AbstractArray)
-    s = sampler(d.invd)
-    for i = 1:length(A)
-        v = 1 / rand(s)
-        @inbounds A[i] = v
-    end
-    A
-end
+_rand!(rng::AbstractRNG, d::InverseGamma) = 1 / rand(rng, d.invd)

--- a/src/univariate/continuous/inversegamma.jl
+++ b/src/univariate/continuous/inversegamma.jl
@@ -116,4 +116,4 @@ end
 
 #### Evaluation
 
-_rand!(rng::AbstractRNG, d::InverseGamma) = 1 / rand(rng, d.invd)
+_rand(rng::AbstractRNG, d::InverseGamma) = 1 / rand(rng, d.invd)

--- a/src/univariate/continuous/inversegaussian.jl
+++ b/src/univariate/continuous/inversegaussian.jl
@@ -150,7 +150,7 @@ end
 #   John R. Michael, William R. Schucany and Roy W. Haas (1976)
 #   Generating Random Variates Using Transformations with Multiple Roots
 #   The American Statistician , Vol. 30, No. 2, pp. 88-90
-function _rand!(rng::AbstractRNG, d::InverseGaussian)
+function _rand(rng::AbstractRNG, d::InverseGaussian)
     μ, λ = params(d)
     z = randn(rng)
     v = z * z

--- a/src/univariate/continuous/inversegaussian.jl
+++ b/src/univariate/continuous/inversegaussian.jl
@@ -150,7 +150,7 @@ end
 #   John R. Michael, William R. Schucany and Roy W. Haas (1976)
 #   Generating Random Variates Using Transformations with Multiple Roots
 #   The American Statistician , Vol. 30, No. 2, pp. 88-90
-function _rand(rng::AbstractRNG, d::InverseGaussian)
+function rand(rng::AbstractRNG, d::InverseGaussian)
     μ, λ = params(d)
     z = randn(rng)
     v = z * z

--- a/src/univariate/continuous/inversegaussian.jl
+++ b/src/univariate/continuous/inversegaussian.jl
@@ -150,8 +150,7 @@ end
 #   John R. Michael, William R. Schucany and Roy W. Haas (1976)
 #   Generating Random Variates Using Transformations with Multiple Roots
 #   The American Statistician , Vol. 30, No. 2, pp. 88-90
-rand(d::InverseGaussian) = rand(GLOBAL_RNG, d)
-function rand(rng::AbstractRNG, d::InverseGaussian)
+function _rand!(rng::AbstractRNG, d::InverseGaussian)
     μ, λ = params(d)
     z = randn(rng)
     v = z * z

--- a/src/univariate/continuous/kolmogorov.jl
+++ b/src/univariate/continuous/kolmogorov.jl
@@ -105,7 +105,7 @@ end
 # Alternating series method, from:
 #   Devroye, Luc (1986) "Non-Uniform Random Variate Generation"
 #   Chapter IV.5, pp. 163-165.
-function _rand!(rng::AbstractRNG, d::Kolmogorov)
+function _rand(rng::AbstractRNG, d::Kolmogorov)
     t = 0.75
     if rand(rng) < 0.3728329582237386 # cdf(d,t)
         # left interval

--- a/src/univariate/continuous/kolmogorov.jl
+++ b/src/univariate/continuous/kolmogorov.jl
@@ -105,8 +105,7 @@ end
 # Alternating series method, from:
 #   Devroye, Luc (1986) "Non-Uniform Random Variate Generation"
 #   Chapter IV.5, pp. 163-165.
-rand(d::Kolmogorov) = rand(GLOBAL_RNG, d)
-function rand(rng::AbstractRNG, d::Kolmogorov)
+function _rand!(rng::AbstractRNG, d::Kolmogorov)
     t = 0.75
     if rand(rng) < 0.3728329582237386 # cdf(d,t)
         # left interval

--- a/src/univariate/continuous/kolmogorov.jl
+++ b/src/univariate/continuous/kolmogorov.jl
@@ -105,7 +105,7 @@ end
 # Alternating series method, from:
 #   Devroye, Luc (1986) "Non-Uniform Random Variate Generation"
 #   Chapter IV.5, pp. 163-165.
-function _rand(rng::AbstractRNG, d::Kolmogorov)
+function rand(rng::AbstractRNG, d::Kolmogorov)
     t = 0.75
     if rand(rng) < 0.3728329582237386 # cdf(d,t)
         # left interval

--- a/src/univariate/continuous/laplace.jl
+++ b/src/univariate/continuous/laplace.jl
@@ -107,8 +107,8 @@ end
 
 #### Sampling
 
-rand(d::Laplace) = rand(GLOBAL_RNG, d)
-rand(rng::AbstractRNG, d::Laplace) = d.μ + d.θ*randexp(rng)*ifelse(rand(rng, Bool), 1, -1)
+_rand!(rng::AbstractRNG, d::Laplace) =
+    d.μ + d.θ*randexp(rng)*ifelse(rand(rng, Bool), 1, -1)
 
 
 #### Fitting

--- a/src/univariate/continuous/laplace.jl
+++ b/src/univariate/continuous/laplace.jl
@@ -107,7 +107,7 @@ end
 
 #### Sampling
 
-_rand!(rng::AbstractRNG, d::Laplace) =
+_rand(rng::AbstractRNG, d::Laplace) =
     d.μ + d.θ*randexp(rng)*ifelse(rand(rng, Bool), 1, -1)
 
 

--- a/src/univariate/continuous/laplace.jl
+++ b/src/univariate/continuous/laplace.jl
@@ -107,7 +107,7 @@ end
 
 #### Sampling
 
-_rand(rng::AbstractRNG, d::Laplace) =
+rand(rng::AbstractRNG, d::Laplace) =
     d.μ + d.θ*randexp(rng)*ifelse(rand(rng, Bool), 1, -1)
 
 

--- a/src/univariate/continuous/levy.jl
+++ b/src/univariate/continuous/levy.jl
@@ -98,4 +98,4 @@ end
 
 #### Sampling
 
-_rand!(rng::AbstractRNG, d::Levy) = d.μ + d.σ / randn(rng)^2
+_rand(rng::AbstractRNG, d::Levy) = d.μ + d.σ / randn(rng)^2

--- a/src/univariate/continuous/levy.jl
+++ b/src/univariate/continuous/levy.jl
@@ -98,5 +98,4 @@ end
 
 #### Sampling
 
-rand(d::Levy) = rand(GLOBAL_RNG, d)
-rand(rng::AbstractRNG, d::Levy) = d.μ + d.σ / randn(rng)^2
+_rand!(rng::AbstractRNG, d::Levy) = d.μ + d.σ / randn(rng)^2

--- a/src/univariate/continuous/levy.jl
+++ b/src/univariate/continuous/levy.jl
@@ -98,4 +98,4 @@ end
 
 #### Sampling
 
-_rand(rng::AbstractRNG, d::Levy) = d.μ + d.σ / randn(rng)^2
+rand(rng::AbstractRNG, d::Levy) = d.μ + d.σ / randn(rng)^2

--- a/src/univariate/continuous/locationscale.jl
+++ b/src/univariate/continuous/locationscale.jl
@@ -71,6 +71,6 @@ cdf(d::LocationScale,x::Real) = cdf(d.ρ,(x-d.μ)/d.σ)
 logcdf(d::LocationScale,x::Real) = logcdf(d.ρ,(x-d.μ)/d.σ)
 quantile(d::LocationScale,q::Real) = d.μ + d.σ * quantile(d.ρ,q)
 
-rand(d::LocationScale) = d.μ + d.σ * rand(d.ρ)
+_rand!(rng::AbstractRNG, d::LocationScale) = d.μ + d.σ * _rand!(rng, d.ρ)
 cf(d::LocationScale, t::Real) = cf(d.ρ,t*d.σ) * exp(1im*t*d.μ)
 gradlogpdf(d::LocationScale, x::Real) = gradlogpdf(d.ρ,(x-d.μ)/d.σ) / d.σ

--- a/src/univariate/continuous/locationscale.jl
+++ b/src/univariate/continuous/locationscale.jl
@@ -71,6 +71,6 @@ cdf(d::LocationScale,x::Real) = cdf(d.ρ,(x-d.μ)/d.σ)
 logcdf(d::LocationScale,x::Real) = logcdf(d.ρ,(x-d.μ)/d.σ)
 quantile(d::LocationScale,q::Real) = d.μ + d.σ * quantile(d.ρ,q)
 
-_rand(rng::AbstractRNG, d::LocationScale) = d.μ + d.σ * _rand(rng, d.ρ)
+rand(rng::AbstractRNG, d::LocationScale) = d.μ + d.σ * rand(rng, d.ρ)
 cf(d::LocationScale, t::Real) = cf(d.ρ,t*d.σ) * exp(1im*t*d.μ)
 gradlogpdf(d::LocationScale, x::Real) = gradlogpdf(d.ρ,(x-d.μ)/d.σ) / d.σ

--- a/src/univariate/continuous/locationscale.jl
+++ b/src/univariate/continuous/locationscale.jl
@@ -71,6 +71,6 @@ cdf(d::LocationScale,x::Real) = cdf(d.ρ,(x-d.μ)/d.σ)
 logcdf(d::LocationScale,x::Real) = logcdf(d.ρ,(x-d.μ)/d.σ)
 quantile(d::LocationScale,q::Real) = d.μ + d.σ * quantile(d.ρ,q)
 
-_rand!(rng::AbstractRNG, d::LocationScale) = d.μ + d.σ * _rand!(rng, d.ρ)
+_rand(rng::AbstractRNG, d::LocationScale) = d.μ + d.σ * _rand(rng, d.ρ)
 cf(d::LocationScale, t::Real) = cf(d.ρ,t*d.σ) * exp(1im*t*d.μ)
 gradlogpdf(d::LocationScale, x::Real) = gradlogpdf(d.ρ,(x-d.μ)/d.σ) / d.σ

--- a/src/univariate/continuous/logistic.jl
+++ b/src/univariate/continuous/logistic.jl
@@ -98,9 +98,3 @@ function cf(d::Logistic, t::Real)
     a = (π * t) * d.θ
     a == zero(a) ? complex(one(a)) : cis(t * d.μ) * (a / sinh(a))
 end
-
-
-#### Sampling
-
-rand(d::Logistic) = rand(GLOBAL_RNG, d)
-rand(rng::AbstractRNG, d::Logistic) = quantile(d, rand(rng))

--- a/src/univariate/continuous/lognormal.jl
+++ b/src/univariate/continuous/lognormal.jl
@@ -120,8 +120,7 @@ end
 
 #### Sampling
 
-rand(d::LogNormal) = rand(GLOBAL_RNG, d)
-rand(rng::AbstractRNG, d::LogNormal) = exp(randn(rng) * d.σ + d.μ)
+_rand!(rng::AbstractRNG, d::LogNormal) = exp(randn(rng) * d.σ + d.μ)
 
 ## Fitting
 

--- a/src/univariate/continuous/lognormal.jl
+++ b/src/univariate/continuous/lognormal.jl
@@ -120,7 +120,7 @@ end
 
 #### Sampling
 
-_rand(rng::AbstractRNG, d::LogNormal) = exp(randn(rng) * d.σ + d.μ)
+rand(rng::AbstractRNG, d::LogNormal) = exp(randn(rng) * d.σ + d.μ)
 
 ## Fitting
 

--- a/src/univariate/continuous/lognormal.jl
+++ b/src/univariate/continuous/lognormal.jl
@@ -120,7 +120,7 @@ end
 
 #### Sampling
 
-_rand!(rng::AbstractRNG, d::LogNormal) = exp(randn(rng) * d.σ + d.μ)
+_rand(rng::AbstractRNG, d::LogNormal) = exp(randn(rng) * d.σ + d.μ)
 
 ## Fitting
 

--- a/src/univariate/continuous/noncentralbeta.jl
+++ b/src/univariate/continuous/noncentralbeta.jl
@@ -42,9 +42,9 @@ function rand(d::NoncentralBeta)
     a / (a + b)
 end
 
-function _rand(rng::AbstractRNG, d::NoncentralBeta)
+function rand(rng::AbstractRNG, d::NoncentralBeta)
     β = d.β
-    a = _rand(rng, NoncentralChisq(2d.α, β))
-    b = _rand(rng, Chisq(2β))
+    a = rand(rng, NoncentralChisq(2d.α, β))
+    b = rand(rng, Chisq(2β))
     a / (a + b)
 end

--- a/src/univariate/continuous/noncentralbeta.jl
+++ b/src/univariate/continuous/noncentralbeta.jl
@@ -40,9 +40,9 @@ function rand(d::NoncentralBeta)
     a / (a + b)
 end
 
-function _rand!(rng::AbstractRNG, d::NoncentralBeta)
+function _rand(rng::AbstractRNG, d::NoncentralBeta)
     β = d.β
-    a = _rand!(rng, NoncentralChisq(2d.α, β))
-    b = _rand!(rng, Chisq(2β))
+    a = _rand(rng, NoncentralChisq(2d.α, β))
+    b = _rand(rng, Chisq(2β))
     a / (a + b)
 end

--- a/src/univariate/continuous/noncentralbeta.jl
+++ b/src/univariate/continuous/noncentralbeta.jl
@@ -32,15 +32,17 @@ params(d::NoncentralBeta) = (d.α, d.β, d.λ)
 
 @_delegate_statsfuns NoncentralBeta nbeta α β λ
 
-# RFunctions
+# TODO: remove RFunctions dependency once NoncentralChisq has its removed
 function rand(d::NoncentralBeta)
-    a = rand(NoncentralChisq(2d.α, d.β))
-    b = rand(Chisq(2d.β))
+    β = d.β
+    a = rand(NoncentralChisq(2d.α, β))
+    b = rand(Chisq(2β))
     a / (a + b)
 end
 
 function _rand!(rng::AbstractRNG, d::NoncentralBeta)
-    a = _rand!(rng, NoncentralChisq(2d.α, d.β))
-    b = _rand!(rng, Chisq(2d.β))
+    β = d.β
+    a = _rand!(rng, NoncentralChisq(2d.α, β))
+    b = _rand!(rng, Chisq(2β))
     a / (a + b)
 end

--- a/src/univariate/continuous/noncentralbeta.jl
+++ b/src/univariate/continuous/noncentralbeta.jl
@@ -1,7 +1,7 @@
 """
     NoncentralBeta(α, β, λ)
 """
-struct NoncentralBeta{T<:Real} <: ContinuousUnivariateDistribution
+struct NoncentralBeta{T<:Real} <: ContinuousUnivariateRDist
     α::T
     β::T
     λ::T
@@ -32,8 +32,15 @@ params(d::NoncentralBeta) = (d.α, d.β, d.λ)
 
 @_delegate_statsfuns NoncentralBeta nbeta α β λ
 
+# RFunctions
 function rand(d::NoncentralBeta)
     a = rand(NoncentralChisq(2d.α, d.β))
     b = rand(Chisq(2d.β))
+    a / (a + b)
+end
+
+function _rand!(rng::AbstractRNG, d::NoncentralBeta)
+    a = _rand!(rng, NoncentralChisq(2d.α, d.β))
+    b = _rand!(rng, Chisq(2d.β))
     a / (a + b)
 end

--- a/src/univariate/continuous/noncentralbeta.jl
+++ b/src/univariate/continuous/noncentralbeta.jl
@@ -1,7 +1,7 @@
 """
     NoncentralBeta(α, β, λ)
 """
-struct NoncentralBeta{T<:Real} <: ContinuousUnivariateRDist
+struct NoncentralBeta{T<:Real} <: ContinuousUnivariateDistribution
     α::T
     β::T
     λ::T
@@ -33,6 +33,8 @@ params(d::NoncentralBeta) = (d.α, d.β, d.λ)
 @_delegate_statsfuns NoncentralBeta nbeta α β λ
 
 # TODO: remove RFunctions dependency once NoncentralChisq has its removed
+@rand_rdist(NoncentralBeta)
+
 function rand(d::NoncentralBeta)
     β = d.β
     a = rand(NoncentralChisq(2d.α, β))

--- a/src/univariate/continuous/noncentralchisq.jl
+++ b/src/univariate/continuous/noncentralchisq.jl
@@ -23,7 +23,7 @@ External links
 
 * [Noncentral chi-squared distribution on Wikipedia](https://en.wikipedia.org/wiki/Noncentral_chi-squared_distribution)
 """
-struct NoncentralChisq{T<:Real} <: ContinuousUnivariateRDist
+struct NoncentralChisq{T<:Real} <: ContinuousUnivariateDistribution
     ν::T
     λ::T
     function NoncentralChisq{T}(ν::T, λ::T) where T
@@ -74,4 +74,6 @@ end
 
 @_delegate_statsfuns NoncentralChisq nchisq ν λ
 
+# TODO: remove RFunctions dependency
+@rand_rdist(NoncentralChisq)
 rand(d::NoncentralChisq) = StatsFuns.RFunctions.nchisqrand(d.ν, d.λ)

--- a/src/univariate/continuous/noncentralchisq.jl
+++ b/src/univariate/continuous/noncentralchisq.jl
@@ -23,7 +23,7 @@ External links
 
 * [Noncentral chi-squared distribution on Wikipedia](https://en.wikipedia.org/wiki/Noncentral_chi-squared_distribution)
 """
-struct NoncentralChisq{T<:Real} <: ContinuousUnivariateDistribution
+struct NoncentralChisq{T<:Real} <: ContinuousUnivariateRDist
     ν::T
     λ::T
     function NoncentralChisq{T}(ν::T, λ::T) where T

--- a/src/univariate/continuous/noncentralf.jl
+++ b/src/univariate/continuous/noncentralf.jl
@@ -49,9 +49,9 @@ var(d::NoncentralF{T}) where {T<:Real} = d.ν2 > 4 ? 2d.ν2^2 *
 
 @_delegate_statsfuns NoncentralF nfdist ν1 ν2 λ
 
-function _rand!(rng::AbstractRNG, d::NoncentralF)
-    r1 = _rand!(rng, NoncentralChisq(d.ν1,d.λ)) / d.ν1
-    r2 = _rand!(rng, Chisq(d.ν2)) / d.ν2
+function _rand(rng::AbstractRNG, d::NoncentralF)
+    r1 = _rand(rng, NoncentralChisq(d.ν1,d.λ)) / d.ν1
+    r2 = _rand(rng, Chisq(d.ν2)) / d.ν2
     r1 / r2
 end
 

--- a/src/univariate/continuous/noncentralf.jl
+++ b/src/univariate/continuous/noncentralf.jl
@@ -1,7 +1,7 @@
 """
     NoncentralF(ν1, ν2, λ)
 """
-struct NoncentralF{T<:Real} <: ContinuousUnivariateDistribution
+struct NoncentralF{T<:Real} <: ContinuousUnivariateRDist
     ν1::T
     ν2::T
     λ::T
@@ -49,6 +49,13 @@ var(d::NoncentralF{T}) where {T<:Real} = d.ν2 > 4 ? 2d.ν2^2 *
 
 @_delegate_statsfuns NoncentralF nfdist ν1 ν2 λ
 
+function _rand!(rng::AbstractRNG, d::NoncentralF)
+    r1 = _rand!(rng, NoncentralChisq(d.ν1,d.λ)) / d.ν1
+    r2 = _rand!(rng, Chisq(d.ν2)) / d.ν2
+    r1 / r2
+end
+
+# Rfunctions
 function rand(d::NoncentralF)
     r1 = rand(NoncentralChisq(d.ν1,d.λ)) / d.ν1
     r2 = rand(Chisq(d.ν2)) / d.ν2

--- a/src/univariate/continuous/noncentralf.jl
+++ b/src/univariate/continuous/noncentralf.jl
@@ -49,9 +49,9 @@ var(d::NoncentralF{T}) where {T<:Real} = d.ν2 > 4 ? 2d.ν2^2 *
 
 @_delegate_statsfuns NoncentralF nfdist ν1 ν2 λ
 
-function _rand(rng::AbstractRNG, d::NoncentralF)
-    r1 = _rand(rng, NoncentralChisq(d.ν1,d.λ)) / d.ν1
-    r2 = _rand(rng, Chisq(d.ν2)) / d.ν2
+function rand(rng::AbstractRNG, d::NoncentralF)
+    r1 = rand(rng, NoncentralChisq(d.ν1,d.λ)) / d.ν1
+    r2 = rand(rng, Chisq(d.ν2)) / d.ν2
     r1 / r2
 end
 
@@ -60,11 +60,5 @@ end
 function rand(d::NoncentralF)
     r1 = rand(NoncentralChisq(d.ν1,d.λ)) / d.ν1
     r2 = rand(Chisq(d.ν2)) / d.ν2
-    r1 / r2
-end
-
-function _rand(rng::AbstractRNG, d::NoncentralF)
-    r1 = _rand(rng, NoncentralChisq(d.ν1,d.λ)) / d.ν1
-    r2 = _rand(rng, Chisq(d.ν2)) / d.ν2
     r1 / r2
 end

--- a/src/univariate/continuous/noncentralf.jl
+++ b/src/univariate/continuous/noncentralf.jl
@@ -55,7 +55,7 @@ function _rand!(rng::AbstractRNG, d::NoncentralF)
     r1 / r2
 end
 
-# Rfunctions
+# TODO: remove RFunctions dependency once NoncentralChisq has its removed
 function rand(d::NoncentralF)
     r1 = rand(NoncentralChisq(d.ν1,d.λ)) / d.ν1
     r2 = rand(Chisq(d.ν2)) / d.ν2

--- a/src/univariate/continuous/noncentralf.jl
+++ b/src/univariate/continuous/noncentralf.jl
@@ -1,7 +1,7 @@
 """
     NoncentralF(ν1, ν2, λ)
 """
-struct NoncentralF{T<:Real} <: ContinuousUnivariateRDist
+struct NoncentralF{T<:Real} <: ContinuousUnivariateDistribution
     ν1::T
     ν2::T
     λ::T
@@ -56,8 +56,15 @@ function _rand(rng::AbstractRNG, d::NoncentralF)
 end
 
 # TODO: remove RFunctions dependency once NoncentralChisq has its removed
+@rand_rdist(NoncentralF)
 function rand(d::NoncentralF)
     r1 = rand(NoncentralChisq(d.ν1,d.λ)) / d.ν1
     r2 = rand(Chisq(d.ν2)) / d.ν2
+    r1 / r2
+end
+
+function _rand(rng::AbstractRNG, d::NoncentralF)
+    r1 = _rand(rng, NoncentralChisq(d.ν1,d.λ)) / d.ν1
+    r2 = _rand(rng, Chisq(d.ν2)) / d.ν2
     r1 / r2
 end

--- a/src/univariate/continuous/noncentralt.jl
+++ b/src/univariate/continuous/noncentralt.jl
@@ -1,7 +1,7 @@
 """
     NoncentralT(ν, λ)
 """
-struct NoncentralT{T<:Real} <: ContinuousUnivariateDistribution
+struct NoncentralT{T<:Real} <: ContinuousUnivariateRDist
     ν::T
     λ::T
 
@@ -47,6 +47,13 @@ end
 
 @_delegate_statsfuns NoncentralT ntdist ν λ
 
+function _rand!(rng::AbstractRNG, d::NoncentralT)
+    z = randn(rng)
+    v = rand(rng, Chisq(d.ν))
+    (z+d.λ)/sqrt(v/d.ν)
+end
+
+# Rfunctions
 function rand(d::NoncentralT)
     z = randn()
     v = rand(Chisq(d.ν))

--- a/src/univariate/continuous/noncentralt.jl
+++ b/src/univariate/continuous/noncentralt.jl
@@ -1,7 +1,7 @@
 """
     NoncentralT(ν, λ)
 """
-struct NoncentralT{T<:Real} <: ContinuousUnivariateRDist
+struct NoncentralT{T<:Real} <: ContinuousUnivariateDistribution
     ν::T
     λ::T
 
@@ -53,9 +53,9 @@ function _rand!(rng::AbstractRNG, d::NoncentralT)
     (z+d.λ)/sqrt(v/d.ν)
 end
 
-# Rfunctions
-function rand(d::NoncentralT)
-    z = randn()
-    v = rand(Chisq(d.ν))
-    (z+d.λ)/sqrt(v/d.ν)
+function _rand!(rng::AbstractRNG, d::NoncentralT)
+    ν = d.ν
+    z = randn(rng)
+    v = rand(rng, Chisq(ν))
+    (z+d.λ)/sqrt(v/ν)
 end

--- a/src/univariate/continuous/noncentralt.jl
+++ b/src/univariate/continuous/noncentralt.jl
@@ -47,12 +47,7 @@ end
 
 @_delegate_statsfuns NoncentralT ntdist ν λ
 
-function _rand!(rng::AbstractRNG, d::NoncentralT)
-    z = randn(rng)
-    v = rand(rng, Chisq(d.ν))
-    (z+d.λ)/sqrt(v/d.ν)
-end
-
+## sampling
 function _rand!(rng::AbstractRNG, d::NoncentralT)
     ν = d.ν
     z = randn(rng)

--- a/src/univariate/continuous/noncentralt.jl
+++ b/src/univariate/continuous/noncentralt.jl
@@ -48,7 +48,7 @@ end
 @_delegate_statsfuns NoncentralT ntdist ν λ
 
 ## sampling
-function _rand(rng::AbstractRNG, d::NoncentralT)
+function rand(rng::AbstractRNG, d::NoncentralT)
     ν = d.ν
     z = randn(rng)
     v = rand(rng, Chisq(ν))

--- a/src/univariate/continuous/noncentralt.jl
+++ b/src/univariate/continuous/noncentralt.jl
@@ -48,7 +48,7 @@ end
 @_delegate_statsfuns NoncentralT ntdist ν λ
 
 ## sampling
-function _rand!(rng::AbstractRNG, d::NoncentralT)
+function _rand(rng::AbstractRNG, d::NoncentralT)
     ν = d.ν
     z = randn(rng)
     v = rand(rng, Chisq(ν))

--- a/src/univariate/continuous/normal.jl
+++ b/src/univariate/continuous/normal.jl
@@ -87,7 +87,7 @@ cf(d::Normal, t::Real) = exp(im * t * d.μ - d.σ^2/2 * t^2)
 
 #### Sampling
 
-_rand!(rng::AbstractRNG, d::Normal) = d.μ + d.σ * randn(rng)
+_rand(rng::AbstractRNG, d::Normal) = d.μ + d.σ * randn(rng)
 
 
 #### Fitting

--- a/src/univariate/continuous/normal.jl
+++ b/src/univariate/continuous/normal.jl
@@ -87,8 +87,7 @@ cf(d::Normal, t::Real) = exp(im * t * d.μ - d.σ^2/2 * t^2)
 
 #### Sampling
 
-rand(d::Normal) = rand(GLOBAL_RNG, d)
-rand(rng::AbstractRNG, d::Normal) = d.μ + d.σ * randn(rng)
+_rand!(rng::AbstractRNG, d::Normal) = d.μ + d.σ * randn(rng)
 
 
 #### Fitting

--- a/src/univariate/continuous/normal.jl
+++ b/src/univariate/continuous/normal.jl
@@ -87,7 +87,7 @@ cf(d::Normal, t::Real) = exp(im * t * d.μ - d.σ^2/2 * t^2)
 
 #### Sampling
 
-_rand(rng::AbstractRNG, d::Normal) = d.μ + d.σ * randn(rng)
+rand(rng::AbstractRNG, d::Normal) = d.μ + d.σ * randn(rng)
 
 
 #### Fitting

--- a/src/univariate/continuous/normalcanon.jl
+++ b/src/univariate/continuous/normalcanon.jl
@@ -75,7 +75,4 @@ invlogccdf(d::NormalCanon, lp::Real) = xval(d, norminvlogccdf(lp))
 
 #### Sampling
 
-rand(cf::NormalCanon) = rand(GLOBAL_RNG, cf)
-rand(rng::AbstractRNG, cf::NormalCanon) = cf.μ + randn(rng) / sqrt(cf.λ)
-rand!(cf::NormalCanon, r::AbstractArray{T}) where {T<:Real} = rand!(GLOBAL_RNG, cf, r)
-rand!(rng::AbstractRNG, cf::NormalCanon, r::AbstractArray{T}) where {T<:Real} = rand!(rng, convert(Normal, cf), r)
+_rand!(rng::AbstractRNG, cf::NormalCanon) = cf.μ + randn(rng) / sqrt(cf.λ)

--- a/src/univariate/continuous/normalcanon.jl
+++ b/src/univariate/continuous/normalcanon.jl
@@ -75,4 +75,4 @@ invlogccdf(d::NormalCanon, lp::Real) = xval(d, norminvlogccdf(lp))
 
 #### Sampling
 
-_rand(rng::AbstractRNG, cf::NormalCanon) = cf.μ + randn(rng) / sqrt(cf.λ)
+rand(rng::AbstractRNG, cf::NormalCanon) = cf.μ + randn(rng) / sqrt(cf.λ)

--- a/src/univariate/continuous/normalcanon.jl
+++ b/src/univariate/continuous/normalcanon.jl
@@ -75,4 +75,4 @@ invlogccdf(d::NormalCanon, lp::Real) = xval(d, norminvlogccdf(lp))
 
 #### Sampling
 
-_rand!(rng::AbstractRNG, cf::NormalCanon) = cf.μ + randn(rng) / sqrt(cf.λ)
+_rand(rng::AbstractRNG, cf::NormalCanon) = cf.μ + randn(rng) / sqrt(cf.λ)

--- a/src/univariate/continuous/pareto.jl
+++ b/src/univariate/continuous/pareto.jl
@@ -111,7 +111,7 @@ quantile(d::Pareto, p::Real) = cquantile(d, 1 - p)
 
 #### Sampling
 
-_rand!(rng::AbstractRNG, d::Pareto) = d.θ * exp(randexp(rng) / d.α)
+_rand(rng::AbstractRNG, d::Pareto) = d.θ * exp(randexp(rng) / d.α)
 
 ## Fitting
 

--- a/src/univariate/continuous/pareto.jl
+++ b/src/univariate/continuous/pareto.jl
@@ -111,7 +111,7 @@ quantile(d::Pareto, p::Real) = cquantile(d, 1 - p)
 
 #### Sampling
 
-_rand(rng::AbstractRNG, d::Pareto) = d.θ * exp(randexp(rng) / d.α)
+rand(rng::AbstractRNG, d::Pareto) = d.θ * exp(randexp(rng) / d.α)
 
 ## Fitting
 

--- a/src/univariate/continuous/pareto.jl
+++ b/src/univariate/continuous/pareto.jl
@@ -111,9 +111,7 @@ quantile(d::Pareto, p::Real) = cquantile(d, 1 - p)
 
 #### Sampling
 
-rand(d::Pareto) = rand(GLOBAL_RNG, d)
-rand(rng::AbstractRNG, d::Pareto) = d.θ * exp(randexp(rng) / d.α)
-
+_rand!(rng::AbstractRNG, d::Pareto) = d.θ * exp(randexp(rng) / d.α)
 
 ## Fitting
 

--- a/src/univariate/continuous/rayleigh.jl
+++ b/src/univariate/continuous/rayleigh.jl
@@ -85,4 +85,4 @@ quantile(d::Rayleigh, p::Real) = sqrt(-2d.σ^2 * log1p(-p))
 
 #### Sampling
 
-_rand(rng::AbstractRNG, d::Rayleigh) = d.σ * sqrt(2 * randexp(rng))
+rand(rng::AbstractRNG, d::Rayleigh) = d.σ * sqrt(2 * randexp(rng))

--- a/src/univariate/continuous/rayleigh.jl
+++ b/src/univariate/continuous/rayleigh.jl
@@ -85,4 +85,4 @@ quantile(d::Rayleigh, p::Real) = sqrt(-2d.σ^2 * log1p(-p))
 
 #### Sampling
 
-_rand!(rng::AbstractRNG, d::Rayleigh) = d.σ * sqrt(2 * randexp(rng))
+_rand(rng::AbstractRNG, d::Rayleigh) = d.σ * sqrt(2 * randexp(rng))

--- a/src/univariate/continuous/rayleigh.jl
+++ b/src/univariate/continuous/rayleigh.jl
@@ -85,5 +85,4 @@ quantile(d::Rayleigh, p::Real) = sqrt(-2d.σ^2 * log1p(-p))
 
 #### Sampling
 
-rand(d::Rayleigh) = rand(GLOBAL_RNG, d)
-rand(rng::AbstractRNG, d::Rayleigh) = d.σ * sqrt(2 * randexp(rng))
+_rand!(rng::AbstractRNG, d::Rayleigh) = d.σ * sqrt(2 * randexp(rng))

--- a/src/univariate/continuous/symtriangular.jl
+++ b/src/univariate/continuous/symtriangular.jl
@@ -138,5 +138,4 @@ end
 
 #### Sampling
 
-rand(d::SymTriangularDist) = rand(GLOBAL_RNG, d)
-rand(rng::AbstractRNG, d::SymTriangularDist) = xval(d, rand(rng) - rand(rng))
+_rand!(rng::AbstractRNG, d::SymTriangularDist) = xval(d, rand(rng) - rand(rng))

--- a/src/univariate/continuous/symtriangular.jl
+++ b/src/univariate/continuous/symtriangular.jl
@@ -138,4 +138,4 @@ end
 
 #### Sampling
 
-_rand(rng::AbstractRNG, d::SymTriangularDist) = xval(d, rand(rng) - rand(rng))
+rand(rng::AbstractRNG, d::SymTriangularDist) = xval(d, rand(rng) - rand(rng))

--- a/src/univariate/continuous/symtriangular.jl
+++ b/src/univariate/continuous/symtriangular.jl
@@ -138,4 +138,4 @@ end
 
 #### Sampling
 
-_rand!(rng::AbstractRNG, d::SymTriangularDist) = xval(d, rand(rng) - rand(rng))
+_rand(rng::AbstractRNG, d::SymTriangularDist) = xval(d, rand(rng) - rand(rng))

--- a/src/univariate/continuous/tdist.jl
+++ b/src/univariate/continuous/tdist.jl
@@ -20,7 +20,7 @@ External links
 [Student's T distribution on Wikipedia](https://en.wikipedia.org/wiki/Student%27s_t-distribution)
 
 """
-struct TDist{T<:Real} <: ContinuousUnivariateDistribution
+struct TDist{T<:Real} <: ContinuousUnivariateRDist
     ν::T
 
     TDist{T}(ν::T) where {T} = (@check_args(TDist, ν > zero(ν)); new{T}(ν))

--- a/src/univariate/continuous/tdist.jl
+++ b/src/univariate/continuous/tdist.jl
@@ -73,11 +73,7 @@ end
 
 @_delegate_statsfuns TDist tdist ν
 
-function rand(rng::AbstractRNG, d::TDist)
-    z = randn(rng)
-    ν = d.ν
-    return z/sqrt(rand(rng, Chisq(ν))/ν)
-end
+rand(rng::AbstractRNG, d::TDist) = randn(rng) / sqrt(rand(rng, Chisq(d.ν))/d.ν)
 
 function cf(d::TDist, t::Real)
     t == 0 && return complex(1)

--- a/src/univariate/continuous/tdist.jl
+++ b/src/univariate/continuous/tdist.jl
@@ -73,7 +73,7 @@ end
 
 @_delegate_statsfuns TDist tdist ν
 
-function _rand(rng::AbstractRNG, d::TDist)
+function rand(rng::AbstractRNG, d::TDist)
     z = randn(rng)
     ν = d.ν
     return z/sqrt(rand(rng, Chisq(ν))/ν)

--- a/src/univariate/continuous/tdist.jl
+++ b/src/univariate/continuous/tdist.jl
@@ -20,7 +20,7 @@ External links
 [Student's T distribution on Wikipedia](https://en.wikipedia.org/wiki/Student%27s_t-distribution)
 
 """
-struct TDist{T<:Real} <: ContinuousUnivariateRDist
+struct TDist{T<:Real} <: ContinuousUnivariateDistribution
     ν::T
 
     TDist{T}(ν::T) where {T} = (@check_args(TDist, ν > zero(ν)); new{T}(ν))

--- a/src/univariate/continuous/tdist.jl
+++ b/src/univariate/continuous/tdist.jl
@@ -73,7 +73,11 @@ end
 
 @_delegate_statsfuns TDist tdist ν
 
-rand(d::TDist) = StatsFuns.RFunctions.tdistrand(d.ν)
+function _rand!(rng::AbstractRNG, d::TDist)
+    z = randn(rng)
+    ν = d.ν
+    return z/sqrt(rand(rng, Chisq(ν))/ν)
+end
 
 function cf(d::TDist, t::Real)
     t == 0 && return complex(1)

--- a/src/univariate/continuous/tdist.jl
+++ b/src/univariate/continuous/tdist.jl
@@ -73,7 +73,7 @@ end
 
 @_delegate_statsfuns TDist tdist ν
 
-function _rand!(rng::AbstractRNG, d::TDist)
+function _rand(rng::AbstractRNG, d::TDist)
     z = randn(rng)
     ν = d.ν
     return z/sqrt(rand(rng, Chisq(ν))/ν)

--- a/src/univariate/continuous/triangular.jl
+++ b/src/univariate/continuous/triangular.jl
@@ -145,8 +145,7 @@ end
 
 #### Sampling
 
-rand(d::TriangularDist) = rand(GLOBAL_RNG, d)
-function rand(rng::AbstractRNG, d::TriangularDist)
+function _rand!(rng::AbstractRNG, d::TriangularDist)
     (a, b, c) = params(d)
     b_m_a = b - a
     u = rand(rng)

--- a/src/univariate/continuous/triangular.jl
+++ b/src/univariate/continuous/triangular.jl
@@ -145,7 +145,7 @@ end
 
 #### Sampling
 
-function _rand!(rng::AbstractRNG, d::TriangularDist)
+function _rand(rng::AbstractRNG, d::TriangularDist)
     (a, b, c) = params(d)
     b_m_a = b - a
     u = rand(rng)

--- a/src/univariate/continuous/triangular.jl
+++ b/src/univariate/continuous/triangular.jl
@@ -145,7 +145,7 @@ end
 
 #### Sampling
 
-function _rand(rng::AbstractRNG, d::TriangularDist)
+function rand(rng::AbstractRNG, d::TriangularDist)
     (a, b, c) = params(d)
     b_m_a = b - a
     u = rand(rng)

--- a/src/univariate/continuous/uniform.jl
+++ b/src/univariate/continuous/uniform.jl
@@ -105,8 +105,7 @@ end
 
 #### Sampling
 
-rand(d::Uniform) = rand(GLOBAL_RNG, d)
-rand(rng::AbstractRNG, d::Uniform) = d.a + (d.b - d.a) * rand(rng)
+_rand!(rng::AbstractRNG, d::Uniform) = d.a + (d.b - d.a) * rand(rng)
 
 
 #### Fitting

--- a/src/univariate/continuous/uniform.jl
+++ b/src/univariate/continuous/uniform.jl
@@ -105,7 +105,7 @@ end
 
 #### Sampling
 
-_rand(rng::AbstractRNG, d::Uniform) = d.a + (d.b - d.a) * rand(rng)
+rand(rng::AbstractRNG, d::Uniform) = d.a + (d.b - d.a) * rand(rng)
 
 
 #### Fitting

--- a/src/univariate/continuous/uniform.jl
+++ b/src/univariate/continuous/uniform.jl
@@ -105,7 +105,7 @@ end
 
 #### Sampling
 
-_rand!(rng::AbstractRNG, d::Uniform) = d.a + (d.b - d.a) * rand(rng)
+_rand(rng::AbstractRNG, d::Uniform) = d.a + (d.b - d.a) * rand(rng)
 
 
 #### Fitting

--- a/src/univariate/continuous/weibull.jl
+++ b/src/univariate/continuous/weibull.jl
@@ -135,4 +135,4 @@ end
 
 #### Sampling
 
-_rand(rng::AbstractRNG, d::Weibull) = xv(d, randexp(rng))
+rand(rng::AbstractRNG, d::Weibull) = xv(d, randexp(rng))

--- a/src/univariate/continuous/weibull.jl
+++ b/src/univariate/continuous/weibull.jl
@@ -135,5 +135,4 @@ end
 
 #### Sampling
 
-rand(d::Weibull) = rand(GLOBAL_RNG, d)
-rand(rng::AbstractRNG, d::Weibull) = xv(d, randexp(rng))
+_rand!(rng::AbstractRNG, d::Weibull) = xv(d, randexp(rng))

--- a/src/univariate/continuous/weibull.jl
+++ b/src/univariate/continuous/weibull.jl
@@ -135,4 +135,4 @@ end
 
 #### Sampling
 
-_rand!(rng::AbstractRNG, d::Weibull) = xv(d, randexp(rng))
+_rand(rng::AbstractRNG, d::Weibull) = xv(d, randexp(rng))

--- a/src/univariate/discrete/bernoulli.jl
+++ b/src/univariate/discrete/bernoulli.jl
@@ -104,7 +104,7 @@ cf(d::Bernoulli, t::Real) = failprob(d) + succprob(d) * cis(t)
 
 #### Sampling
 
-_rand!(rng::AbstractRNG, d::Bernoulli) = round(Int, rand(rng) <= succprob(d))
+_rand(rng::AbstractRNG, d::Bernoulli) = round(Int, rand(rng) <= succprob(d))
 
 #### MLE fitting
 

--- a/src/univariate/discrete/bernoulli.jl
+++ b/src/univariate/discrete/bernoulli.jl
@@ -104,7 +104,7 @@ cf(d::Bernoulli, t::Real) = failprob(d) + succprob(d) * cis(t)
 
 #### Sampling
 
-_rand(rng::AbstractRNG, d::Bernoulli) = round(Int, rand(rng) <= succprob(d))
+rand(rng::AbstractRNG, d::Bernoulli) = round(Int, rand(rng) <= succprob(d))
 
 #### MLE fitting
 

--- a/src/univariate/discrete/bernoulli.jl
+++ b/src/univariate/discrete/bernoulli.jl
@@ -104,9 +104,7 @@ cf(d::Bernoulli, t::Real) = failprob(d) + succprob(d) * cis(t)
 
 #### Sampling
 
-rand(d::Bernoulli) = rand(GLOBAL_RNG, d)
-rand(rng::AbstractRNG, d::Bernoulli) = round(Int, rand(rng) <= succprob(d))
-
+_rand!(rng::AbstractRNG, d::Bernoulli) = round(Int, rand(rng) <= succprob(d))
 
 #### MLE fitting
 

--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -18,7 +18,7 @@ External links:
 
 * [Beta-binomial distribution on Wikipedia](https://en.wikipedia.org/wiki/Beta-binomial_distribution)
 """
-struct BetaBinomial{T<:Real} <: DiscreteUnivariateRDist
+struct BetaBinomial{T<:Real} <: DiscreteUnivariateDistribution
     n::Int
     α::T
     β::T
@@ -109,6 +109,3 @@ quantile(d::BetaBinomial, p::Float64) = quantile(Categorical(pdf.(Ref(d), suppor
 
 _rand!(rng::AbstractRNG, d::BetaBinomial) =
     _rand!(rng, Binomial(d.n, _rand!(rng, Beta(d.α, d.β))))
-
-# RFunctions
-rand(d::BetaBinomial) = rand(Binomial(d.n, rand(Beta(d.α, d.β))))

--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -18,7 +18,7 @@ External links:
 
 * [Beta-binomial distribution on Wikipedia](https://en.wikipedia.org/wiki/Beta-binomial_distribution)
 """
-struct BetaBinomial{T<:Real} <: DiscreteUnivariateDistribution
+struct BetaBinomial{T<:Real} <: DiscreteUnivariateRDist
     n::Int
     α::T
     β::T
@@ -104,3 +104,11 @@ mode(d::BetaBinomial) = argmax(pdf.(Ref(d),support(d))) - 1
 modes(d::BetaBinomial) = modes(Categorical(pdf.(Ref(d),support(d)))) .- 1
 
 quantile(d::BetaBinomial, p::Float64) = quantile(Categorical(pdf.(Ref(d), support(d))), p) - 1
+
+#### Sampling
+
+_rand!(rng::AbstractRNG, d::BetaBinomial) =
+    _rand!(rng, Binomial(d.n, _rand!(rng, Beta(d.α, d.β))))
+
+# RFunctions
+rand(d::BetaBinomial) = rand(Binomial(d.n, rand(Beta(d.α, d.β))))

--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -107,5 +107,5 @@ quantile(d::BetaBinomial, p::Float64) = quantile(Categorical(pdf.(Ref(d), suppor
 
 #### Sampling
 
-_rand!(rng::AbstractRNG, d::BetaBinomial) =
-    _rand!(rng, Binomial(d.n, _rand!(rng, Beta(d.α, d.β))))
+_rand(rng::AbstractRNG, d::BetaBinomial) =
+    _rand(rng, Binomial(d.n, _rand(rng, Beta(d.α, d.β))))

--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -107,5 +107,5 @@ quantile(d::BetaBinomial, p::Float64) = quantile(Categorical(pdf.(Ref(d), suppor
 
 #### Sampling
 
-_rand(rng::AbstractRNG, d::BetaBinomial) =
-    _rand(rng, Binomial(d.n, _rand(rng, Beta(d.α, d.β))))
+rand(rng::AbstractRNG, d::BetaBinomial) =
+    rand(rng, Binomial(d.n, rand(rng, Beta(d.α, d.β))))

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -108,7 +108,7 @@ end
 
 @_delegate_statsfuns Binomial binom n p
 
-function _rand!(rng::AbstractRNG, d::Binomial)
+function _rand(rng::AbstractRNG, d::Binomial)
     p, n = d.p, d.n
     if p <= 0.5
         r = p
@@ -116,9 +116,9 @@ function _rand!(rng::AbstractRNG, d::Binomial)
         r = 1.0-p
     end
     if r*n <= 10.0
-        y = _rand!(rng, BinomialGeomSampler(n,r))
+        y = _rand(rng, BinomialGeomSampler(n,r))
     else
-        y = _rand!(rng, BinomialTPESampler(n,r))
+        y = _rand(rng, BinomialTPESampler(n,r))
     end
     p <= 0.5 ? y : n-y
 end

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -120,7 +120,7 @@ function rand(rng::AbstractRNG, d::Binomial)
     if r*n <= 10.0
         y = rand(rng, BinomialGeomSampler(n,r))
     else
-        y = rand_btpe(rng, BinomialTPESampler(n,r))
+        y = rand(rng, BinomialTPESampler(n,r))
     end
     p <= 0.5 ? y : n-y
 end

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -108,9 +108,7 @@ end
 
 @_delegate_statsfuns Binomial binom n p
 
-rand(d::Binomial) = convert(Int, StatsFuns.RFunctions.binomrand(d.n, d.p))
-
-function rand(rng::AbstractRNG, d::Binomial)
+function _rand!(rng::AbstractRNG, d::Binomial)
     p, n = d.p, d.n
     if p <= 0.5
         r = p
@@ -118,9 +116,9 @@ function rand(rng::AbstractRNG, d::Binomial)
         r = 1.0-p
     end
     if r*n <= 10.0
-        y = rand(rng, BinomialGeomSampler(n,r))
+        y = _rand!(rng, BinomialGeomSampler(n,r))
     else
-        y = rand(rng, BinomialTPESampler(n,r))
+        y = _rand!(rng, BinomialTPESampler(n,r))
     end
     p <= 0.5 ? y : n-y
 end

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -108,7 +108,7 @@ end
 
 @_delegate_statsfuns Binomial binom n p
 
-function _rand(rng::AbstractRNG, d::Binomial)
+function rand(rng::AbstractRNG, d::Binomial)
     p, n = d.p, d.n
     if p <= 0.5
         r = p
@@ -116,9 +116,9 @@ function _rand(rng::AbstractRNG, d::Binomial)
         r = 1.0-p
     end
     if r*n <= 10.0
-        y = _rand(rng, BinomialGeomSampler(n,r))
+        y = rand(rng, BinomialGeomSampler(n,r))
     else
-        y = _rand(rng, BinomialTPESampler(n,r))
+        y = rand(rng, BinomialTPESampler(n,r))
     end
     p <= 0.5 ? y : n-y
 end

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -110,6 +110,21 @@ end
 
 rand(d::Binomial) = convert(Int, StatsFuns.RFunctions.binomrand(d.n, d.p))
 
+function rand(rng::AbstractRNG, d::Binomial)
+    p, n = d.p, d.n
+    if p <= 0.5
+        r = p
+    else
+        r = 1.0-p
+    end
+    if r*n <= 10.0
+        y = rand(rng, BinomialGeomSampler(n,r))
+    else
+        y = rand_btpe(rng, BinomialTPESampler(n,r))
+    end
+    p <= 0.5 ? y : n-y
+end
+
 struct RecursiveBinomProbEvaluator{T<:Real} <: RecursiveProbabilityEvaluator
     n::Int
     coef::T   # p / (1 - p)

--- a/src/univariate/discrete/discretenonparametric.jl
+++ b/src/univariate/discrete/discretenonparametric.jl
@@ -88,7 +88,7 @@ function rand(rng::AbstractRNG, d::DiscreteNonParametric{T,P}) where {T,P}
     x[i]
 end
 
-rand(d::DiscreteNonParametric) = rand(Random.GLOBAL_RNG, d)
+rand(d::DiscreteNonParametric) = rand(GLOBAL_RNG, d)
 
 sampler(d::DiscreteNonParametric) =
     DiscreteNonParametricSampler(support(d), probs(d))

--- a/src/univariate/discrete/discreteuniform.jl
+++ b/src/univariate/discrete/discreteuniform.jl
@@ -95,7 +95,7 @@ end
 
 ### Sampling
 
-_rand!(rng::AbstractRNG, d::DiscreteUniform) = rand(rng, d.a:d.b)
+_rand(rng::AbstractRNG, d::DiscreteUniform) = rand(rng, d.a:d.b)
 
 # Fit model
 

--- a/src/univariate/discrete/discreteuniform.jl
+++ b/src/univariate/discrete/discreteuniform.jl
@@ -95,7 +95,7 @@ end
 
 ### Sampling
 
-_rand(rng::AbstractRNG, d::DiscreteUniform) = rand(rng, d.a:d.b)
+rand(rng::AbstractRNG, d::DiscreteUniform) = rand(rng, d.a:d.b)
 
 # Fit model
 

--- a/src/univariate/discrete/discreteuniform.jl
+++ b/src/univariate/discrete/discreteuniform.jl
@@ -95,8 +95,7 @@ end
 
 ### Sampling
 
-rand(d::DiscreteUniform) = rand(GLOBAL_RNG, d)
-rand(rng::AbstractRNG, d::DiscreteUniform) = rand(rng, d.a:d.b)
+_rand!(rng::AbstractRNG, d::DiscreteUniform) = rand(rng, d.a:d.b)
 
 # Fit model
 

--- a/src/univariate/discrete/geometric.jl
+++ b/src/univariate/discrete/geometric.jl
@@ -147,9 +147,7 @@ end
 
 ### Sampling
 
-rand(d::Geometric) = rand(GLOBAL_RNG, d)
-rand(rng::AbstractRNG, d::Geometric) = floor(Int,-randexp(rng) / log1p(-d.p))
-
+_rand!(rng::AbstractRNG, d::Geometric) = floor(Int,-randexp(rng) / log1p(-d.p))
 
 ### Model Fitting
 

--- a/src/univariate/discrete/geometric.jl
+++ b/src/univariate/discrete/geometric.jl
@@ -147,7 +147,7 @@ end
 
 ### Sampling
 
-_rand!(rng::AbstractRNG, d::Geometric) = floor(Int,-randexp(rng) / log1p(-d.p))
+_rand(rng::AbstractRNG, d::Geometric) = floor(Int,-randexp(rng) / log1p(-d.p))
 
 ### Model Fitting
 

--- a/src/univariate/discrete/geometric.jl
+++ b/src/univariate/discrete/geometric.jl
@@ -147,7 +147,7 @@ end
 
 ### Sampling
 
-_rand(rng::AbstractRNG, d::Geometric) = floor(Int,-randexp(rng) / log1p(-d.p))
+rand(rng::AbstractRNG, d::Geometric) = floor(Int,-randexp(rng) / log1p(-d.p))
 
 ### Model Fitting
 

--- a/src/univariate/discrete/hypergeometric.jl
+++ b/src/univariate/discrete/hypergeometric.jl
@@ -19,7 +19,7 @@ External links
 * [Hypergeometric distribution on Wikipedia](http://en.wikipedia.org/wiki/Hypergeometric_distribution)
 
 """
-struct Hypergeometric <: DiscreteUnivariateRDist
+struct Hypergeometric <: DiscreteUnivariateDistribution
     ns::Int     # number of successes in population
     nf::Int     # number of failures in population
     n::Int      # sample size
@@ -75,11 +75,13 @@ end
 @_delegate_statsfuns Hypergeometric hyper ns nf n
 
 ## sampling
-# TODO: Implement:
+
+# TODO: remove RFunctions dependency. Implement:
 #   V. Kachitvichyanukul & B. Schmeiser
 #   "Computer generation of hypergeometric random variates"
 #   Journal of Statistical Computation and Simulation, 22(2):127-145
 #   doi:10.1080/00949658508810839
+@rand_rdist(Hypergeometric)
 rand(d::Hypergeometric) =
     convert(Int, StatsFuns.RFunctions.hyperrand(d.ns, d.nf, d.n))
 

--- a/src/univariate/discrete/hypergeometric.jl
+++ b/src/univariate/discrete/hypergeometric.jl
@@ -19,7 +19,7 @@ External links
 * [Hypergeometric distribution on Wikipedia](http://en.wikipedia.org/wiki/Hypergeometric_distribution)
 
 """
-struct Hypergeometric <: DiscreteUnivariateDistribution
+struct Hypergeometric <: DiscreteUnivariateRDist
     ns::Int     # number of successes in population
     nf::Int     # number of failures in population
     n::Int      # sample size
@@ -74,7 +74,8 @@ end
 
 @_delegate_statsfuns Hypergeometric hyper ns nf n
 
-rand(d::Hypergeometric) = convert(Int, StatsFuns.RFunctions.hyperrand(d.ns, d.nf, d.n))
+rand(d::Hypergeometric) =
+    convert(Int, StatsFuns.RFunctions.hyperrand(d.ns, d.nf, d.n))
 
 struct RecursiveHypergeomProbEvaluator <: RecursiveProbabilityEvaluator
     ns::Float64

--- a/src/univariate/discrete/hypergeometric.jl
+++ b/src/univariate/discrete/hypergeometric.jl
@@ -74,6 +74,12 @@ end
 
 @_delegate_statsfuns Hypergeometric hyper ns nf n
 
+## sampling
+# TODO: Implement:
+#   V. Kachitvichyanukul & B. Schmeiser
+#   "Computer generation of hypergeometric random variates"
+#   Journal of Statistical Computation and Simulation, 22(2):127-145
+#   doi:10.1080/00949658508810839
 rand(d::Hypergeometric) =
     convert(Int, StatsFuns.RFunctions.hyperrand(d.ns, d.nf, d.n))
 

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -28,7 +28,7 @@ External links:
 Note: The definition of the negative binomial distribution in Wolfram is different from the [Wikipedia definition](http://en.wikipedia.org/wiki/Negative_binomial_distribution). In Wikipedia, `r` is the number of failures and `k` is the number of successes.
 
 """
-struct NegativeBinomial{T<:Real} <: DiscreteUnivariateRDist
+struct NegativeBinomial{T<:Real} <: DiscreteUnivariateDistribution
     r::T
     p::T
 
@@ -88,6 +88,7 @@ mode(d::NegativeBinomial) = (p = succprob(d); floor(Int,(1 - p) * (d.r - 1) / p)
 
 ## sampling
 # TODO: remove RFunctions dependency once Poisson has its removed
+@rand_rdist(NegativeBinomial)
 rand(d::NegativeBinomial) =
     convert(Int, StatsFuns.RFunctions.nbinomrand(d.r, d.p))
 

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -28,7 +28,7 @@ External links:
 Note: The definition of the negative binomial distribution in Wolfram is different from the [Wikipedia definition](http://en.wikipedia.org/wiki/Negative_binomial_distribution). In Wikipedia, `r` is the number of failures and `k` is the number of successes.
 
 """
-struct NegativeBinomial{T<:Real} <: DiscreteUnivariateDistribution
+struct NegativeBinomial{T<:Real} <: DiscreteUnivariateRDist
     r::T
     p::T
 
@@ -86,7 +86,8 @@ mode(d::NegativeBinomial) = (p = succprob(d); floor(Int,(1 - p) * (d.r - 1) / p)
 
 @_delegate_statsfuns NegativeBinomial nbinom r p
 
-rand(d::NegativeBinomial) = convert(Int, StatsFuns.RFunctions.nbinomrand(d.r, d.p))
+rand(d::NegativeBinomial) =
+    convert(Int, StatsFuns.RFunctions.nbinomrand(d.r, d.p))
 
 struct RecursiveNegBinomProbEvaluator <: RecursiveProbabilityEvaluator
     r::Float64

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -92,9 +92,9 @@ mode(d::NegativeBinomial) = (p = succprob(d); floor(Int,(1 - p) * (d.r - 1) / p)
 rand(d::NegativeBinomial) =
     convert(Int, StatsFuns.RFunctions.nbinomrand(d.r, d.p))
 
-function _rand(rng::AbstractRNG, d::NegativeBinomial)
-    lambda = _rand(rng, Gamma(d.r, (1-d.p)/d.p))
-    return _rand(rng, Poisson(lambda))
+function rand(rng::AbstractRNG, d::NegativeBinomial)
+    lambda = rand(rng, Gamma(d.r, (1-d.p)/d.p))
+    return rand(rng, Poisson(lambda))
 end
 
 struct RecursiveNegBinomProbEvaluator <: RecursiveProbabilityEvaluator

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -86,8 +86,15 @@ mode(d::NegativeBinomial) = (p = succprob(d); floor(Int,(1 - p) * (d.r - 1) / p)
 
 @_delegate_statsfuns NegativeBinomial nbinom r p
 
+## sampling
+# TODO: remove RFunctions dependency once Poisson has its removed
 rand(d::NegativeBinomial) =
     convert(Int, StatsFuns.RFunctions.nbinomrand(d.r, d.p))
+
+function _rand!(rng::AbstractRNG, d::NegativeBinomial)
+    lambda = _rand!(rng, Gamma(d.r, (1-d.p)/d.p))
+    return _rand!(rng, Poisson(lambda))
+end
 
 struct RecursiveNegBinomProbEvaluator <: RecursiveProbabilityEvaluator
     r::Float64

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -91,9 +91,9 @@ mode(d::NegativeBinomial) = (p = succprob(d); floor(Int,(1 - p) * (d.r - 1) / p)
 rand(d::NegativeBinomial) =
     convert(Int, StatsFuns.RFunctions.nbinomrand(d.r, d.p))
 
-function _rand!(rng::AbstractRNG, d::NegativeBinomial)
-    lambda = _rand!(rng, Gamma(d.r, (1-d.p)/d.p))
-    return _rand!(rng, Poisson(lambda))
+function _rand(rng::AbstractRNG, d::NegativeBinomial)
+    lambda = _rand(rng, Gamma(d.r, (1-d.p)/d.p))
+    return _rand(rng, Poisson(lambda))
 end
 
 struct RecursiveNegBinomProbEvaluator <: RecursiveProbabilityEvaluator

--- a/src/univariate/discrete/poisson.jl
+++ b/src/univariate/discrete/poisson.jl
@@ -20,7 +20,7 @@ External links:
 * [Poisson distribution on Wikipedia](http://en.wikipedia.org/wiki/Poisson_distribution)
 
 """
-struct Poisson{T<:Real} <: DiscreteUnivariateRDist
+struct Poisson{T<:Real} <: DiscreteUnivariateDistribution
     λ::T
 
     Poisson{T}(λ::Real) where {T} = (@check_args(Poisson, λ >= zero(λ)); new{T}(λ))
@@ -86,11 +86,6 @@ end
 
 @_delegate_statsfuns Poisson pois λ
 
-
-# TODO: remove RFunctions dependency once Poisson has been fully implemented
-# Currently depends on a quantile function for one option
-rand(d::Poisson) = convert(Int, StatsFuns.RFunctions.poisrand(d.λ))
-
 struct RecursivePoissonProbEvaluator <: RecursiveProbabilityEvaluator
     λ::Float64
 end
@@ -140,6 +135,13 @@ function suffstats(::Type{Poisson}, x::AbstractArray{T}, w::AbstractArray{Float6
 end
 
 fit_mle(::Type{Poisson}, ss::PoissonStats) = Poisson(ss.sx / ss.tw)
+
+## samplers
+
+# TODO: remove RFunctions dependency once Poisson has been fully implemented
+# Currently depends on a quantile function for one option
+@rand_rdist(Poisson)
+rand(d::Poisson) = convert(Int, StatsFuns.RFunctions.poisrand(d.λ))
 
 # algorithm from:
 #   J.H. Ahrens, U. Dieter (1982)

--- a/src/univariate/discrete/poisson.jl
+++ b/src/univariate/discrete/poisson.jl
@@ -86,6 +86,9 @@ end
 
 @_delegate_statsfuns Poisson pois λ
 
+
+# TODO: remove RFunctions dependency once Poisson has been fully implemented
+# Currently depends on a quantile function for one option
 rand(d::Poisson) = convert(Int, StatsFuns.RFunctions.poisrand(d.λ))
 
 struct RecursivePoissonProbEvaluator <: RecursiveProbabilityEvaluator
@@ -137,3 +140,97 @@ function suffstats(::Type{Poisson}, x::AbstractArray{T}, w::AbstractArray{Float6
 end
 
 fit_mle(::Type{Poisson}, ss::PoissonStats) = Poisson(ss.sx / ss.tw)
+
+# algorithm from:
+#   J.H. Ahrens, U. Dieter (1982)
+#   "Computer Generation of Poisson Deviates from Modified Normal Distributions"
+#   ACM Transactions on Mathematical Software, 8(2):163-179
+# TODO: implement poisson sampler
+function _rand!(rng::AbstractRNG, d::Poisson)
+    μ = d.λ
+    if μ >= 10.0  # Case A
+
+        s = sqrt(μ)
+        d = 6.0*μ^2
+        L = floor(Int64, μ-1.1484)
+
+        # Step N
+        T = randn(rng)
+        G = μ + s*T
+
+        if G >= 0.0
+            K = floor(Int64, G)
+            # Step I
+            if K >= L
+                return K
+            end
+
+            # Step S
+            U = rand(rng)
+            if d*U >= (μ-K)^3
+                return K
+            end
+
+            # Step P
+            px,py,fx,fy = procf(μ,K,s)
+
+            # Step Q
+            if fy*(1-U) <= py*exp(px-fx)
+                return K
+            end
+        end
+
+        while true
+            # Step E
+            E = randexp(rng)
+            U = rand(rng)
+            U = 2.0*U-1.0
+            T = 1.8+copysign(E,U)
+            if T <= -0.6744
+                continue
+            end
+
+            K = floor(Int64, μ + s*T)
+            px,py,fx,fy = procf(μ,K,s)
+            c = 0.1069/μ
+
+            # Step H
+            if c*abs(U) <= py*exp(px+E)-fy*exp(fx+E)
+                return K
+            end
+        end
+    else # Case B
+        # Ahrens & Dieter use a sequential method for tabulating and looking up quantiles.
+        # TODO: check which is more efficient.
+        return quantile(d,rand(rng))
+    end
+end
+
+
+# Procedure F
+function procf(μ,K,s)
+    ω = 0.3989422804014327/s
+    b1 = 0.041666666666666664/μ
+    b2 = 0.3*b1^2
+    c3 = 0.14285714285714285*b1*b2
+    c2 = b2 - 15.0*c3
+    c1 = b1 - 6.0*b2 + 45.0*c3
+    c0 = 1.0 - b1 + 3.0*b2 - 15.0*c3
+
+    if K < 10
+        px = -μ
+        py = μ^K/factorial(K) # replace with loopup?
+    else
+        δ = 0.08333333333333333/K
+        δ -= 4.8*δ^3
+        V = (μ-K)/K
+        px = K*log1pmx(V) - δ # avoids need for table
+        py = 0.3989422804014327/sqrt(K)
+
+    end
+    X = (K-μ+0.5)/s
+    X2 = X^2
+    fx = -0.5*X2 # missing negation in paper
+    fy = ω*(((c3*X2+c2)*X2+c1)*X2+c0)
+    return px,py,fx,fy
+end

--- a/src/univariate/discrete/poisson.jl
+++ b/src/univariate/discrete/poisson.jl
@@ -148,7 +148,7 @@ rand(d::Poisson) = convert(Int, StatsFuns.RFunctions.poisrand(d.λ))
 #   "Computer Generation of Poisson Deviates from Modified Normal Distributions"
 #   ACM Transactions on Mathematical Software, 8(2):163-179
 # TODO: implement poisson sampler
-function _rand(rng::AbstractRNG, d::Poisson)
+function rand(rng::AbstractRNG, d::Poisson)
     μ = d.λ
     if μ >= 10.0  # Case A
 

--- a/src/univariate/discrete/poisson.jl
+++ b/src/univariate/discrete/poisson.jl
@@ -146,7 +146,7 @@ fit_mle(::Type{Poisson}, ss::PoissonStats) = Poisson(ss.sx / ss.tw)
 #   "Computer Generation of Poisson Deviates from Modified Normal Distributions"
 #   ACM Transactions on Mathematical Software, 8(2):163-179
 # TODO: implement poisson sampler
-function _rand!(rng::AbstractRNG, d::Poisson)
+function _rand(rng::AbstractRNG, d::Poisson)
     μ = d.λ
     if μ >= 10.0  # Case A
 

--- a/src/univariate/discrete/poisson.jl
+++ b/src/univariate/discrete/poisson.jl
@@ -20,7 +20,7 @@ External links:
 * [Poisson distribution on Wikipedia](http://en.wikipedia.org/wiki/Poisson_distribution)
 
 """
-struct Poisson{T<:Real} <: DiscreteUnivariateDistribution
+struct Poisson{T<:Real} <: DiscreteUnivariateRDist
     λ::T
 
     Poisson{T}(λ::Real) where {T} = (@check_args(Poisson, λ >= zero(λ)); new{T}(λ))

--- a/src/univariate/discrete/skellam.jl
+++ b/src/univariate/discrete/skellam.jl
@@ -20,7 +20,7 @@ External links:
 
 * [Skellam distribution on Wikipedia](http://en.wikipedia.org/wiki/Skellam_distribution)
 """
-struct Skellam{T<:Real} <: DiscreteUnivariateRDist
+struct Skellam{T<:Real} <: DiscreteUnivariateDistribution
     μ1::T
     μ2::T
 
@@ -85,6 +85,7 @@ cdf(d::Skellam, x::Real) = throw(MethodError(cdf, (d, x)))
 
 #### Sampling
 # TODO: remove RFunctions dependency once Poisson has its removed
+@rand_rdist(Skellam)
 rand(d::Skellam) = rand(Poisson(d.μ1)) - rand(Poisson(d.μ2))
 
 _rand(rng::AbstractRNG, d::Skellam) =

--- a/src/univariate/discrete/skellam.jl
+++ b/src/univariate/discrete/skellam.jl
@@ -84,7 +84,7 @@ cdf(d::Skellam, x::Int) = throw(MethodError(cdf, (d, x)))
 cdf(d::Skellam, x::Real) = throw(MethodError(cdf, (d, x)))
 
 #### Sampling
-# Rfunctions
+# TODO: remove RFunctions dependency once Poisson has its removed
 rand(d::Skellam) = rand(Poisson(d.μ1)) - rand(Poisson(d.μ2))
 
 _rand!(rng::AbstractRNG, d::Skellam) =

--- a/src/univariate/discrete/skellam.jl
+++ b/src/univariate/discrete/skellam.jl
@@ -20,7 +20,7 @@ External links:
 
 * [Skellam distribution on Wikipedia](http://en.wikipedia.org/wiki/Skellam_distribution)
 """
-struct Skellam{T<:Real} <: DiscreteUnivariateDistribution
+struct Skellam{T<:Real} <: DiscreteUnivariateRDist
     μ1::T
     μ2::T
 
@@ -84,5 +84,8 @@ cdf(d::Skellam, x::Int) = throw(MethodError(cdf, (d, x)))
 cdf(d::Skellam, x::Real) = throw(MethodError(cdf, (d, x)))
 
 #### Sampling
-
+# Rfunctions
 rand(d::Skellam) = rand(Poisson(d.μ1)) - rand(Poisson(d.μ2))
+
+_rand!(rng::AbstractRNG, d::Skellam) =
+    _rand!(rng, Poisson(d.μ1)) - _rand!(rng, Poisson(d.μ2))

--- a/src/univariate/discrete/skellam.jl
+++ b/src/univariate/discrete/skellam.jl
@@ -87,5 +87,5 @@ cdf(d::Skellam, x::Real) = throw(MethodError(cdf, (d, x)))
 # TODO: remove RFunctions dependency once Poisson has its removed
 rand(d::Skellam) = rand(Poisson(d.μ1)) - rand(Poisson(d.μ2))
 
-_rand!(rng::AbstractRNG, d::Skellam) =
-    _rand!(rng, Poisson(d.μ1)) - _rand!(rng, Poisson(d.μ2))
+_rand(rng::AbstractRNG, d::Skellam) =
+    _rand(rng, Poisson(d.μ1)) - _rand(rng, Poisson(d.μ2))

--- a/src/univariate/discrete/skellam.jl
+++ b/src/univariate/discrete/skellam.jl
@@ -88,5 +88,5 @@ cdf(d::Skellam, x::Real) = throw(MethodError(cdf, (d, x)))
 @rand_rdist(Skellam)
 rand(d::Skellam) = rand(Poisson(d.μ1)) - rand(Poisson(d.μ2))
 
-_rand(rng::AbstractRNG, d::Skellam) =
-    _rand(rng, Poisson(d.μ1)) - _rand(rng, Poisson(d.μ2))
+rand(rng::AbstractRNG, d::Skellam) =
+    rand(rng, Poisson(d.μ1)) - rand(rng, Poisson(d.μ2))

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -154,7 +154,7 @@ end
 
 ## sampling
 # single univariate, no allocation
-rand(rng::AbstractRNG, s::Sampleable{Univariate}) = _rand!(rng, s)
+rand(rng::AbstractRNG, s::Sampleable{Univariate}) = _rand(rng, s)
 
 # multiple univariate, must allocate array
 rand(rng::AbstractRNG, s::Sampleable{Univariate}, dims::Dims) =
@@ -164,17 +164,17 @@ rand(rng::AbstractRNG, s::Sampleable{Univariate}, dims::Dims) =
 function rand!(rng::AbstractRNG, s::Sampleable{Univariate}, A::AbstractArray)
     smp = sampler(s)
     for i in eachindex(A)
-        @inbounds A[i] = _rand!(rng, smp)
+        @inbounds A[i] = _rand(rng, smp)
     end
     return A
 end
 
 """
-    _rand!(d::UnivariateDistribution)
+    _rand(d::UnivariateDistribution)
 
 Generate a scalar sample from `d`. The general fallback is `quantile(d, rand())`.
 """
-_rand!(rng::AbstractRNG, d::UnivariateDistribution) = quantile(d, rand(rng))
+_rand(rng::AbstractRNG, d::UnivariateDistribution) = quantile(d, rand(rng))
 
 ## statistics
 

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -153,31 +153,28 @@ end
 ##### generic methods (fallback) #####
 
 ## sampling
+# single univariate, no allocation
+rand(rng::AbstractRNG, s::Sampleable{Univariate}) = _rand!(rng, s)
+
+# multiple univariate, must allocate array
+rand(rng::AbstractRNG, s::Sampleable{Univariate}, dims::Dims) =
+    rand!(rng, sampler(s), Array{eltype(s)}(undef, dims))
+
+# multiple univariate with pre-allocated array
+function rand!(rng::AbstractRNG, s::Sampleable{Univariate}, A::AbstractArray)
+    smp = sampler(s)
+    for i in eachindex(A)
+        @inbounds A[i] = _rand!(rng, smp)
+    end
+    return A
+end
 
 """
-    rand(d::UnivariateDistribution)
+    _rand!(d::UnivariateDistribution)
 
 Generate a scalar sample from `d`. The general fallback is `quantile(d, rand())`.
-
-    rand(d::UnivariateDistribution, n::Int) -> Vector
-
-Generates a vector of `n` random scalar samples from `d`. The general fallback is to
-pick random samples from `sampler(d)`.
 """
-rand(d::UnivariateDistribution) = quantile(d, rand())
-
-"""
-    rand!(d::UnivariateDistribution, A::AbstractArray)
-
-Populates the array `A` with scalar samples from `d`. The general fallback is to pick
-random samples from `sampler(d)`.
-"""
-rand!(d::UnivariateDistribution, A::AbstractArray) = _rand!(sampler(d), A)
-rand(d::UnivariateDistribution, n::Int) = _rand!(sampler(d), Vector{eltype(d)}(undef, n))
-rand(d::UnivariateDistribution, shp::Dims) = _rand!(sampler(d), Vector{eltype(d)}(undef, shp))
-
-
-sampler(d::UnivariateDistribution) = d
+_rand!(rng::AbstractRNG, d::UnivariateDistribution) = quantile(d, rand(rng))
 
 ## statistics
 

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -154,7 +154,7 @@ end
 
 ## sampling
 # single univariate, no allocation
-rand(rng::AbstractRNG, s::Sampleable{Univariate}) = _rand(rng, s)
+rand(rng::AbstractRNG, s::Sampleable{Univariate}) = rand(rng, s)
 
 # multiple univariate, must allocate array
 rand(rng::AbstractRNG, s::Sampleable{Univariate}, dims::Dims) =
@@ -164,17 +164,17 @@ rand(rng::AbstractRNG, s::Sampleable{Univariate}, dims::Dims) =
 function rand!(rng::AbstractRNG, s::Sampleable{Univariate}, A::AbstractArray)
     smp = sampler(s)
     for i in eachindex(A)
-        @inbounds A[i] = _rand(rng, smp)
+        @inbounds A[i] = rand(rng, smp)
     end
     return A
 end
 
 """
-    _rand(d::UnivariateDistribution)
+    rand(d::UnivariateDistribution)
 
 Generate a scalar sample from `d`. The general fallback is `quantile(d, rand())`.
 """
-_rand(rng::AbstractRNG, d::UnivariateDistribution) = quantile(d, rand(rng))
+rand(rng::AbstractRNG, d::UnivariateDistribution) = quantile(d, rand(rng))
 
 ## statistics
 

--- a/test/continuous.jl
+++ b/test/continuous.jl
@@ -1,6 +1,6 @@
 # Testing continuous univariate distributions
 
-using Distributions
+using Distributions, Random
 using Test
 
 using Calculus: derivative
@@ -8,17 +8,15 @@ using Calculus: derivative
 n_tsamples = 100
 
 # additional distributions that have no direct counterparts in R references
-for distr in [
-    Biweight(),
-    Biweight(1,3),
-    Epanechnikov(),
-    Epanechnikov(1,3),
-    Triweight(),
-    Triweight(2),
-    Triweight(1, 3),
-    Triweight(1),
-]
-    println("    testing $(distr)")
+@testset "Testing $(distr)" for distr in [Biweight(),
+                                          Biweight(1,3),
+                                          Epanechnikov(),
+                                          Epanechnikov(1,3),
+                                          Triweight(),
+                                          Triweight(2),
+                                          Triweight(1, 3),
+                                          Triweight(1)]
+    
     test_distr(distr, n_tsamples; testquan=false)
 end
 
@@ -52,6 +50,7 @@ using ForwardDiff
     @test quantile(d, 1.0) == +Inf
 
     @test rand(d) == 0.5
+    @test rand(MersenneTwister(), d) == 0.5
 end
 
 # Test for parameters beyond those supported in R references

--- a/test/continuous.jl
+++ b/test/continuous.jl
@@ -50,7 +50,7 @@ using ForwardDiff
     @test quantile(d, 1.0) == +Inf
 
     @test rand(d) == 0.5
-    @test rand(MersenneTwister(), d) == 0.5
+    @test rand(MersenneTwister(123), d) == 0.5
 end
 
 # Test for parameters beyond those supported in R references

--- a/test/dirichlet.jl
+++ b/test/dirichlet.jl
@@ -6,7 +6,7 @@ using Test, Random, LinearAlgebra
 
 Random.seed!(34567)
 
-rng = MersenneTwister()
+rng = MersenneTwister(123)
 
 @testset "Testing Dirichlet with $key" for (key, func) in
     Dict("rand(...)" => [rand, rand],

--- a/test/dirichlet.jl
+++ b/test/dirichlet.jl
@@ -6,6 +6,12 @@ using Test, Random, LinearAlgebra
 
 Random.seed!(34567)
 
+rng = MersenneTwister()
+
+@testset "Testing Dirichlet with $key" for (key, func) in
+    Dict("rand(...)" => [rand, rand],
+         "rand(rng, ...)" => [dist -> rand(rng, dist), (dist, n) -> rand(rng, dist, n)])
+
 d = Dirichlet(3, 2.0)
 
 @test length(d) == 3
@@ -21,7 +27,7 @@ d = Dirichlet(3, 2.0)
 @test logpdf(d, [0.2, 0.3, 0.5]) ≈ log(3.6)
 @test logpdf(d, [0.4, 0.5, 0.1]) ≈ log(2.4)
 
-x = rand(d, 100)
+x = func[2](d, 100)
 p = pdf(d, x)
 lp = logpdf(d, x)
 for i in 1 : size(x, 2)
@@ -48,7 +54,7 @@ d = Dirichlet(v)
 @test logpdf(d, [0.2, 0.3, 0.5]) ≈ log(3.0)
 @test logpdf(d, [0.4, 0.5, 0.1]) ≈ log(0.24)
 
-x = rand(d, 100)
+x = func[2](d, 100)
 p = pdf(d, x)
 lp = logpdf(d, x)
 for i in 1 : size(x, 2)
@@ -58,11 +64,11 @@ end
 
 # Sampling
 
-x = rand(d)
+x = func[1](d)
 @test isa(x, Vector{Float64})
 @test length(x) == 3
 
-x = rand(d, 10)
+x = func[2](d, 10)
 @test isa(x, Matrix{Float64})
 @test size(x) == (3, 10)
 
@@ -70,7 +76,7 @@ x = rand(d, 10)
 # Test MLE
 
 n = 10000
-x = rand(d, n)
+x = func[2](d, n)
 x = x ./ sum(x, dims=1)
 
 r = fit_mle(Dirichlet, x)
@@ -78,3 +84,5 @@ r = fit_mle(Dirichlet, x)
 
 # r = fit_mle(Dirichlet, x, fill(2.0, n))
 # @test isapprox(r.alpha, d.alpha, atol=0.25)
+
+end

--- a/test/dirichletmultinomial.jl
+++ b/test/dirichletmultinomial.jl
@@ -8,13 +8,18 @@ import SpecialFunctions: factorial
 
 Random.seed!(123)
 
+rng = MersenneTwister()
+
+@testset "Testing DirichletMultinomial with $key" for (key, func) in
+    Dict("rand(...)" => [rand, rand],
+         "rand(rng, ...)" => [dist -> rand(rng, dist), (dist, n) -> rand(rng, dist, n)])
 
 # Test Constructors
 d = DirichletMultinomial(10, ones(5))
 d2 = DirichletMultinomial(10, ones(Int, 5))
 @test typeof(d) == typeof(d2)
 
-α = rand(5)
+α = func[1](5)
 d = DirichletMultinomial(10, α)
 
 # test parameters
@@ -29,7 +34,7 @@ d = DirichletMultinomial(10, α)
 @test mean(d) ≈ α * (d.n / d.α0)
 p = d.α / d.α0
 @test var(d)  ≈ d.n * (d.n + d.α0) / (1 + d.α0) .* p .* (1.0 .- p)
-x = rand(d, 10_000)
+x = func[2](d, 10_000)
 
 # test statistics with mle fit
 d = fit(DirichletMultinomial, x)
@@ -40,7 +45,7 @@ d = fit(DirichletMultinomial, x)
 # test Evaluation
 d = DirichletMultinomial(10, 5)
 @test typeof(d) == DirichletMultinomial{Float64}
-@test !insupport(d, rand(5))
+@test !insupport(d, func[1](5))
 @test insupport(d, [2, 2, 2, 2, 2])
 @test insupport(d, 2.0 * ones(5))
 @test !insupport(d, 3.0 * ones(5))
@@ -54,13 +59,13 @@ for x in (2 * ones(5), [1, 2, 3, 4, 0], [3.0, 0.0, 3.0, 0.0, 4.0], [0, 0, 0, 0, 
 end
 
 # test Sampling
-x = rand(d)
+x = func[1](d)
 @test isa(x, Vector{Int})
 @test sum(x) == d.n
 @test length(x) == length(d)
 @test insupport(d, x)
 
-x = rand(d, 50)
+x = func[2](d, 50)
 @test all(x -> (x >= 0), x)
 @test size(x, 1) == length(d)
 @test size(x, 2) == 50
@@ -68,7 +73,7 @@ x = rand(d, 50)
 @test all(insupport(d, x))
 
 # test MLE
-x = rand(d, 10_000)
+x = func[2](d, 10_000)
 ss = suffstats(DirichletMultinomial, x)
 @test size(ss.s, 1) == length(d)
 @test size(ss.s, 2) == ntrials(d)
@@ -79,4 +84,6 @@ mle = fit(DirichletMultinomial, x)
 for w in (.1 * ones(10_000), ones(10_000), 10 * ones(10_000))
     mle2 = fit(DirichletMultinomial, x, w)
     @test mle.α ≈ mle2.α
+end
+
 end

--- a/test/dirichletmultinomial.jl
+++ b/test/dirichletmultinomial.jl
@@ -8,7 +8,7 @@ import SpecialFunctions: factorial
 
 Random.seed!(123)
 
-rng = MersenneTwister()
+rng = MersenneTwister(123)
 
 @testset "Testing DirichletMultinomial with $key" for (key, func) in
     Dict("rand(...)" => [rand, rand],

--- a/test/discretenonparametric.jl
+++ b/test/discretenonparametric.jl
@@ -1,5 +1,6 @@
 import StatsBase: ProbabilityWeights
 using Random, Distributions
+using Test
 
 rng = MersenneTwister(123)
 

--- a/test/discretenonparametric.jl
+++ b/test/discretenonparametric.jl
@@ -1,7 +1,7 @@
 import StatsBase: ProbabilityWeights
 using Random, Distributions
 
-rng = MersenneTwister()
+rng = MersenneTwister(123)
 
 @testset "Testing matrix-variates with $key" for (key, func) in
     Dict("rand(...)" => [rand, rand],

--- a/test/discretenonparametric.jl
+++ b/test/discretenonparametric.jl
@@ -1,7 +1,13 @@
 import StatsBase: ProbabilityWeights
+using Random, Distributions
+
+rng = MersenneTwister()
+
+@testset "Testing matrix-variates with $key" for (key, func) in
+    Dict("rand(...)" => [rand, rand],
+         "rand(rng, ...)" => [dist -> rand(rng, dist), (dist, n) -> rand(rng, dist, n)])
 
 d = DiscreteNonParametric([40., 80., 120., -60.], [.4, .3, .1,  .2])
-println("    testing $d")
 
 @test !(d ≈ DiscreteNonParametric([40., 80, 120, -60], [.4, .3, .1, .2], Distributions.NoArgCheck()))
 @test d ≈ DiscreteNonParametric([-60., 40., 80, 120], [.2, .4, .3, .1], Distributions.NoArgCheck())
@@ -18,8 +24,8 @@ Distributions.test_evaluation(d, vs, true)
 Distributions.test_stats(d, vs)
 Distributions.test_params(d)
 
-@test rand(d) ∈ [40., 80., 120., -60.]
-@test rand(sampler(d)) ∈ [40., 80., 120., -60.]
+@test func[1](d) ∈ [40., 80., 120., -60.]
+@test func[1](sampler(d)) ∈ [40., 80., 120., -60.]
 
 @test pdf(d, -100.) == 0.
 @test pdf(d, -100) == 0.
@@ -99,3 +105,5 @@ d3 = fit(DiscreteNonParametric, xs)
 @test typeof(d2) == typeof(d1)
 @test support(d3) == support(d1)
 @test probs(d3) ≈ probs(d1)
+
+end

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -11,24 +11,30 @@ using Test, Random, LinearAlgebra
 n0 = 100
 N = 10^5
 
-w = rand(n0)
+rng = MersenneTwister()
+
+@testset "Testing fit for $key" for (key, func) in
+    Dict("rand(...)" => [rand, rand],
+         "rand(rng, ...)" => [dist -> rand(rng, dist), (dist, n) -> rand(rng, dist, n)])
+
+w = func[1](n0)
 
 # DiscreteUniform
 
-x = rand(DiscreteUniform(10, 15), n0)
+x = func[2](DiscreteUniform(10, 15), n0)
 d = fit(DiscreteUniform, x)
 @test isa(d, DiscreteUniform)
 @test minimum(d) == minimum(x)
 @test maximum(d) == maximum(x)
 
-d = fit(DiscreteUniform, rand(DiscreteUniform(10, 15), N))
+d = fit(DiscreteUniform, func[2](DiscreteUniform(10, 15), N))
 @test minimum(d) == 10
 @test maximum(d) == 15
 
 
 # Bernoulli
 
-x = rand(Bernoulli(0.7), n0)
+x = func[2](Bernoulli(0.7), n0)
 
 ss = suffstats(Bernoulli, x)
 @test isa(ss, Distributions.BernoulliStats)
@@ -50,14 +56,14 @@ p = sum(w[x .== 1]) / sum(w)
 @test isa(d, Bernoulli)
 @test mean(d) ≈ p
 
-d = fit(Bernoulli, rand(Bernoulli(0.7), N))
+d = fit(Bernoulli, func[2](Bernoulli(0.7), N))
 @test isa(d, Bernoulli)
 @test isapprox(mean(d), 0.7, atol=0.01)
 
 
 # Beta
 
-d = fit(Beta, rand(Beta(1.3, 3.7), N))
+d = fit(Beta, func[2](Beta(1.3, 3.7), N))
 @test isa(d, Beta)
 @test isapprox(d.α, 1.3, atol=0.1)
 @test isapprox(d.β, 3.7, atol=0.1)
@@ -65,7 +71,7 @@ d = fit(Beta, rand(Beta(1.3, 3.7), N))
 
 # Binomial
 
-x = rand(Binomial(100, 0.3), n0)
+x = func[2](Binomial(100, 0.3), n0)
 
 ss = suffstats(Binomial, (100, x))
 @test isa(ss, Distributions.BinomialStats)
@@ -89,7 +95,7 @@ d = fit(Binomial, (100, x), w)
 @test ntrials(d) == 100
 @test succprob(d) ≈ dot(x, w) / (sum(w) * 100)
 
-d = fit(Binomial, 100, rand(Binomial(100, 0.3), N))
+d = fit(Binomial, 100, func[2](Binomial(100, 0.3), N))
 @test isa(d, Binomial)
 @test ntrials(d) == 100
 @test isapprox(succprob(d), 0.3, atol=0.01)
@@ -98,7 +104,7 @@ d = fit(Binomial, 100, rand(Binomial(100, 0.3), N))
 # Categorical
 
 p = [0.2, 0.5, 0.3]
-x = rand(Categorical(p), n0)
+x = func[2](Categorical(p), n0)
 
 ss = suffstats(Categorical, (3, x))
 h = Float64[count(v->v == i, x) for i = 1 : 3]
@@ -127,7 +133,7 @@ d = fit(Categorical, suffstats(Categorical, 3, x, w))
 @test isa(d, Categorical)
 @test probs(d) ≈ (h / sum(h))
 
-d = fit(Categorical, rand(Categorical(p), N))
+d = fit(Categorical, func[2](Categorical(p), N))
 @test isa(d, Categorical)
 @test isapprox(probs(d), p, atol=0.01)
 
@@ -139,7 +145,7 @@ d = fit(Categorical, rand(Categorical(p), N))
 
 # Exponential
 
-x = rand(Exponential(0.5), n0)
+x = func[2](Exponential(0.5), n0)
 
 ss = suffstats(Exponential, x)
 @test isa(ss, Distributions.ExponentialStats)
@@ -159,7 +165,7 @@ d = fit(Exponential, x, w)
 @test isa(d, Exponential)
 @test scale(d) ≈ dot(x, w) / sum(w)
 
-d = fit(Exponential, rand(Exponential(0.5), N))
+d = fit(Exponential, func[2](Exponential(0.5), N))
 @test isa(d, Exponential)
 @test isapprox(scale(d), 0.5, atol=0.01)
 
@@ -169,7 +175,7 @@ d = fit(Exponential, rand(Exponential(0.5), N))
 μ = 11.3
 σ = 3.2
 
-x = rand(Normal(μ, σ), n0)
+x = func[2](Normal(μ, σ), n0)
 
 ss = suffstats(Normal, x)
 @test isa(ss, Distributions.NormalStats)
@@ -195,7 +201,7 @@ d = fit(Normal, x, w)
 @test d.μ ≈ dot(x, w) / sum(w)
 @test d.σ ≈ sqrt(dot((x .- d.μ).^2, w) / sum(w))
 
-d = fit(Normal, rand(Normal(μ, σ), N))
+d = fit(Normal, func[2](Normal(μ, σ), N))
 @test isa(d, Normal)
 @test isapprox(d.μ, μ, atol=0.1)
 @test isapprox(d.σ, σ, atol=0.1)
@@ -250,14 +256,14 @@ d = fit_mle(Normal, x, w; sigma=σ)
 
 # Uniform
 
-x = rand(Uniform(1.2, 5.8), n0)
+x = func[2](Uniform(1.2, 5.8), n0)
 d = fit(Uniform, x)
 @test isa(d, Uniform)
 @test 1.2 <= minimum(d) <= maximum(d) <= 5.8
 @test minimum(d) == minimum(x)
 @test maximum(d) == maximum(x)
 
-d = fit(Uniform, rand(Uniform(1.2, 5.8), N))
+d = fit(Uniform, func[2](Uniform(1.2, 5.8), N))
 @test 1.2 <= minimum(d) <= maximum(d) <= 5.8
 @test isapprox(minimum(d), 1.2, atol=0.02)
 @test isapprox(maximum(d), 5.8, atol=0.02)
@@ -265,7 +271,7 @@ d = fit(Uniform, rand(Uniform(1.2, 5.8), N))
 
 # Gamma
 
-x = rand(Gamma(3.9, 2.1), n0)
+x = func[2](Gamma(3.9, 2.1), n0)
 
 ss = suffstats(Gamma, x)
 @test isa(ss, Distributions.GammaStats)
@@ -279,7 +285,7 @@ ss = suffstats(Gamma, x, w)
 @test ss.slogx ≈ dot(log.(x), w)
 @test ss.tw    ≈ sum(w)
 
-d = fit(Gamma, rand(Gamma(3.9, 2.1), N))
+d = fit(Gamma, func[2](Gamma(3.9, 2.1), N))
 @test isa(d, Gamma)
 @test isapprox(shape(d), 3.9, atol=0.1)
 @test isapprox(scale(d), 2.1, atol=0.2)
@@ -287,7 +293,7 @@ d = fit(Gamma, rand(Gamma(3.9, 2.1), N))
 
 # Geometric
 
-x = rand(Geometric(0.3), n0)
+x = func[2](Geometric(0.3), n0)
 
 ss = suffstats(Geometric, x)
 @test isa(ss, Distributions.GeometricStats)
@@ -307,21 +313,21 @@ d = fit(Geometric, x, w)
 @test isa(d, Geometric)
 @test succprob(d) ≈ inv(1. + dot(x, w) / sum(w))
 
-d = fit(Geometric, rand(Geometric(0.3), N))
+d = fit(Geometric, func[2](Geometric(0.3), N))
 @test isa(d, Geometric)
 @test isapprox(succprob(d), 0.3, atol=0.01)
 
 
 # Laplace
 
-d = fit(Laplace, rand(Laplace(5.0, 3.0), N))
+d = fit(Laplace, func[2](Laplace(5.0, 3.0), N))
 @test isa(d, Laplace)
 @test isapprox(location(d), 5.0, atol=0.1)
 @test isapprox(scale(d)   , 3.0, atol=0.2)
 
 # Pareto
 
-x = rand(Pareto(3., 7.), N)
+x = func[2](Pareto(3., 7.), N)
 d = fit(Pareto, x)
 
 @test isa(d, Pareto)
@@ -330,7 +336,7 @@ d = fit(Pareto, x)
 
 # Poisson
 
-x = rand(Poisson(8.2), n0)
+x = func[2](Poisson(8.2), n0)
 
 ss = suffstats(Poisson, x)
 @test isa(ss, Distributions.PoissonStats)
@@ -350,6 +356,8 @@ d = fit(Poisson, x, w)
 @test isa(d, Poisson)
 @test mean(d) ≈ dot(Float64[xx for xx in x], w) / sum(w)
 
-d = fit(Poisson, rand(Poisson(8.2), N))
+d = fit(Poisson, func[2](Poisson(8.2), N))
 @test isa(d, Poisson)
 @test isapprox(mean(d), 8.2, atol=0.2)
+
+end

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -11,7 +11,7 @@ using Test, Random, LinearAlgebra
 n0 = 100
 N = 10^5
 
-rng = MersenneTwister()
+rng = MersenneTwister(123)
 
 @testset "Testing fit for $key" for (key, func) in
     Dict("rand(...)" => [rand, rand],

--- a/test/locationscale.jl
+++ b/test/locationscale.jl
@@ -4,7 +4,8 @@ using Random, Test
 
 
 
-function test_location_scale_normal(μ::Float64,σ::Float64,μD::Float64,σD::Float64)
+function test_location_scale_normal(μ::Float64,σ::Float64,μD::Float64,σD::Float64,
+                                    rng::Union{AbstractRNG, Missing} = missing)
     ρ = Normal(μD,σD)
     d = LocationScale(μ,σ,ρ)
     dref = Normal(μ+σ*μD,σ*σD)
@@ -67,7 +68,11 @@ function test_location_scale_normal(μ::Float64,σ::Float64,μD::Float64,σD::Fl
     @test invlogccdf(d,log(0.8)) ≈ invlogccdf(dref,log(0.8))
 
     r = Array{Float64}(undef, 100000)
-    rand!(d,r)
+    if ismissing(rng)
+        rand!(d,r)
+    else
+        rand!(rng,d,r)
+    end
     @test mean(r) ≈ mean(dref) atol=0.01
     @test std(r) ≈ std(dref) atol=0.01
     @test cf(d, -0.1) ≈ cf(dref,-0.1)
@@ -75,7 +80,12 @@ function test_location_scale_normal(μ::Float64,σ::Float64,μD::Float64,σD::Fl
 
 end
 
-println("\ttesting LocationScale")
-test_location_scale_normal(0.3,0.2,0.1,0.2)
-test_location_scale_normal(-0.3,0.1,-0.1,0.3)
-test_location_scale_normal(1.3,0.4,-0.1,0.5)
+@testset "Testing LocationScale" begin
+    rng = MersenneTwister()
+    test_location_scale_normal(0.3,0.2,0.1,0.2)
+    test_location_scale_normal(-0.3,0.1,-0.1,0.3)
+    test_location_scale_normal(1.3,0.4,-0.1,0.5)
+    test_location_scale_normal(0.3,0.2,0.1,0.2,rng)
+    test_location_scale_normal(-0.3,0.1,-0.1,0.3,rng)
+    test_location_scale_normal(1.3,0.4,-0.1,0.5,rng)
+end

--- a/test/locationscale.jl
+++ b/test/locationscale.jl
@@ -81,7 +81,7 @@ function test_location_scale_normal(μ::Float64,σ::Float64,μD::Float64,σD::Fl
 end
 
 @testset "Testing LocationScale" begin
-    rng = MersenneTwister()
+    rng = MersenneTwister(123)
     test_location_scale_normal(0.3,0.2,0.1,0.2)
     test_location_scale_normal(-0.3,0.1,-0.1,0.3)
     test_location_scale_normal(1.3,0.4,-0.1,0.5)

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -15,59 +15,98 @@ rng = MersenneTwister(123)
     Dict("rand(...)" => [rand, rand],
          "rand(rng, ...)" => [dist -> rand(rng, dist), (dist, n) -> rand(rng, dist, n)])
 
-for d in [W,IW]
-    local d
-    @test size(d) == size(func[1](d))
-    @test length(d) == length(func[1](d))
-    @test typeof(d)(params(d)...) == d
-    @test partype(d) == Float64
+    for d in [W,IW]
+        local d
+        @test size(d) == size(func[1](d))
+        @test length(d) == length(func[1](d))
+        @test typeof(d)(params(d)...) == d
+        @test partype(d) == Float64
+    end
+
+    @test partype(Wishart(7, Matrix{Float32}(I, 2, 2))) == Float32
+    @test partype(InverseWishart(7, Matrix{Float32}(I, 2, 2))) == Float32
+
+    @test isapprox(mean(func[2](W,100000)) , mean(W) , atol=0.1)
+    @test isapprox(mean(func[2](IW,100000)), mean(IW), atol=0.1)
+
+    v = 3.0
+
+    @test isapprox(pdf(Wishart(v,S), S)         , 0.04507168, atol=1e-8)
+    @test isapprox(pdf(Wishart(v,S), inv(S))    , 0.01327698, atol=1e-8)
+    @test isapprox(pdf(Wishart(v,inv(S)),S)     , 0.0148086 , atol=1e-8)
+    @test isapprox(pdf(Wishart(v,inv(S)),inv(S)), 0.01901462, atol=1e-8)
+
+    @test isapprox(pdf(Wishart(v,S), [S, S])               , [0.04507168, 0.04507168], atol=1e-6)
+    @test isapprox(pdf(Wishart(v,S), [inv(S), inv(S)])     , [0.01327698, 0.01327698], atol=1e-6)
+    @test isapprox(pdf(Wishart(v,inv(S)), [S, S])          , [0.0148086, 0.0148086]  , atol=1e-6)
+    @test isapprox(pdf(Wishart(v,inv(S)), [inv(S), inv(S)]), [0.01901462, 0.01901462], atol=1e-6)
+
+    @test logpdf(Wishart(v,S), S)           ≈ log.(pdf(Wishart(v,S), S))
+    @test logpdf(Wishart(v,S), inv(S))      ≈ log.(pdf(Wishart(v,S), inv(S)))
+    @test logpdf(Wishart(v,inv(S)), S)      ≈ log.(pdf(Wishart(v,inv(S)), S))
+    @test logpdf(Wishart(v,inv(S)), inv(S)) ≈ log.(pdf(Wishart(v,inv(S)), inv(S)))
+
+    @test logpdf(Wishart(v,S), [S, S])                ≈ log.(pdf(Wishart(v,S), [S, S]))
+    @test logpdf(Wishart(v,S), [inv(S), inv(S)])      ≈ log.(pdf(Wishart(v,S), [inv(S), inv(S)]))
+    @test logpdf(Wishart(v,inv(S)), [S, S])           ≈ log.(pdf(Wishart(v,inv(S)), [S, S]))
+    @test logpdf(Wishart(v,inv(S)), [inv(S), inv(S)]) ≈ log.(pdf(Wishart(v,inv(S)), [inv(S), inv(S)]))
+
+    @test isapprox(pdf(InverseWishart(v,S), S)         , 0.04507168 , atol=1e-8)
+    @test isapprox(pdf(InverseWishart(v,S), inv(S))    , 0.006247377, atol=1e-8)
+    @test isapprox(pdf(InverseWishart(v,inv(S)),S)     , 0.03147137 , atol=1e-8)
+    @test isapprox(pdf(InverseWishart(v,inv(S)),inv(S)), 0.01901462 , atol=1e-8)
+
+    @test isapprox(pdf(InverseWishart(v,S), [S, S])               , [0.04507168,  0.04507168] , atol=1e-6)
+    @test isapprox(pdf(InverseWishart(v,S), [inv(S), inv(S)])     , [0.006247377, 0.006247377], atol=1e-6)
+    @test isapprox(pdf(InverseWishart(v,inv(S)), [S, S])          , [0.03147137,  0.03147137] , atol=1e-6)
+    @test isapprox(pdf(InverseWishart(v,inv(S)), [inv(S), inv(S)]), [0.01901462,  0.01901462] , atol=1e-6)
+
+    @test logpdf(InverseWishart(v,S), S)           ≈ log(pdf(InverseWishart(v,S), S))
+    @test logpdf(InverseWishart(v,S), inv(S))      ≈ log(pdf(InverseWishart(v,S), inv(S)))
+    @test logpdf(InverseWishart(v,inv(S)), S)      ≈ log(pdf(InverseWishart(v,inv(S)), S))
+    @test logpdf(InverseWishart(v,inv(S)), inv(S)) ≈ log(pdf(InverseWishart(v,inv(S)), inv(S)))
+
+    @test logpdf(InverseWishart(v,S), [S, S])                ≈ log.(pdf(InverseWishart(v,S), [S, S]))
+    @test logpdf(InverseWishart(v,S), [inv(S), inv(S)])      ≈ log.(pdf(InverseWishart(v,S), [inv(S), inv(S)]))
+    @test logpdf(InverseWishart(v,inv(S)), [S, S])           ≈ log.(pdf(InverseWishart(v,inv(S)), [S, S]))
+    @test logpdf(InverseWishart(v,inv(S)), [inv(S), inv(S)]) ≈ log.(pdf(InverseWishart(v,inv(S)), [inv(S), inv(S)]))
 end
 
-@test partype(Wishart(7, Matrix{Float32}(I, 2, 2))) == Float32
-@test partype(InverseWishart(7, Matrix{Float32}(I, 2, 2))) == Float32
+@testset "Testing matrix-variates with $key" for (key, func) in
+    Dict("rand!(...; allocate=false)" => [(dist, X) -> rand!(dist, X; allocate = false), rand!],
+         "rand!(rng, ...; allocate=false)" => [(dist, X) -> rand!(rng, dist, X; allocate = false), (dist, X) -> rand!(rng, dist, X)])
 
-@test isapprox(mean(func[2](W,100000)) , mean(W) , atol=0.1)
-@test isapprox(mean(func[2](IW,100000)), mean(IW), atol=0.1)
+    for d in [W,IW]
+        local d
+        local m = Matrix{Float64}(undef, size(d))
+        @test size(d) == size(func[2](d, m))
+        @test length(d) == length(func[2](d, m))
+        @test typeof(d)(params(d)...) == d
+        @test partype(d) == Float64
+    end
 
-v = 3.0
+    m = [Matrix{partype(W)}(undef, size(W)) for _ in Base.OneTo(100000)]
 
-@test isapprox(pdf(Wishart(v,S), S)         , 0.04507168, atol=1e-8)
-@test isapprox(pdf(Wishart(v,S), inv(S))    , 0.01327698, atol=1e-8)
-@test isapprox(pdf(Wishart(v,inv(S)),S)     , 0.0148086 , atol=1e-8)
-@test isapprox(pdf(Wishart(v,inv(S)),inv(S)), 0.01901462, atol=1e-8)
+    @test isapprox(mean(func[1](W,m)) , mean(W) , atol=0.1)
+    @test isapprox(mean(func[1](IW,m)), mean(IW), atol=0.1)
 
-@test isapprox(pdf(Wishart(v,S), [S, S])               , [0.04507168, 0.04507168], atol=1e-6)
-@test isapprox(pdf(Wishart(v,S), [inv(S), inv(S)])     , [0.01327698, 0.01327698], atol=1e-6)
-@test isapprox(pdf(Wishart(v,inv(S)), [S, S])          , [0.0148086, 0.0148086]  , atol=1e-6)
-@test isapprox(pdf(Wishart(v,inv(S)), [inv(S), inv(S)]), [0.01901462, 0.01901462], atol=1e-6)
+    m3 = Array{partype(W), 3}(undef, size(W)..., 100000)
 
-@test logpdf(Wishart(v,S), S)           ≈ log.(pdf(Wishart(v,S), S))
-@test logpdf(Wishart(v,S), inv(S))      ≈ log.(pdf(Wishart(v,S), inv(S)))
-@test logpdf(Wishart(v,inv(S)), S)      ≈ log.(pdf(Wishart(v,inv(S)), S))
-@test logpdf(Wishart(v,inv(S)), inv(S)) ≈ log.(pdf(Wishart(v,inv(S)), inv(S)))
-
-@test logpdf(Wishart(v,S), [S, S])                ≈ log.(pdf(Wishart(v,S), [S, S]))
-@test logpdf(Wishart(v,S), [inv(S), inv(S)])      ≈ log.(pdf(Wishart(v,S), [inv(S), inv(S)]))
-@test logpdf(Wishart(v,inv(S)), [S, S])           ≈ log.(pdf(Wishart(v,inv(S)), [S, S]))
-@test logpdf(Wishart(v,inv(S)), [inv(S), inv(S)]) ≈ log.(pdf(Wishart(v,inv(S)), [inv(S), inv(S)]))
-
-@test isapprox(pdf(InverseWishart(v,S), S)         , 0.04507168 , atol=1e-8)
-@test isapprox(pdf(InverseWishart(v,S), inv(S))    , 0.006247377, atol=1e-8)
-@test isapprox(pdf(InverseWishart(v,inv(S)),S)     , 0.03147137 , atol=1e-8)
-@test isapprox(pdf(InverseWishart(v,inv(S)),inv(S)), 0.01901462 , atol=1e-8)
-
-@test isapprox(pdf(InverseWishart(v,S), [S, S])               , [0.04507168,  0.04507168] , atol=1e-6)
-@test isapprox(pdf(InverseWishart(v,S), [inv(S), inv(S)])     , [0.006247377, 0.006247377], atol=1e-6)
-@test isapprox(pdf(InverseWishart(v,inv(S)), [S, S])          , [0.03147137,  0.03147137] , atol=1e-6)
-@test isapprox(pdf(InverseWishart(v,inv(S)), [inv(S), inv(S)]), [0.01901462,  0.01901462] , atol=1e-6)
-
-@test logpdf(InverseWishart(v,S), S)           ≈ log(pdf(InverseWishart(v,S), S))
-@test logpdf(InverseWishart(v,S), inv(S))      ≈ log(pdf(InverseWishart(v,S), inv(S)))
-@test logpdf(InverseWishart(v,inv(S)), S)      ≈ log(pdf(InverseWishart(v,inv(S)), S))
-@test logpdf(InverseWishart(v,inv(S)), inv(S)) ≈ log(pdf(InverseWishart(v,inv(S)), inv(S)))
-
-@test logpdf(InverseWishart(v,S), [S, S])                ≈ log.(pdf(InverseWishart(v,S), [S, S]))
-@test logpdf(InverseWishart(v,S), [inv(S), inv(S)])      ≈ log.(pdf(InverseWishart(v,S), [inv(S), inv(S)]))
-@test logpdf(InverseWishart(v,inv(S)), [S, S])           ≈ log.(pdf(InverseWishart(v,inv(S)), [S, S]))
-@test logpdf(InverseWishart(v,inv(S)), [inv(S), inv(S)]) ≈ log.(pdf(InverseWishart(v,inv(S)), [inv(S), inv(S)]))
+    @test isapprox(mean(func[2](W,m3)) , mean(mean(W)) , atol=0.1)
+    @test isapprox(mean(func[2](IW,m3)), mean(mean(IW)), atol=0.1)
 end
+
+@testset "Testing matrix-variates with $key" for (key, func) in
+    Dict("rand!(...; allocate=true)" => (dist, X) -> rand!(dist, X; allocate = true),
+         "rand!(rng, ...; allocate=true)" => (dist, X) -> rand!(rng, dist, X; allocate = true))
+
+    m = Vector{Matrix{partype(W)}}(undef, 100000)
+
+    @test isapprox(mean(func(W,m)) , mean(W) , atol=0.1)
+    @test isapprox(mean(func(IW,m)), mean(IW), atol=0.1)
+
+end
+
+repeats = 10
+m = Vector{Matrix{partype(W)}}(undef, repeats)
+@test_deprecated rand!(W, m)

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -73,8 +73,8 @@ rng = MersenneTwister(123)
 end
 
 @testset "Testing matrix-variates with $key" for (key, func) in
-    Dict("rand!(...; allocate=false)" => [(dist, X) -> rand!(dist, X; allocate = false), rand!],
-         "rand!(rng, ...; allocate=false)" => [(dist, X) -> rand!(rng, dist, X; allocate = false), (dist, X) -> rand!(rng, dist, X)])
+    Dict("rand!(..., false)" => [(dist, X) -> rand!(dist, X, false), rand!],
+         "rand!(rng, ..., false)" => [(dist, X) -> rand!(rng, dist, X, false), (dist, X) -> rand!(rng, dist, X)])
 
     for d in [W,IW]
         local d
@@ -105,8 +105,8 @@ end
 end
 
 @testset "Testing matrix-variates with $key" for (key, func) in
-    Dict("rand!(...; allocate=true)" => (dist, X) -> rand!(dist, X; allocate = true),
-         "rand!(rng, ...; allocate=true)" => (dist, X) -> rand!(rng, dist, X; allocate = true))
+    Dict("rand!(..., true)" => (dist, X) -> rand!(dist, X, true),
+         "rand!(rng, true)" => (dist, X) -> rand!(rng, dist, X, true))
 
     m = Vector{Matrix{partype(W)}}(undef, 100000)
     x = func(W,m)
@@ -120,4 +120,15 @@ end
 
 repeats = 10
 m = Vector{Matrix{partype(W)}}(undef, repeats)
-@test_deprecated rand!(W, m)
+rand!(W, m)
+@test isassigned(m, 1)
+m1=m[1]
+rand!(W, m)
+@test m1 ≡ m[1]
+rand!(W, m, true)
+@test m1 ≢ m[1]
+m1 = m[1]
+rand!(W, m, false)
+@test m1 ≡ m[1]
+
+

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -79,21 +79,29 @@ end
     for d in [W,IW]
         local d
         local m = Matrix{Float64}(undef, size(d))
-        @test size(d) == size(func[2](d, m))
+        local x = func[2](d, m)
+        @test x ≡ m
+        @test size(d) == size(x)
         @test length(d) == length(func[2](d, m))
         @test typeof(d)(params(d)...) == d
         @test partype(d) == Float64
     end
 
     m = [Matrix{partype(W)}(undef, size(W)) for _ in Base.OneTo(100000)]
-
-    @test isapprox(mean(func[1](W,m)) , mean(W) , atol=0.1)
-    @test isapprox(mean(func[1](IW,m)), mean(IW), atol=0.1)
+    x = func[1](W,m)
+    @test x ≡ m
+    @test isapprox(mean(x) , mean(W) , atol=0.1)
+    x = func[1](IW,m)
+    @test x ≡ m
+    @test isapprox(mean(x), mean(IW), atol=0.1)
 
     m3 = Array{partype(W), 3}(undef, size(W)..., 100000)
-
-    @test isapprox(mean(func[2](W,m3)) , mean(mean(W)) , atol=0.1)
-    @test isapprox(mean(func[2](IW,m3)), mean(mean(IW)), atol=0.1)
+    x = func[2](W,m3)
+    @test x ≡ m3
+    @test isapprox(mean(x) , mean(mean(W)) , atol=0.1)
+    x = func[2](IW,m3)
+    @test x ≡ m3
+    @test isapprox(mean(x), mean(mean(IW)), atol=0.1)
 end
 
 @testset "Testing matrix-variates with $key" for (key, func) in
@@ -101,9 +109,12 @@ end
          "rand!(rng, ...; allocate=true)" => (dist, X) -> rand!(rng, dist, X; allocate = true))
 
     m = Vector{Matrix{partype(W)}}(undef, 100000)
-
-    @test isapprox(mean(func(W,m)) , mean(W) , atol=0.1)
-    @test isapprox(mean(func(IW,m)), mean(IW), atol=0.1)
+    x = func(W,m)
+    @test x ≡ m
+    @test isapprox(mean(x), mean(W) , atol=0.1)
+    x = func(IW,m)
+    @test x ≡ m
+    @test isapprox(mean(x), mean(IW), atol=0.1)
 
 end
 

--- a/test/matrix.jl
+++ b/test/matrix.jl
@@ -9,7 +9,7 @@ S[1, 2] = S[2, 1] = 0.5
 W = Wishart(v,S)
 IW = InverseWishart(v,S)
 
-rng = MersenneTwister()
+rng = MersenneTwister(123)
 
 @testset "Testing matrix-variates with $key" for (key, func) in
     Dict("rand(...)" => [rand, rand],

--- a/test/mixture.jl
+++ b/test/mixture.jl
@@ -162,7 +162,7 @@ end
 
 @testset "Testing Mixtures with $key" for (key, rng) in
     Dict("rand(...)" => missing,
-         "rand(rng, ...)" => MersenneTwister())
+         "rand(rng, ...)" => MersenneTwister(123))
 
 @testset "Testing UnivariateMixture" begin
 g_u = MixtureModel(Normal, [(0.0, 1.0), (2.0, 1.0), (-4.0, 1.5)], [0.2, 0.5, 0.3])

--- a/test/mixture.jl
+++ b/test/mixture.jl
@@ -1,13 +1,18 @@
-using Distributions
+using Distributions, Random
 using Test
 
 
 # Core testing procedure
 
-function test_mixture(g::UnivariateMixture, n::Int, ns::Int)
+function test_mixture(g::UnivariateMixture, n::Int, ns::Int,
+                      rng::Union{AbstractRNG, Missing} = missing)
     X = zeros(n)
     for i = 1:n
-        X[i] = rand(g)
+        if ismissing(rng)
+            X[i] = rand(g)
+        else
+            X[i] = rand(rng, g)
+        end
     end
 
     K = ncomponents(g)
@@ -63,16 +68,25 @@ function test_mixture(g::UnivariateMixture, n::Int, ns::Int)
     @test componentwise_logpdf(g, X) ≈ LP0
 
     # sampling
-    Xs = rand(g, ns)
+    if ismissing(rng)
+        Xs = rand(g, ns)
+    else
+        Xs = rand(rng, g, ns)
+    end
     @test isa(Xs, Vector{Float64})
     @test length(Xs) == ns
     @test isapprox(mean(Xs), mean(g), atol=0.01)
 end
 
-function test_mixture(g::MultivariateMixture, n::Int, ns::Int)
+function test_mixture(g::MultivariateMixture, n::Int, ns::Int,
+                      rng::Union{AbstractRNG, Missing} = missing)
     X = zeros(length(g), n)
     for i = 1:n
-        X[:,i] = rand(g)
+        if ismissing(rng)
+            X[:, i] = rand(g)
+        else
+            X[:, i] = rand(rng, g)
+        end
     end
 
     K = ncomponents(g)
@@ -119,7 +133,11 @@ function test_mixture(g::MultivariateMixture, n::Int, ns::Int)
     @test componentwise_logpdf(g, X) ≈ LP0
 
     # sampling
-    Xs = rand(g, ns)
+    if ismissing(rng)
+        Xs = rand(g, ns)
+    else
+        Xs = rand(rng, g, ns)
+    end
     @test isa(Xs, Matrix{Float64})
     @test size(Xs) == (length(g), ns)
     @test isapprox(vec(mean(Xs, dims=2)), mean(g), atol=0.1)
@@ -142,12 +160,15 @@ end
 
 # Tests
 
-println("    testing UnivariateMixture")
+@testset "Testing Mixtures with $key" for (key, rng) in
+    Dict("rand(...)" => missing,
+         "rand(rng, ...)" => MersenneTwister())
 
+@testset "Testing UnivariateMixture" begin
 g_u = MixtureModel(Normal, [(0.0, 1.0), (2.0, 1.0), (-4.0, 1.5)], [0.2, 0.5, 0.3])
 @test isa(g_u, MixtureModel{Univariate, Continuous, Normal})
 @test ncomponents(g_u) == 3
-test_mixture(g_u, 1000, 10^6)
+test_mixture(g_u, 1000, 10^6, rng)
 test_params(g_u)
 @test minimum(g_u) == -Inf
 @test maximum(g_u) == Inf
@@ -163,13 +184,14 @@ g_u = MixtureModel([TriangularDist(-1,2,0),TriangularDist(-.5,3,1),TriangularDis
 g_u = UnivariateGMM([0.0, 2.0, -4.0], [1.0, 1.2, 1.5], Categorical([0.2, 0.5, 0.3]))
 @test isa(g_u, UnivariateGMM)
 @test ncomponents(g_u) == 3
-test_mixture(g_u, 1000, 10^6)
+test_mixture(g_u, 1000, 10^6, rng)
 test_params(g_u)
 @test minimum(g_u) == -Inf
 @test maximum(g_u) == Inf
 @test extrema(g_u) == (-Inf, Inf)
+end
 
-println("    testing MultivariateMixture")
+@testset "Testing MultivariatevariateMixture" begin
 g_m = MixtureModel(
     IsoNormal[ MvNormal([0.0, 0.0], 1.0),
                MvNormal([0.2, 1.0], 1.0),
@@ -179,17 +201,19 @@ g_m = MixtureModel(
 @test length(components(g_m)) == 3
 @test length(g_m) == 2
 @test insupport(g_m, [0.0, 0.0]) == true
-test_mixture(g_m, 1000, 10^6)
+test_mixture(g_m, 1000, 10^6, rng)
 test_params(g_m)
 
-const u1 =  Uniform()
-const u2 =  Uniform(1.0, 2.0)
-const utot =Uniform(0.0, 2.0)
+u1 =  Uniform()
+u2 =  Uniform(1.0, 2.0)
+utot =Uniform(0.0, 2.0)
  
 # mixture supposed to be a uniform on [0.0,2.0]
-const unif_mixt =  MixtureModel([u1,u2])
+unif_mixt =  MixtureModel([u1,u2])
 @test var(utot) ≈  var(unif_mixt)
 @test mean(utot) ≈ mean(unif_mixt)
 for x in -1.0:0.5:2.5
     @test cdf(utot,x) ≈ cdf(utot,x)
+end
+end
 end

--- a/test/multinomial.jl
+++ b/test/multinomial.jl
@@ -7,7 +7,7 @@ using Test
 p = [0.2, 0.5, 0.3]
 nt = 10
 d = Multinomial(nt, p)
-rng = MersenneTwister()
+rng = MersenneTwister(123)
 
 @testset "Testing Multinomial with $key" for (key, func) in
     Dict("rand(...)" => [rand, rand],

--- a/test/multinomial.jl
+++ b/test/multinomial.jl
@@ -133,8 +133,8 @@ d0 = Multinomial(0, p)
 end
 
 @testset "Testing Multinomial with $key" for (key, func) in
-    Dict("rand!(...; allocate = true)" => (dist, X) -> rand!(dist, X),
-         "rand!(rng, ...; allocate = true)" => (dist, X) -> rand!(rng, dist, X))
+    Dict("rand!(...)" => (dist, X) -> rand!(dist, X),
+         "rand!(rng, ...)" => (dist, X) -> rand!(rng, dist, X))
     # random sampling
     X = Matrix{Int}(undef, length(p), 100)
     x = func(d, X)
@@ -151,8 +151,8 @@ end
 end
 
 @testset "Testing Multinomial with $key" for (key, func) in
-    Dict("rand!(...; allocate = true)" => (dist, X) -> rand!(dist, X; allocate = true),
-         "rand!(rng, ...; allocate = true)" => (dist, X) -> rand!(rng, dist, X; allocate = true))
+    Dict("rand!(..., true)" => (dist, X) -> rand!(dist, X, true),
+         "rand!(rng, ..., true)" => (dist, X) -> rand!(rng, dist, X, true))
     # random sampling
     X = Vector{Vector{Int}}(undef, 100)
     x = func(d, X)
@@ -162,8 +162,8 @@ end
 end
 
 @testset "Testing Multinomial with $key" for (key, func) in
-    Dict("rand!(...; allocate = false)" => (dist, X) -> rand!(dist, X),
-         "rand!(rng, ...; allocate = false)" => (dist, X) -> rand!(rng, dist, X))
+    Dict("rand!(..., false)" => (dist, X) -> rand!(dist, X, false),
+         "rand!(rng, ..., false)" => (dist, X) -> rand!(rng, dist, X, false))
     # random sampling
     X = [Vector{Int}(undef, length(p)) for _ in Base.OneTo(100)]
     x1 = X[1]
@@ -172,3 +172,22 @@ end
     @test all(sum.(x) .== nt)
     @test all(insupport(d, a) for a in x)
 end
+
+repeats = 10
+m = Vector{Vector{partype(d)}}(undef, repeats)
+rand!(d, m)
+@test isassigned(m, 1)
+m1=m[1]
+rand!(d, m)
+@test m1 ≡ m[1]
+rand!(d, m, true)
+@test m1 ≢ m[1]
+m1 = m[1]
+rand!(d, m, false)
+@test m1 ≡ m[1]
+
+p = [0.2, 0.4, 0.3, 0.1]
+nt = 10
+d = Multinomial(nt, p)
+@test_throws DimensionMismatch rand!(d, m, false)
+@test_nowarn rand!(d, m)

--- a/test/mvlognormal.jl
+++ b/test/mvlognormal.jl
@@ -113,7 +113,7 @@ C = [0.4 -0.2 -0.1; -0.2 0.5 -0.1; -0.1 -0.1 0.6]
 
 @testset "Testing MvLogNormal with $key" for (key, rng) in
     Dict("rand(...)" => missing,
-         "rand(rng, ...)" => MersenneTwister())
+         "rand(rng, ...)" => MersenneTwister(123))
     
     @testset "Testing MvLogNormal with $key for $(typeof(g)) with $(Distributions.distrname(g.normal))" for (g, μ, Σ) in [
         (MvLogNormal(mu,PDMats.PDMat(C)), mu, C),

--- a/test/mvlognormal.jl
+++ b/test/mvlognormal.jl
@@ -7,7 +7,8 @@ using LinearAlgebra, Random, Test
 
 ####### Core testing procedure
 
-function test_mvlognormal(g::MvLogNormal, n_tsamples::Int=10^6)
+function test_mvlognormal(g::MvLogNormal, n_tsamples::Int=10^6,
+                          rng::Union{AbstractRNG, Missing} = missing)
     d = length(g)
     mn = mean(g)
     md = median(g)
@@ -39,7 +40,11 @@ function test_mvlognormal(g::MvLogNormal, n_tsamples::Int=10^6)
     @test !insupport(g,-ones(d))
 
     # sampling
-    X = rand(g, n_tsamples)
+    if ismissing(rng)
+        X = rand(g, n_tsamples)
+    else
+        X = rand(rng, g, n_tsamples)
+    end        
     emp_mn = vec(mean(X, dims=2))
     emp_md = vec(median(X, dims=2))
     Z = X .- emp_mn
@@ -86,7 +91,7 @@ function test_mvlognormal(g::MvLogNormal, n_tsamples::Int=10^6)
 end
 
 ####### Validate results for a single-dimension MvLogNormal by comparing with univariate LogNormal
-println("    comparing results from MvLogNormal with univariate LogNormal")
+@testset "Comparing results from MvLogNormal with univariate LogNormal" begin
 l1 = LogNormal(0.1,0.4)
 l2 = MvLogNormal(0.1*ones(1),0.4)
 @test [mean(l1)]     ≈ mean(l2)
@@ -97,6 +102,8 @@ l2 = MvLogNormal(0.1*ones(1),0.4)
 @test logpdf(l1,5.0) ≈ logpdf(l2,[5.0])
 @test pdf(l1,5.0)    ≈ pdf(l2,[5.0])
 @test (Random.seed!(78393) ; [rand(l1)]) == (Random.seed!(78393) ; rand(l2))
+@test [rand(MersenneTwister(78393), l1)] == rand(MersenneTwister(78393), l2)
+end
 
 ###### General Testing
 
@@ -104,21 +111,24 @@ mu = [0.1, 0.2, 0.3]
 va = [0.16, 0.25, 0.36]
 C = [0.4 -0.2 -0.1; -0.2 0.5 -0.1; -0.1 -0.1 0.6]
 
-for (g, μ, Σ) in [
-    (MvLogNormal(mu,PDMats.PDMat(C)), mu, C),
-    (MvLogNormal(PDMats.PDiagMat(Vector{Float64}(sqrt.(va)))), zeros(3), Matrix(Diagonal(va))), # Julia 0.4 loses type information so Vector{Float64} can be dropped when we don't support 0.4
-    (MvLogNormal(mu, sqrt(0.2)), mu, Matrix(0.2I, 3, 3)),
-    (MvLogNormal(3, sqrt(0.2)), zeros(3), Matrix(0.2I, 3, 3)),
-    (MvLogNormal(mu, Vector{Float64}(sqrt.(va))), mu, Matrix(Diagonal(va))), # Julia 0.4 loses type information so Vector{Float64} can be dropped when we don't support 0.4
-    (MvLogNormal(Vector{Float64}(sqrt.(va))), zeros(3), Matrix(Diagonal(va))), # Julia 0.4 loses type information so Vector{Float64} can be dropped when we don't support 0.4
-    (MvLogNormal(mu, C), mu, C),
-    (MvLogNormal(C), zeros(3), C) ]
-
-    println("    testing $(typeof(g)) with normal distribution $(Distributions.distrname(g.normal))")
-
-    m,s = params(g)
-    @test Vector(m) ≈ μ
-    test_mvlognormal(g, 10^4)
+@testset "Testing MvLogNormal with $key" for (key, rng) in
+    Dict("rand(...)" => missing,
+         "rand(rng, ...)" => MersenneTwister())
+    
+    @testset "Testing MvLogNormal with $key for $(typeof(g)) with $(Distributions.distrname(g.normal))" for (g, μ, Σ) in [
+        (MvLogNormal(mu,PDMats.PDMat(C)), mu, C),
+        (MvLogNormal(PDMats.PDiagMat(sqrt.(va))), zeros(3), Matrix(Diagonal(va))),
+        (MvLogNormal(mu, sqrt(0.2)), mu, Matrix(0.2I, 3, 3)),
+        (MvLogNormal(3, sqrt(0.2)), zeros(3), Matrix(0.2I, 3, 3)),
+        (MvLogNormal(mu, sqrt.(va)), mu, Matrix(Diagonal(va))),
+        (MvLogNormal(sqrt.(va)), zeros(3), Matrix(Diagonal(va))),
+        (MvLogNormal(mu, C), mu, C),
+        (MvLogNormal(C), zeros(3), C) ]
+        
+        m,s = params(g)
+        @test Vector(m) ≈ μ
+        test_mvlognormal(g, 10^4, rng)
+    end
 end
 
 ##### Constructors and conversions

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -99,7 +99,7 @@ J = [4. -2. -1.; -2. 5. -1.; -1. -1. 6.]
 
 @testset "Testing MvNormal with $key" for (key, rng) in
     Dict("rand(...)" => missing,
-         "rand(rng, ...)" => MersenneTwister())
+         "rand(rng, ...)" => MersenneTwister(123))
     
     @testset "Testing MvNormal with $key for $(distrname(g))" for (T, g, μ, Σ) in [
     (IsoNormal, MvNormal(mu, sqrt(2.0)), mu, Matrix(2.0I, 3, 3)),

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -11,7 +11,8 @@ import Distributions: distrname
 
 ####### Core testing procedure
 
-function test_mvnormal(g::AbstractMvNormal, n_tsamples::Int=10^6)
+function test_mvnormal(g::AbstractMvNormal, n_tsamples::Int=10^6,
+                       rng::Union{AbstractRNG, Missing} = missing)
     d = length(g)
     μ = mean(g)
     Σ = cov(g)
@@ -28,12 +29,22 @@ function test_mvnormal(g::AbstractMvNormal, n_tsamples::Int=10^6)
     @test g == typeof(g)(params(g)...)
 
     # test sampling for AbstractMatrix (here, a SubArray):
-    subX = view(rand(d, 2d), :, 1:d)
-    @test isa(rand!(g, subX), SubArray)
-
+    if ismissing(rng)
+        subX = view(rand(d, 2d), :, 1:d)
+        @test isa(rand!(g, subX), SubArray)
+    else
+        subX = view(rand(rng, d, 2d), :, 1:d)
+        @test isa(rand!(rng, g, subX), SubArray)
+    end
+    
     # sampling
-    @test isa(rand(g), Vector{Float64})
-    X = rand(g, n_tsamples)
+    if ismissing(rng)
+        @test isa(rand(g), Vector{Float64})
+        X = rand(g, n_tsamples)
+    else
+        @test isa(rand(rng, g), Vector{Float64})
+        X = rand(rng, g, n_tsamples)
+    end        
     emp_mu = vec(mean(X, dims=2))
     Z = X .- emp_mu
     emp_cov = (Z * Z') * inv(n_tsamples)
@@ -86,7 +97,11 @@ h = [1., 2., 3.]
 dv = [1.2, 3.4, 2.6]
 J = [4. -2. -1.; -2. 5. -1.; -1. -1. 6.]
 
-for (T, g, μ, Σ) in [
+@testset "Testing MvNormal with $key" for (key, rng) in
+    Dict("rand(...)" => missing,
+         "rand(rng, ...)" => MersenneTwister())
+    
+    @testset "Testing MvNormal with $key for $(distrname(g))" for (T, g, μ, Σ) in [
     (IsoNormal, MvNormal(mu, sqrt(2.0)), mu, Matrix(2.0I, 3, 3)),
     (ZeroMeanIsoNormal, MvNormal(3, sqrt(2.0)), zeros(3), Matrix(2.0I, 3, 3)),
     (DiagNormal, MvNormal(mu, sqrt.(va)), mu, Matrix(Diagonal(va))),
@@ -102,13 +117,11 @@ for (T, g, μ, Σ) in [
     (FullNormal, MvNormal(mu, Symmetric(C)), mu, Matrix(Symmetric(C))),
     (DiagNormal, MvNormal(mu, Diagonal(dv)), mu, Matrix(Diagonal(dv))) ]
 
-    println("    testing $(distrname(g))")
-
     @test isa(g, T)
     @test mean(g)   ≈ μ
     @test cov(g)    ≈ Σ
     @test invcov(g) ≈ inv(Σ)
-    test_mvnormal(g, 10^4)
+    test_mvnormal(g, 10^4, rng)
 
     # conversion between mean form and canonical form
     if isa(g, MvNormal)
@@ -125,6 +138,7 @@ for (T, g, μ, Σ) in [
         @test mean(gc) ≈ mean(g)
         @test cov(gc)  ≈ cov(g)
     end
+end
 end
 
 ##### Constructors and conversions
@@ -173,8 +187,7 @@ function _gauss_mle(x::Matrix{Float64}, w::Vector{Float64})
     return mu, C
 end
 
-println("    testing fit_mle")
-
+@testset "Testing fit_mle" begin
 x = randn(3, 200) .+ randn(3) * 2.
 w = rand(200)
 u, C = _gauss_mle(x)
@@ -214,3 +227,4 @@ g = fit_mle(DiagNormal, x, w)
 @test isa(g, DiagNormal)
 @test g.μ      ≈ uw
 @test g.Σ.diag ≈ diag(Cw)
+end

--- a/test/mvtdist.jl
+++ b/test/mvtdist.jl
@@ -44,5 +44,5 @@ d = GenericMvTDist(1, Array{Float32}(mu), PDMat(Array{Float32}(Sigma)))
 
 @test size(rand(MvTDist(1., mu, Sigma))) == (2,)
 @test size(rand(MvTDist(1., mu, Sigma), 10)) == (2,10)
-@test size(rand(MersenneTwister(), MvTDist(1., mu, Sigma))) == (2,)
-@test size(rand(MersenneTwister(), MvTDist(1., mu, Sigma), 10)) == (2,10)
+@test size(rand(MersenneTwister(123), MvTDist(1., mu, Sigma))) == (2,)
+@test size(rand(MersenneTwister(123), MvTDist(1., mu, Sigma), 10)) == (2,10)

--- a/test/mvtdist.jl
+++ b/test/mvtdist.jl
@@ -1,4 +1,4 @@
-using Distributions
+using Distributions, Random
 using Test
 
 import Distributions: GenericMvTDist
@@ -44,3 +44,5 @@ d = GenericMvTDist(1, Array{Float32}(mu), PDMat(Array{Float32}(Sigma)))
 
 @test size(rand(MvTDist(1., mu, Sigma))) == (2,)
 @test size(rand(MvTDist(1., mu, Sigma), 10)) == (2,10)
+@test size(rand(MersenneTwister(), MvTDist(1., mu, Sigma))) == (2,)
+@test size(rand(MersenneTwister(), MvTDist(1., mu, Sigma), 10)) == (2,10)

--- a/test/product.jl
+++ b/test/product.jl
@@ -1,7 +1,7 @@
 using Distributions, Compat.Test, Random, LinearAlgebra
 using Distributions: Product
 
-@testset "product" begin
+@testset "Testing Product distributions" begin
 let
     rng, D = MersenneTwister(123456), 11
 

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -48,11 +48,12 @@ for (S, paramlst) in [
     (BinomialPolySampler, binomparams),
     (BinomialAliasSampler, binomparams) ]
     local S
-
+    rng = MersenneTwister()
     println("    testing $S")
     for pa in paramlst
         n, p = pa
         test_samples(S(n, p), Binomial(n, p), n_tsamples)
+        test_samples(rng, S(n, p), Binomial(n, p), n_tsamples)
     end
 end
 

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -27,7 +27,7 @@ n_tsamples = 10^6
 @test_throws ArgumentError CategoricalDirectSampler(Float64[])
 @test_throws ArgumentError AliasTable(Float64[])
 
-rng = MersenneTwister()
+rng = MersenneTwister(123)
 for S in [CategoricalDirectSampler, AliasTable]
     local S
     println("    testing $S")

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -27,11 +27,13 @@ n_tsamples = 10^6
 @test_throws ArgumentError CategoricalDirectSampler(Float64[])
 @test_throws ArgumentError AliasTable(Float64[])
 
+rng = MersenneTwister()
 for S in [CategoricalDirectSampler, AliasTable]
     local S
     println("    testing $S")
     for p in Any[[1.0], [0.3, 0.7], [0.2, 0.3, 0.4, 0.1]]
         test_samples(S(p), Categorical(p), n_tsamples)
+        test_samples(S(p), Categorical(p), n_tsamples, rng=rng)
     end
 end
 
@@ -48,12 +50,11 @@ for (S, paramlst) in [
     (BinomialPolySampler, binomparams),
     (BinomialAliasSampler, binomparams) ]
     local S
-    rng = MersenneTwister()
     println("    testing $S")
     for pa in paramlst
         n, p = pa
         test_samples(S(n, p), Binomial(n, p), n_tsamples)
-        test_samples(rng, S(n, p), Binomial(n, p), n_tsamples)
+        test_samples(S(n, p), Binomial(n, p), n_tsamples, rng=rng)
     end
 end
 
@@ -68,6 +69,7 @@ for (S, paramlst) in [
     println("    testing $S")
     for μ in paramlst
         test_samples(S(μ), Poisson(μ), n_tsamples)
+        test_samples(S(μ), Poisson(μ), n_tsamples, rng=rng)
     end
 end
 
@@ -78,6 +80,7 @@ println("    testing $S")
 for p in paramlst
     d = PoissonBinomial(p)
     test_samples(S(d), d, n_tsamples)
+    test_samples(S(d), d, n_tsamples, rng=rng)
 end
 
 
@@ -88,6 +91,7 @@ for S in [ExponentialSampler]
     println("    testing $S")
     for scale in [1.0, 2.0, 3.0]
         test_samples(S(scale), Exponential(scale), n_tsamples)
+        test_samples(S(scale), Exponential(scale), n_tsamples, rng=rng)
     end
 end
 
@@ -99,7 +103,8 @@ for S in [GammaGDSampler, GammaMTSampler]
     println("    testing $S")
     for d in [Gamma(1.0, 1.0), Gamma(2.0, 1.0), Gamma(3.0, 1.0),
                Gamma(1.0, 2.0), Gamma(3.0, 2.0), Gamma(100.0, 2.0)]
-        test_samples(S(d), d, n_tsamples)
+               test_samples(S(d), d, n_tsamples)
+               test_samples(S(d), d, n_tsamples, rng=rng)
     end
 end
 
@@ -109,5 +114,6 @@ for S in [GammaGSSampler, GammaIPSampler]
     println("    testing $S")
     for d in [Gamma(0.1,1.0),Gamma(0.9,1.0)]
         test_samples(S(d), d, n_tsamples)
+        test_samples(S(d), d, n_tsamples, rng=rng)
     end
 end

--- a/test/truncnormal.jl
+++ b/test/truncnormal.jl
@@ -1,9 +1,29 @@
 using Test
-using Distributions
+using Distributions, Random
+
+rng = MersenneTwister(123)
 
 @testset "Truncated normal, mean and variance" begin
     d = Distributions.TruncatedNormal(0,1,100,115); @test mean(d) ≈ 100.00999800099926070518490239457545847490332879043
     d = Distributions.TruncatedNormal(0,1,50,70); @test var(d) ≈ 0.00039904318680389954790992722653605933053648912703600
     d = Distributions.TruncatedNormal(-2,3,50,70); @test mean(d) ≈ 50.171943499898757645751683644632860837133138152489
     d = Distributions.TruncatedNormal(-2,3,50,70); @test var(d) ≈ 0.029373438107168350377591231295634273607812172191712
+end
+@testset "Truncated normal $trunc" for trunc in [TruncatedNormal(0, 1, -2, 2),
+                                                 Truncated(Normal(0, 1), -2, 2)]
+    @testset "Truncated normal $trunc with $func" for func in
+        [(r = rand, r! = rand!),
+         (r = ((d, n) -> rand(rng, d, n)), r! = ((d, X) -> rand!(rng, d, X)))]
+        repeats = 1000000
+        
+        @test abs(mean(func.r(trunc, repeats))) < 0.01
+        @test abs(median(func.r(trunc, repeats))) < 0.01
+        @test abs(var(func.r(trunc, repeats)) - var(trunc)) < 0.01
+
+        X = Matrix{Float64}(undef, 1000, 1000)
+        func.r!(trunc, X)
+        @test abs(mean(X)) < 0.01
+        @test abs(median(X)) < 0.01
+        @test abs(var(X) - var(trunc)) < 0.01
+    end
 end

--- a/test/vonmisesfisher.jl
+++ b/test/vonmisesfisher.jl
@@ -96,7 +96,7 @@ n = 1000
 ns = 10^6
 @testset "Testing VonMisesFisher with $key" for (key, rng) in
     Dict("rand(...)" => missing,
-         "rand(rng, ...)" => MersenneTwister())
+         "rand(rng, ...)" => MersenneTwister(123))
 
     @testset "Testing VonMisesFisher with $key at ($p, $κ)" for (p, κ) in [(2, 1.0),
                                                                            (2, 5.0),

--- a/test/vonmisesfisher.jl
+++ b/test/vonmisesfisher.jl
@@ -1,6 +1,6 @@
 # Tests for Von-Mises Fisher distribution
 
-using Distributions
+using Distributions, Random
 using LinearAlgebra, Test
 
 using SpecialFunctions
@@ -9,16 +9,26 @@ vmfCp(p::Int, κ::Float64) = (κ ^ (p/2 - 1)) / ((2π)^(p/2) * besseli(p/2-1, κ
 
 safe_vmfpdf(μ::Vector, κ::Float64, x::Vector) = vmfCp(length(μ), κ) * exp(κ * dot(μ, x))
 
-function gen_vmf_tdata(n::Int, p::Int)
-    X = randn(p, n)
+function gen_vmf_tdata(n::Int, p::Int,
+                       rng::Union{AbstractRNG, Missing} = missing)
+    if ismissing(rng)
+        X = randn(p, n)
+    else
+        X = randn(rng, p, n)
+    end
     for i = 1:n
         X[:,i] = X[:,i] ./ norm(X[:,i])
     end
     return X
 end
 
-function test_vonmisesfisher(p::Int, κ::Float64, n::Int, ns::Int)
-    μ = randn(p)
+function test_vonmisesfisher(p::Int, κ::Float64, n::Int, ns::Int,
+                             rng::Union{AbstractRNG, Missing} = missing)
+    if ismissing(rng)
+        μ = randn(p)
+    else
+        μ = randn(rng, p)
+    end
     μ = μ ./ norm(μ)
 
     d = VonMisesFisher(μ, κ)
@@ -41,7 +51,7 @@ function test_vonmisesfisher(p::Int, κ::Float64, n::Int, ns::Int)
 
     @test isapprox(d.logCκ, log(vmfCp(p, κ)), atol=1.0e-12)
 
-    X = gen_vmf_tdata(n, p)
+    X = gen_vmf_tdata(n, p, rng)
     lp0 = zeros(n)
     for i = 1:n
         xi = X[:,i]
@@ -51,16 +61,28 @@ function test_vonmisesfisher(p::Int, κ::Float64, n::Int, ns::Int)
     @test logpdf(d, X) ≈ lp0
 
     # sampling
-    x = rand(d)
+    if ismissing(rng)
+        x = rand(d)
+    else
+        x = rand(rng, d)
+    end
     @test norm(x) ≈ 1.0
 
-    X = rand(d, n)
+    if ismissing(rng)
+        X = rand(d, n)
+    else
+        X = rand(rng, d, n)
+    end
     for i = 1:n
         @test norm(X[:,i]) ≈ 1.0
     end
 
     # MLE
-    X = rand(d, ns)
+    if ismissing(rng)
+        X = rand(d, ns)
+    else
+        X = rand(rng, d, ns)
+    end
     d_est = fit_mle(VonMisesFisher, X)
     @test isa(d_est, VonMisesFisher)
     @test isapprox(d_est.μ, μ, atol=0.01)
@@ -72,12 +94,15 @@ end
 
 n = 1000
 ns = 10^6
-for (p, κ) in [(2, 1.0),
-               (2, 5.0),
-               (3, 1.0),
-               (3, 5.0),
-               (5, 2.0)]
-    local p
+@testset "Testing VonMisesFisher with $key" for (key, rng) in
+    Dict("rand(...)" => missing,
+         "rand(rng, ...)" => MersenneTwister())
 
-    test_vonmisesfisher(p, κ, n, ns)
+    @testset "Testing VonMisesFisher with $key at ($p, $κ)" for (p, κ) in [(2, 1.0),
+                                                                           (2, 5.0),
+                                                                           (3, 1.0),
+                                                                           (3, 5.0),
+                                                                           (5, 2.0)]
+        test_vonmisesfisher(p, κ, n, ns, rng)
+    end
 end


### PR DESCRIPTION
I need to be able to use per-thread random number generators for a large application I've written, and I discovered that Distributions.jl doesn't support it. This seems to be because of a dependency on Rfunction code, which has been sitting around waiting to be fixed in #138 since 2013. I have fixed my problem here, and generalised it as much as possible so that all distributions now work with an optional first argument of a RNG.

This required refactoring the code slightly so that - although the interface remains identical as far as I can see - the internal API for implementing RNGs for a specific distribution is simpler. Instead of multiple `rand()` and `rand!()` functions that need to be implemented in different situations, just `_rand!(::AbstractRNG, ::Distribution)` needs to be implemented for non-Rfunction-based distributions and then they will be able to do anything (though it's a bit more complicated for non-univariable distributions). For the remaining Rfunction-based distributions (I've fixed Beta, Binomial, Chisq and Gamma distributions and their dependencies, using code in the repository where possible, and otherwise taking from elsewhere),`rand(::Distribution)` needs to be implemented, to allow the same behaviour as before.

Where you need to generate random numbers for one of the remaining Rfunction distributions with a specific RNG, the code will fall back to a quantile-based approach, which is obviously slow, but at least keeps the functionality consistent. I took this approach because many (weird!) distributions use a quantile-based approach anyway.

I'm happy to fiddle with this as desired, but given the 6 years to has taken to not remove Rfunction dependencies so far, if the general idea seems sound I'd rather not wait until all of the remaining distributions have been fixed - they should now be easy to pick off one at a time... the main issue the PR is intended to fix is instead allowing multithreaded random number generation.

Issues to resolve:

- [x] What to do about partially allocated arrays of arrays being allowed as inputs to `rand!()` - currently ~a deprecated keyword argument keeps existing (allocate subarrays) behaviour by default, but can be set either way to remove deprecation.~ by default it looks to see if allocation is necessary and does it if so, but can be set to allocate or not specifically by use of an added boolean argument.
- [x] Do we need to add further tests for new RNGs? Currently they are tested anyway, since calls without specified RNGs use _rand!(GLOBAL_RNG, ...). Done for univariable distributions through extending `test_samples()`. Done
- [x] ~Can we leave the remaining RFunction distributions for now, and fix them later? I don't have code for other distributions, and it's not the purpose of this PR. Once they are all rewritten, it's trivial to remove their support structure by removing the `ContinuousUnivariateRDist <: ContinuousUnivariateDistribution` and `DiscreteUnivariateRDist <: DiscreteUnivariateDistribution` subtypes~ yes
- [x] Fix Product distribution
- [x] Add in tests for truncated normal if they are missing, or fix them if not
- [x] Decide what to do in the short term about RFunction-based distributions and do it...