### PR TITLE
Remove test-only dependencies from [compat]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,6 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 
 [compat]
-JSON = "0.20"
 PDMats = "0.9"
 QuadGK = "2.0"
 SpecialFunctions = "0.7"


### PR DESCRIPTION
Due to a bug in Registrator, we can't register a new version of Distributions until either the bug is fixed or we remove `[compat]` entries for test-only dependencies. See #868 and https://github.com/JuliaComputing/Registrator.jl/issues/110.