### PR TITLE
Ensure compatibility with SpecialFunctions.jl

### DIFF
--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -1,11 +1,11 @@
 #### Deprecate on 0.6 (to be removed on 0.7)
 
 @Base.deprecate expected_logdet meanlogdet
-if isdefined(SpecialFunctions, :logabsgamma)
-    logabsgamma(x) = (lgamma(x),sign(gamma(x)))
+if !isdefined(SpecialFunctions, :logabsgamma)
+    logabsgamma(x) = SpecialFunctions.lgamma_r(x)
     loggamma(x) = lgamma(x)
 end
-if isdefined(SpecialFunctions, :logabsbeta)
+if !isdefined(SpecialFunctions, :logabsbeta)
     logabsbeta(x, w) = (lbeta(x, w), sign(beta(x, w)))
     logbeta(x, w) = lbeta(x, w)
 end

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -1,6 +1,10 @@
 #### Deprecate on 0.6 (to be removed on 0.7)
 
 @Base.deprecate expected_logdet meanlogdet
+if isdefined(SpecialFunctions, :logabsgamma)
+    logabsgamma(x) = (lgamma(x),sign(gamma(x)))
+    loggamma(x) = lgamma(x)
+end
 
 function probs(d::DiscreteUnivariateDistribution)
     Base.depwarn("probs(d::$(typeof(d))) is deprecated. Please use pdf(d) instead.", :probs)

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -5,6 +5,10 @@ if isdefined(SpecialFunctions, :logabsgamma)
     logabsgamma(x) = (lgamma(x),sign(gamma(x)))
     loggamma(x) = lgamma(x)
 end
+if isdefined(SpecialFunctions, :logabsbeta)
+    logabsbeta(x, w) = (lbeta(x, w), sign(beta(x, w)))
+    logbeta(x, w) = lbeta(x, w)
+end
 
 function probs(d::DiscreteUnivariateDistribution)
     Base.depwarn("probs(d::$(typeof(d))) is deprecated. Please use pdf(d) instead.", :probs)

--- a/src/multivariate/dirichlet.jl
+++ b/src/multivariate/dirichlet.jl
@@ -33,15 +33,15 @@ struct Dirichlet{T<:Real} <: ContinuousMultivariateDistribution
             ai > 0 ||
                 throw(ArgumentError("Dirichlet: alpha must be a positive vector."))
             alpha0 += ai
-            lmnB += lgamma(ai)
+            lmnB += logabsgamma(ai)[1]
         end
-        lmnB -= lgamma(alpha0)
+        lmnB -= logabsgamma(alpha0)[1]
         new{T}(alpha, alpha0, lmnB)
     end
 
     function Dirichlet{T}(d::Integer, alpha::T) where T
         alpha0 = alpha * d
-        new{T}(fill(alpha, d), alpha0, lgamma(alpha) * d - lgamma(alpha0))
+        new{T}(fill(alpha, d), alpha0, logabsgamma(alpha)[1] * d - logabsgamma(alpha0)[1])
     end
 end
 
@@ -325,7 +325,7 @@ function fit_dirichlet!(elogp::Vector{Float64}, α::Vector{Float64};
     α0 = sum(α)
 
     if debug
-        objv = dot(α - 1.0, elogp) + lgamma(α0) - sum(lgamma(α))
+        objv = dot(α - 1.0, elogp) + logabsgamma(α0)[1] - sum(logabsgamma(α)[1])
     end
 
     t = 0
@@ -369,7 +369,7 @@ function fit_dirichlet!(elogp::Vector{Float64}, α::Vector{Float64};
 
         if debug
             prev_objv = objv
-            objv = dot(α - 1.0, elogp) + lgamma(α0) - sum(lgamma(α))
+            objv = dot(α - 1.0, elogp) + logabsgamma(α0)[1] - sum(logabsgamma(α)[1])
             @printf("Iter %4d: objv = %.4e  ch = %.3e  gnorm = %.3e\n",
                 t, objv, objv - prev_objv, gnorm)
         end

--- a/src/multivariate/dirichletmultinomial.jl
+++ b/src/multivariate/dirichletmultinomial.jl
@@ -56,10 +56,10 @@ function insupport(d::DirichletMultinomial, x::AbstractVector{T}) where T<:Real
     return sum(x) == ntrials(d)
 end
 function _logpdf(d::DirichletMultinomial{S}, x::AbstractVector{T}) where {T<:Real, S<:Real}
-    c = lgamma(S(d.n + 1)) + lgamma(d.α0) - lgamma(d.n + d.α0)
+    c = logabsgamma(S(d.n + 1))[1] + logabsgamma(d.α0)[1] - logabsgamma(d.n + d.α0)[1]
     for j in eachindex(x)
         @inbounds xj, αj = x[j], d.α[j]
-        c += lgamma(xj + αj) - lgamma(xj + 1) - lgamma(αj)
+        c += logabsgamma(xj + αj)[1] - logabsgamma(xj + 1)[1] - logabsgamma(αj)[1]
     end
     c
 end

--- a/src/multivariate/multinomial.jl
+++ b/src/multivariate/multinomial.jl
@@ -113,11 +113,11 @@ end
 
 function entropy(d::Multinomial)
     n, p = params(d)
-    s = -lgamma(n+1) + n*entropy(p)
+    s = -logabsgamma(n+1)[1] + n*entropy(p)
     for pr in p
         b = Binomial(n, pr)
         for x in 0:n
-            s += pdf(b, x) * lgamma(x+1)
+            s += pdf(b, x) * logabsgamma(x+1)[1]
         end
     end
     return s
@@ -146,11 +146,11 @@ function _logpdf(d::Multinomial, x::AbstractVector{T}) where T<:Real
     S = eltype(p)
     R = promote_type(T, S)
     insupport(d,x) || return -R(Inf)
-    s = R(lgamma(n + 1))
+    s = R(logabsgamma(n + 1)[1])
     for i = 1:length(p)
         @inbounds xi = x[i]
         @inbounds p_i = p[i]
-        s -= R(lgamma(R(xi) + 1))
+        s -= R(logabsgamma(R(xi) + 1)[1])
         s += xlogy(xi, p_i)
     end
     return s

--- a/src/multivariate/mvtdist.jl
+++ b/src/multivariate/mvtdist.jl
@@ -103,7 +103,7 @@ params(d::GenericMvTDist) = (d.df, d.μ, d.Σ)
 function entropy(d::GenericMvTDist)
     hdf, hdim = 0.5*d.df, 0.5*d.dim
     shdfhdim = hdf+hdim
-    0.5*logdet(d.Σ)+hdim*log(d.df*pi)+lbeta(hdim, hdf)-lgamma(hdim)+shdfhdim*(digamma(shdfhdim)-digamma(hdf))
+    0.5*logdet(d.Σ)+hdim*log(d.df*pi)+lbeta(hdim, hdf)-logabsgamma(hdim)[1]+shdfhdim*(digamma(shdfhdim)-digamma(hdf))
 end
 
 # evaluation (for GenericMvTDist)
@@ -128,7 +128,7 @@ function mvtdist_consts(d::AbstractMvTDist)
     hdf = 0.5 * d.df
     hdim = 0.5 * d.dim
     shdfhdim = hdf + hdim
-    v = lgamma(shdfhdim) - lgamma(hdf) - hdim*log(d.df) - hdim*log(pi) - 0.5*logdet(d.Σ)
+    v = logabsgamma(shdfhdim)[1] - logabsgamma(hdf)[1] - hdim*log(d.df) - hdim*log(pi) - 0.5*logdet(d.Σ)
     return (shdfhdim, v)
 end
 

--- a/src/multivariate/mvtdist.jl
+++ b/src/multivariate/mvtdist.jl
@@ -103,7 +103,7 @@ params(d::GenericMvTDist) = (d.df, d.μ, d.Σ)
 function entropy(d::GenericMvTDist)
     hdf, hdim = 0.5*d.df, 0.5*d.dim
     shdfhdim = hdf+hdim
-    0.5*logdet(d.Σ)+hdim*log(d.df*pi)+lbeta(hdim, hdf)-logabsgamma(hdim)[1]+shdfhdim*(digamma(shdfhdim)-digamma(hdf))
+    0.5*logdet(d.Σ)+hdim*log(d.df*pi)+logabsbeta(hdim, hdf)[1]-logabsgamma(hdim)[1]+shdfhdim*(digamma(shdfhdim)-digamma(hdf))
 end
 
 # evaluation (for GenericMvTDist)

--- a/src/univariate/continuous/beta.jl
+++ b/src/univariate/continuous/beta.jl
@@ -101,7 +101,7 @@ end
 function entropy(d::Beta)
     α, β = params(d)
     s = α + β
-    lbeta(α, β) - (α - 1) * digamma(α) - (β - 1) * digamma(β) +
+    logabsbeta(α, β)[1] - (α - 1) * digamma(α) - (β - 1) * digamma(β) +
         (s - 2) * digamma(s)
 end
 

--- a/src/univariate/continuous/betaprime.jl
+++ b/src/univariate/continuous/betaprime.jl
@@ -90,7 +90,7 @@ function logpdf(d::BetaPrime{T}, x::Real) where T<:Real
     if x < 0
         T(-Inf)
     else
-        (α - 1) * log(x) - (α + β) * log1p(x) - lbeta(α, β)
+        (α - 1) * log(x) - (α + β) * log1p(x) - logabsbeta(α, β)[1]
     end
 end
 

--- a/src/univariate/continuous/chi.jl
+++ b/src/univariate/continuous/chi.jl
@@ -64,7 +64,7 @@ function kurtosis(d::Chi)
 end
 
 entropy(d::Chi{T}) where {T<:Real} = (ν = d.ν;
-    lgamma(ν/2) - T(logtwo)/2 - ((ν - 1)/2) * digamma(ν/2) + ν/2)
+    logabsgamma(ν/2)[1] - T(logtwo)/2 - ((ν - 1)/2) * digamma(ν/2) + ν/2)
 
 function mode(d::Chi)
     d.ν >= 1 || error("Chi distribution has no mode when ν < 1")
@@ -77,7 +77,7 @@ end
 pdf(d::Chi, x::Real) = exp(logpdf(d, x))
 
 logpdf(d::Chi, x::Real) = (ν = d.ν;
-    (1 - ν/2) * logtwo + (ν - 1) * log(x) - x^2/2 - lgamma(ν/2)
+    (1 - ν/2) * logtwo + (ν - 1) * log(x) - x^2/2 - logabsgamma(ν/2)[1]
 )
 
 gradlogpdf(d::Chi{T}, x::Real) where {T<:Real} = x >= 0 ? (d.ν - 1) / x - x : zero(T)

--- a/src/univariate/continuous/chisq.jl
+++ b/src/univariate/continuous/chisq.jl
@@ -64,7 +64,7 @@ end
 
 function entropy(d::Chisq)
     hν = d.ν/2
-    hν + logtwo + lgamma(hν) + (1 - hν) * digamma(hν)
+    hν + logtwo + logabsgamma(hν)[1] + (1 - hν) * digamma(hν)
 end
 
 

--- a/src/univariate/continuous/erlang.jl
+++ b/src/univariate/continuous/erlang.jl
@@ -61,7 +61,7 @@ end
 
 function entropy(d::Erlang)
     (α, θ) = params(d)
-    α + lgamma(α) + (1 - α) * digamma(α) + log(θ)
+    α + logabsgamma(α)[1] + (1 - α) * digamma(α) + log(θ)
 end
 
 mgf(d::Erlang, t::Real) = (1 - t * d.θ)^(-d.α)

--- a/src/univariate/continuous/fdist.jl
+++ b/src/univariate/continuous/fdist.jl
@@ -91,7 +91,7 @@ function entropy(d::FDist)
     hν1 = ν1/2
     hν2 = ν2/2
     hs = (ν1 + ν2)/2
-    return log(ν2 / ν1) + lgamma(hν1) + lgamma(hν2) - lgamma(hs) +
+    return log(ν2 / ν1) + logabsgamma(hν1)[1] + logabsgamma(hν2)[1] - logabsgamma(hs)[1] +
         (1 - hν1) * digamma(hν1) + (-1 - hν2) * digamma(hν2) +
         hs * digamma(hs)
 end

--- a/src/univariate/continuous/gamma.jl
+++ b/src/univariate/continuous/gamma.jl
@@ -73,7 +73,7 @@ end
 
 function entropy(d::Gamma)
     (α, θ) = params(d)
-    α + lgamma(α) + (1 - α) * digamma(α) + log(θ)
+    α + logabsgamma(α)[1] + (1 - α) * digamma(α) + log(θ)
 end
 
 mgf(d::Gamma, t::Real) = (1 - t * d.θ)^(-d.α)

--- a/src/univariate/continuous/inversegamma.jl
+++ b/src/univariate/continuous/inversegamma.jl
@@ -80,7 +80,7 @@ end
 
 function entropy(d::InverseGamma)
     (α, θ) = params(d)
-    α + lgamma(α) - (1 + α) * digamma(α) + log(θ)
+    α + logabsgamma(α)[1] - (1 + α) * digamma(α) + log(θ)
 end
 
 
@@ -90,7 +90,7 @@ pdf(d::InverseGamma, x::Real) = exp(logpdf(d, x))
 
 function logpdf(d::InverseGamma, x::Real)
     (α, θ) = params(d)
-    α * log(θ) - lgamma(α) - (α + 1) * log(x) - θ / x
+    α * log(θ) - logabsgamma(α)[1] - (α + 1) * log(x) - θ / x
 end
 
 cdf(d::InverseGamma, x::Real) = ccdf(d.invd, 1 / x)

--- a/src/univariate/continuous/tdist.jl
+++ b/src/univariate/continuous/tdist.jl
@@ -65,7 +65,7 @@ end
 function entropy(d::TDist)
     h = d.ν/2
     h1 = h + 1//2
-    h1 * (digamma(h1) - digamma(h)) + log(d.ν)/2 + lbeta(h, 1//2)
+    h1 * (digamma(h1) - digamma(h)) + log(d.ν)/2 + logabsbeta(h, 1//2)[1]
 end
 
 

--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -92,9 +92,9 @@ end
 
 function logpdf(d::BetaBinomial{T}, k::Int) where T
     n, α, β = d.n, d.α, d.β
-    logbinom = - log1p(n) - lbeta(k + 1, n - k + 1)
-    lognum   = lbeta(k + α, n - k + β)
-    logdenom = lbeta(α, β)
+    logbinom = - log1p(n) - logabsbeta(k + 1, n - k + 1)[1]
+    lognum   = logabsbeta(k + α, n - k + β)[1]
+    logdenom = logabsbeta(α, β)[1]
     logbinom + lognum - logdenom
 end
 

--- a/src/univariate/discrete/noncentralhypergeometric.jl
+++ b/src/univariate/discrete/noncentralhypergeometric.jl
@@ -62,8 +62,8 @@ convert(::Type{FisherNoncentralHypergeometric{T}}, d::FisherNoncentralHypergeome
 # Properties
 function _P(d::FisherNoncentralHypergeometric, k::Int)
     y = support(d)
-    p = -log(d.ns + 1) .- lbeta.(d.ns + 1 .- y, y .+ 1) .-
-            log(d.nf + 1) .- lbeta.(d.nf - d.n + 1 .+ y, d.n + 1 .- y) .+
+    p = -log(d.ns + 1) .- map(first, logabsbeta.(d.ns + 1 .- y, y .+ 1)) .-
+            log(d.nf + 1) .- map(first, logabsbeta.(d.nf - d.n + 1 .+ y, d.n + 1 .- y)) .+
             xlogy.(y, d.ω) .+ xlogy.(k, y)
     logsumexp(p)
 end
@@ -82,8 +82,8 @@ mode(d::FisherNoncentralHypergeometric) = floor(Int, _mode(d))
 testfd(d::FisherNoncentralHypergeometric) = d.ω^3
 
 logpdf(d::FisherNoncentralHypergeometric, k::Int) =
-    -log(d.ns + 1) - lbeta(d.ns - k + 1, k + 1) -
-    log(d.nf + 1) - lbeta(d.nf - d.n + k + 1, d.n - k + 1) +
+    -log(d.ns + 1) - logabsbeta(d.ns - k + 1, k + 1)[1] -
+    log(d.nf + 1) - logabsbeta(d.nf - d.n + k + 1, d.n - k + 1)[1] +
     xlogy(k, d.ω) - _P(d, 0)
 
 pdf(d::FisherNoncentralHypergeometric, k::Int) = exp(logpdf(d, k))
@@ -126,8 +126,8 @@ function logpdf(d::WalleniusNoncentralHypergeometric, k::Int)
     D = d.ω * (d.ns - k) + (d.nf - d.n + k)
     f(t) = (1 - t^(d.ω / D))^k * (1 - t^(1 / D))^(d.n - k)
     I, _ = quadgk(f, 0, 1)
-    return -log(d.ns + 1) - lbeta(d.ns - k + 1, k + 1) -
-    log(d.nf + 1) - lbeta(d.nf - d.n + k + 1, d.n - k + 1) + log(I)
+    return -log(d.ns + 1) - logabsbeta(d.ns - k + 1, k + 1)[1] -
+    log(d.nf + 1) - logabsbeta(d.nf - d.n + k + 1, d.n - k + 1)[1] + log(I)
 end
 
 pdf(d::WalleniusNoncentralHypergeometric, k::Int) = exp(logpdf(d, k))

--- a/src/univariate/discrete/poisson.jl
+++ b/src/univariate/discrete/poisson.jl
@@ -70,7 +70,7 @@ function entropy(d::Poisson{T}) where T<:Real
         λk = one(T)
         for k = 1:100
             λk *= λ
-            s += λk * lgamma(k + 1) / gamma(k + 1)
+            s += λk * logabsgamma(k + 1)[1] / gamma(k + 1)
         end
         return λ * (1 - log(λ)) + exp(-λ) * s
     else

--- a/test/dirichletmultinomial.jl
+++ b/test/dirichletmultinomial.jl
@@ -5,7 +5,14 @@ using Distributions
 using Test, Random, SpecialFunctions
 
 import SpecialFunctions: factorial
-
+if !isdefined(SpecialFunctions, :logabsgamma)
+    logabsgamma(x) = SpecialFunctions.lgamma_r(x)
+    loggamma(x) = lgamma(x)
+end
+if !isdefined(SpecialFunctions, :logabsbeta)
+    logabsbeta(x, w) = (lbeta(x, w), sign(beta(x, w)))
+    logbeta(x, w) = lbeta(x, w)
+end
 Random.seed!(123)
 
 rng = MersenneTwister(123)

--- a/test/dirichletmultinomial.jl
+++ b/test/dirichletmultinomial.jl
@@ -55,7 +55,7 @@ for x in (2 * ones(5), [1, 2, 3, 4, 0], [3.0, 0.0, 3.0, 0.0, 4.0], [0, 0, 0, 0, 
     @test pdf(d, x) ≈
         factorial(d.n) * gamma(d.α0) / gamma(d.n + d.α0) * prod(gamma.(d.α + x) ./ factorial.(x) ./ gamma.(d.α))
     @test logpdf(d, x) ≈
-        log(factorial(d.n)) + lgamma(d.α0) - lgamma(d.n + d.α0) + sum(lgamma.(d.α + x) - log.(factorial.(x)) - lgamma.(d.α))
+        log(factorial(d.n)) + logabsgamma(d.α0)[1] - logabsgamma(d.n + d.α0)[1] + sum(first, logabsgamma.(d.α + x)) - sum(first, logabsgamma.(d.α)) - sum(log.(factorial.(x)))
 end
 
 # test Sampling


### PR DESCRIPTION
Recently following a discussion in [issue #154](https://github.com/JuliaMath/SpecialFunctions.jl/issues/154) a change was made in [PR #156](https://github.com/JuliaMath/SpecialFunctions.jl/pull/156) to rename `lgamma` function into more descriptive `loggamma` and `logabsgamma`. 
This PR ensures compatibility with the latest `SpecialFunctions.jl` functions . Also added a fallback in `deprecations.jl` file to ensure that it works even now, until SpecialFunctions is upgraded.
cc @simonbyrne 