### PR TITLE
Bernoulli sampler to Bool

### DIFF
--- a/src/univariate/discrete/bernoulli.jl
+++ b/src/univariate/discrete/bernoulli.jl
@@ -104,7 +104,7 @@ cf(d::Bernoulli, t::Real) = failprob(d) + succprob(d) * cis(t)
 
 #### Sampling
 
-rand(rng::AbstractRNG, d::Bernoulli) = round(Int, rand(rng) <= succprob(d))
+rand(rng::AbstractRNG, d::Bernoulli) = rand(rng) <= succprob(d)
 
 #### MLE fitting
 


### PR DESCRIPTION
No need for a dichotomy outcome to use `Int` instead of `Bool`.