### PR TITLE
Add "Histogram distribution"

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -92,6 +92,7 @@ export
     Geometric,
     Gumbel,
     Hypergeometric,
+    HistogramDist,
     InverseWishart,
     InverseGamma,
     InverseGaussian,

--- a/src/univariate/continuous/histogram.jl
+++ b/src/univariate/continuous/histogram.jl
@@ -63,9 +63,11 @@ HistogramDist{Tp}(B::TB, P) where {Tp,Tb,TB<:AbstractVector{Tb}} =
 HistogramDist{Tp}(B, P) where {Tp} =
 	HistogramDist{Tp,Tp}(B, P)
 
-HistogramDist(B, P::Categorical{Tp}) where {Tp} =
-	HistogramDist{Tp}(B, probs(P))
+HistogramDist(B, P::Categorical) =
+	HistogramDist(B, probs(P))
 HistogramDist(B, P::AbstractVector{Tp}) where {Tp} =
+	HistogramDist(B, float(P))
+HistogramDist(B, P::AbstractVector{Tp}) where {Tp<:AbstractFloat} =
 	HistogramDist{Tp}(B, P)
 
 @distr_support HistogramDist convert(eltype(d), @inbounds d.B[1]) convert(eltype(d), @inbounds d.B[end])
@@ -110,6 +112,7 @@ var(d::HistogramDist) = begin
 	v2 = @inbounds sum(p*abs2(mean(component(d,i)) - m) for (i,p) in enumerate(probs(d)))
 	convert(eltype(d), v1 + v2)
 end
+mode(d::HistogramDist) = @inbounds d.B[argmax(d.P)]
 
 #### Evaluation
 function pdf(d::HistogramDist{Tp}, x::Real) where {Tp}

--- a/src/univariate/continuous/histogram.jl
+++ b/src/univariate/continuous/histogram.jl
@@ -96,6 +96,11 @@ function show(io::IO, d::HistogramDist)
 	print(io, ")")
 end
 
+#### Compare
+==(d1::HistogramDist, d2::HistogramDist) = ((d1.B == d2.B) || all(d1.B .== d2.B)) && ((d1.P == d2.P) || all(d1.P .== d2.P))
+Base.isapprox(d1::HistogramDist, d2::HistogramDist) = ((d1.B ≈ d2.B) || all(d1.B .≈ d2.B)) && ((d1.P ≈ d2.P) || all(d1.P .≈ d2.P))
+Base.hash(d::HistogramDist, h::UInt) = hash(d.P, hash(d.B, h))
+
 #### Statistics
 mean(d::HistogramDist) =
 	@inbounds convert(eltype(d), sum(p*mean(component(d,i)) for (i,p) in enumerate(probs(d))))

--- a/src/univariate/continuous/histogram.jl
+++ b/src/univariate/continuous/histogram.jl
@@ -1,0 +1,144 @@
+"""
+    HistogramDist(B,P)
+
+The continuous distribution formed by sampling uniformly from a histogram with ``n`` bins described by ``n+1`` bin edges ``B`` and ``n`` bin probabilities ``P``. Its probability density function is
+
+```math
+f(x; B, P) = \\frac{P_i}{B_{i+1}-B_i} \\quad\\text{ where } B_i ≤ x < B_{i+1}\\text.
+```
+
+```julia
+HistogramDist(B,P)   # histogram distribution with bins edges B and probabilities P
+
+params(d)            # Get the parameters, i.e. (B,P)
+minimum(d)           # Get the lower bound, i.e. B[1]
+maximum(d)           # Get the upper bound, i.e. B[n]
+probs(d)             # Get the bin probabilities, i.e. P
+ncomponents(d)       # Get the number of bins, i.e. n
+component(d,i)       # Get the ith component, i.e. Uniform(B[i],B[i+1])
+```
+"""
+struct HistogramDist{Tp<:Real,Tb<:Real,TB<:AbstractVector{Tb},TP<:Categorical{Tp}} <: ContinuousUnivariateDistribution
+	# params
+	B :: TB
+	P :: TP
+	# cache
+	_pdf :: Vector{Tp}
+	_cdf :: Vector{Tp}
+	function HistogramDist{Tp,Tb,TB,TP}(B::TB, P::TP) where {Tp<:Real,Tb<:Real,TB<:AbstractVector{Tb},TP<:Categorical{Tp}}
+		ps = probs(P)
+		typeof(axes(ps)) <: Tuple{Base.OneTo} || error("P must have 1-up indexing")
+		typeof(axes(B)) <: Tuple{Base.OneTo} || error("B must have 1-up indexing")
+		n = length(ps)
+		length(B)==n+1 || error("expect one more bin edge than bin probs")
+		ws = Vector{Tp}(undef, n)
+		ws .= view(B,2:n) .- view(B,1:n-1)
+		all(ws .> 0) || error("bin edges must be sorted and distinct")
+		pdf = Vector{Tp}(undef, n)
+		pdf .= ps ./ ws
+		cdf = zeros(Tp, n)
+		cdf[2:end] = cumsum(ps[1:end-1])
+		new(B, P, pdf, cdf)
+	end
+end
+
+#### Constructors
+HistogramDist{Tp,Tb,TB,TP}(B, P) where {Tp,Tb,TB,TP} =
+	HistogramDist{Tp,Tb,TB,TP}(convert(TB, B), convert(TP, P))
+
+HistogramDist{Tp,Tb,TB}(B, P::TP) where {Tp,Tb,TB,TP<:Categorical{Tp}} =
+	HistogramDist{Tp,Tb,TB,TP}(B, P)
+HistogramDist{Tp,Tb,TB}(B, P::TP) where {Tp,Tb,TB,TP<:AbstractVector{Tp}} =
+	HistogramDist{Tp,Tb,TB,Categorical{Tp,TP}}(B, P)
+HistogramDist{Tp,Tb,TB}(B, P) where {Tp,Tb,TB} =
+	HistogramDist{Tp,Tb,TB,Categorical{Tp,Vector{Tp}}}(B, P)
+
+HistogramDist{Tp,Tb}(B::BT, P) where {Tp,Tb,BT<:AbstractVector{Tb}} =
+	HistogramDist{Tp,Tb,BT}(B, P)
+HistogramDist{Tp,Tb}(B, P) where {Tp,Tb} =
+	HistogramDist{Tp,Tb,Vector{Tb}}(B, P)
+
+HistogramDist{Tp}(B::TB, P) where {Tp,Tb,TB<:AbstractVector{Tb}} =
+	HistogramDist{Tp,Tb,TB}(B, P)
+HistogramDist{Tp}(B, P) where {Tp} =
+	HistogramDist{Tp,Tp}(B, P)
+
+HistogramDist(B, P::Categorical{Tp}) where {Tp} =
+	HistogramDist{Tp}(B, P)
+HistogramDist(B, P::AbstractVector{Tp}) where {Tp} =
+	HistogramDist{Tp}(B, P)
+
+@distr_support HistogramDist d.B[1] d.B[end]
+
+#### Conversions
+convert(::Type{TH}, B, P) where {TH<:HistogramDist} = TH(B, P)
+convert(::Type{TH}, d::TH) where {TH<:HistogramDist} = d
+convert(::Type{TH}, d::HistogramDist) where {TH<:HistogramDist} = TH(d.B, d.P)
+function convert(::Type{TH}, h::StatsBase.Histogram{T,1}) where {TH<:HistogramDist,T}
+	h2 = LinearAlgebra.normalize(h)
+	TH(h2.edges[1], h2.weights)
+end
+convert(::Type{H}, d::HistogramDist) where {H<:StatsBase.Histogram} = H(d.B, probs(d), :left, true)
+
+#### Parameters
+params(d::HistogramDist) = (d.B, probs(d.P))
+probs(d::HistogramDist) = probs(d.P)
+ncomponents(d::HistogramDist) = length(probs(d))
+component(d::HistogramDist, i::Integer) = (@boundscheck 1≤i<length(d.B) || throw(BoundsError(i)); @inbounds Uniform(d.B[i], d.B[i+1]))
+components(d::HistogramDist) = [@inbounds component(d,i) for i in 1:ncomponents(d)]
+
+#### show
+show(io::IO, d::HistogramDist) = print("HistogramDist(B=", d.B, ", P=", probs(d), ")")
+
+#### Statistics
+mean(d::HistogramDist) =
+	@inbounds sum(p*mean(component(d,i)) for (i,p) in enumerate(probs(d)))
+var(d::HistogramDist) = begin
+	v1 = @inbounds sum(p*var(component(d,i)) for (i,p) in enumerate(probs(d)))
+	m = mean(d)
+	v2 = @inbounds sum(p*abs2(mean(component(d,i)) - m) for (i,p) in enumerate(probs(d)))
+	v1 + v2
+end
+
+#### Evaluation
+function pdf(d::HistogramDist{Tp}, x::Real) where {Tp}
+	i = searchsortedlast(d.B, x)
+	@inbounds(0 < i < length(d.B) ? d._pdf[i] : zero(Tp)) :: Tp
+end
+function cdf(d::HistogramDist{Tp}, x::Real) where {Tp}
+	i = searchsortedlast(d.B, x)
+	@inbounds(i ≤ 0 ? zero(Tp) : i ≥ length(d.B) ? one(Tp) : (x-d.B[i])*d._pdf[i] + d._cdf[i]) :: Tp
+end
+function quantile(d::HistogramDist, p::Real)
+	i = searchsortedlast(d._cdf, p)
+	(i ≤ 0 || p > 1) && throw(DomainError(p, "not a probability"))
+	@inbounds convert(Float64, d.B[i] + (p - d._cdf[i]) / d._pdf[i])
+end
+mgf(d::HistogramDist, t::Real) =
+	@inbounds sum(p*mgf(component(d,i),t) for (i,p) in enumerate(probs(d)))
+cf(d::HistogramDist, t::Real) =
+	@inbounds sum(p*sf(component(d,i),t) for (i,p) in enumerate(probs(d)))
+
+#### Sampling
+function rand(rng::AbstractRNG, d::HistogramDist)
+    p = rand(rng)
+    i = searchsortedlast(d._cdf, p)
+    @inbounds convert(Float64, d.B[i] + (p - d._cdf[i]) / d._pdf[i])
+end
+
+#### Fitting
+function fit_mle(::Type{TD}, x::AbstractArray{<:Real}, bins::AbstractArray{<:Real}) where {TD<:HistogramDist}
+	n = length(bins) - 1
+	n ≥ 0 || error("require at least one bin edge")
+	issorted(bins) || error("bins must be sorted")
+	counts = zeros(Int, n)
+	for pt in x
+	    i = searchsortedlast(bins, pt)
+	    if 1 ≤ i ≤ n
+	    	@inbounds counts[i] += 1
+	    else
+	    	error("out of bounds: $pt")
+	    end
+	end
+	TD(bins, counts./sum(counts))
+end

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -579,6 +579,7 @@ const continuous_distributions = [
     "generalizedpareto",
     "generalizedextremevalue",
     "gumbel",
+    "histogram",
     "inversegamma",
     "inversegaussian",
     "kolmogorov",


### PR DESCRIPTION
Hello,

I have implemented a "histogram distribution", called `HistogramDist`. That is, its parameters are a vector of bin edges and a distribution over bins, and the distribution is to sample a bin, then sample uniformly from that bin.

Functionally, this is identical to a mixture of uniform distributions, but the implementation of `cdf` for example takes time `log(nbins)`. This is because the mixture components (bins) are known to be disjoint and sorted.

A few considerations I can think of:
- The name. Perhaps `ContinuousNonParametric` is better? People usually refer to fitting histograms to data as "non-parametric density estimation", so this seems suitable.
- It could be made a subtype of `AbstractMixtureModel`. In this case, maybe the name should be `UniformMixtureModel`?
- The type precomputes and stores `O(nbins)` data (fields `_pdf`, `_cdf` and `_aliastable`) for making `rand` and `cdf` fast (`O(1)` and `O(log(nbins))` respectively). Does this fit with the design of the module?

Hope this is useful to you.