### PR TITLE
Depend on the Test package even outside of the test target.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,12 +13,12 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [extras]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
 
 [targets]
-test = ["Test", "JSON", "ForwardDiff", "Calculus"]
+test = ["JSON", "ForwardDiff", "Calculus"]


### PR DESCRIPTION
testutils.jl uses `import Test` which makes Test a dependency.

This commit resolves the following warning displayed when `using 
Distributions`:

```
[ Info: Recompiling stale cache file 
~/.julia/compiled/v1.1/Distributions/xILW0.ji for Distributions 
[31c24e10-a181-5473-b8eb-7969acd0382f]
┌ Warning: Package Distributions does not have Test in its dependencies:
│ - If you have Distributions checked out for development and have
│   added Test as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with Distributions
└ Loading Test into Distributions from project dependency, future 
warnings for Distributions are suppressed.
```