### PR TITLE
loosen type restrictions to accept accept variants

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -72,16 +72,10 @@ end
 
 allzeros(x::ZeroVector) = true
 
-function allnonneg(x::Array{T}) where T<:Real
-    for i = 1 : length(x)
-        if !(x[i] >= zero(T))
-            return false
-        end
-    end
-    return true
-end
+allnonneg(xs::AbstractArray{T}) where T<:Real = all(x -> x >= zero(T), xs)
 
-isprobvec(p::Vector{T}) where {T<:Real} = allnonneg(p) && isapprox(sum(p), one(T))
+isprobvec(p::AbstractVector{T}) where {T<:Real} =
+    allnonneg(p) && isapprox(sum(p), one(T))
 
 pnormalize!(v::AbstractVector{<:Real}) = (v ./= sum(v); v)
 
@@ -140,4 +134,3 @@ function trycholesky(a::Matrix{Float64})
         return e
     end
 end
-

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -72,7 +72,7 @@ end
 
 allzeros(x::ZeroVector) = true
 
-allnonneg(xs::AbstractArray{T}) where T<:Real = all(x -> x >= zero(T), xs)
+allnonneg(xs::AbstractArray{<:Real}) = all(x -> x >= 0, xs)
 
 isprobvec(p::AbstractVector{T}) where {T<:Real} =
     allnonneg(p) && isapprox(sum(p), one(T))


### PR DESCRIPTION
Flux tracked arrays do not work with the `isprobvec` and `allnonneg` functions as they are. I changed the type definitions to accept abstract vectors and abstract arrays.