### PR TITLE
Add special case for truncating Uniform.

### DIFF
--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -113,3 +113,4 @@ _use_multline_show(d::Truncated) = _use_multline_show(d.untruncated)
 
 include(joinpath("truncated", "normal.jl"))
 include(joinpath("truncated", "exponential.jl"))
+include(joinpath("truncated", "uniform.jl"))

--- a/src/truncated/uniform.jl
+++ b/src/truncated/uniform.jl
@@ -1,0 +1,5 @@
+#####
+##### Shortcut for truncating uniform distributions.
+#####
+
+Truncated(d::Uniform, l::Float64, u::Float64) = Uniform(max(l, d.a), min(u, d.b))

--- a/test/truncate.jl
+++ b/test/truncate.jl
@@ -38,13 +38,14 @@ function verify_and_test_drive(jsonfile, selected, n_tsamples::Int,lower::Int,up
 
         println("    testing Truncated($(ex),$lower,$upper)")
         d = Truncated(eval(Meta.parse(ex)),lower,upper)
-        if dtype != TruncatedNormal
-            @assert isa(dtype, Type) && dtype <: UnivariateDistribution
-            @test isa(d, dtypet)
+        if dtype != Uniform # Uniform is truncated to Uniform
+            if dtype != TruncatedNormal
+                @assert isa(dtype, Type) && dtype <: UnivariateDistribution
+                @test isa(d, dtypet)
+            end
+            # verification and testing
+            verify_and_test(d, dct, n_tsamples)
         end
-
-        # verification and testing
-        verify_and_test(d, dct, n_tsamples)
     end
 end
 

--- a/test/truncated_uniform.jl
+++ b/test/truncated_uniform.jl
@@ -1,0 +1,12 @@
+using Distributions, Test
+
+@testset "truncated uniform" begin
+    # just test equivalence of truncation results
+    u = Uniform(1, 2)
+    @test Truncated(u, -Inf, Inf) == u
+    @test Truncated(u, 0, Inf) == u
+    @test Truncated(u, -Inf, 2.1) == u
+    @test Truncated(u, 1.1, Inf) == Uniform(1.1, 2)
+    @test Truncated(u, 1.1, 2.1) == Uniform(1.1, 2)
+    @test Truncated(u, 1.1, 1.9) == Uniform(1.1, 1.9)
+end


### PR DESCRIPTION
This is implemented by making `Truncated(::Uniform, ...)` return a
`Uniform`.

The advantage is that no other functionality needs to be duplicated.

A minor style infraction is a `T(...)` function not constructing a `T`
object, but I think in this case this is a reasonable compromise.