### PR TITLE
Fix #894 Normal distribution and its type parameter

### DIFF
--- a/src/univariate/continuous/normal.jl
+++ b/src/univariate/continuous/normal.jl
@@ -61,6 +61,8 @@ params(d::Normal) = (d.μ, d.σ)
 location(d::Normal) = d.μ
 scale(d::Normal) = d.σ
 
+eltype(::Normal{T}) where {T} = T
+
 #### Statistics
 
 mean(d::Normal) = d.μ

--- a/src/univariate/continuous/normal.jl
+++ b/src/univariate/continuous/normal.jl
@@ -87,7 +87,7 @@ cf(d::Normal, t::Real) = exp(im * t * d.μ - d.σ^2/2 * t^2)
 
 #### Sampling
 
-rand(rng::AbstractRNG, d::Normal) = d.μ + d.σ * randn(rng)
+rand(rng::AbstractRNG, d::Normal{T}) where {T} = d.μ + d.σ * randn(rng, T)
 
 
 #### Fitting

--- a/test/continuous.jl
+++ b/test/continuous.jl
@@ -26,6 +26,21 @@ using ForwardDiff
 @test derivative(t -> logpdf(Normal(1.0, 0.15), t), 2.5) ≈ -66.66666666666667
 @test derivative(t -> pdf(Normal(t, 1.0), 0.0), 0.0) == 0.0
 
+# issue #894:
+@testset "Normal distribution with non-standard (ie not Float64) parameter types" begin
+    n32 = Normal(1f0, 0.1f0)
+    n64 = Normal(1., 0.1)
+    nbig = Normal(big(pi), big(ℯ))
+
+    @test eltype(n32) === Float32
+    @test eltype(rand(n32)) === Float32
+    @test eltype(rand(n32, 4)) === Float32
+
+    @test eltype(n64) === Float64
+    @test eltype(rand(n64)) === Float64
+    @test eltype(rand(n64, 4)) === Float64
+end
+
 # Test for numerical problems
 @test pdf(Logistic(6,0.01),-2) == 0
 


### PR DESCRIPTION
I didn't see any similar tests so I'm not sure if this needs any tests. I don't imagine that fixing the `eltype` would be particularly breaking (although it is changing the output type of `rand(n::Normal, dims)`).

However, the fix for the single `rand` return type could change an incorrect return type into an error, if the `eltype` of the Normal dist. doesn't support `randn`. I noticed this when using DoubleFloats (prior to v0.8.1 of DoubleFloats.jl).

```julia
# Before PR
julia> n = Normal(Double64(1), Double64(0.1))
Normal{DoubleFloat{Float64}}(μ=1.0, σ=0.1)

julia> x = rand(n)
0.9972028245261662

julia> typeof(x)
DoubleFloat{Float64}

julia> n32 = Normal(1f0, 0.1f0)
Normal{Float32}(μ=r1.0f0, σ=0.1f0)

julia> x32 = rand(n32)
0.9335312783262796

julia> typeof(x32)
Float64

# After PR (with DoubleFloats.jl v0.7.24 as an example of a type that doesn't support `randn`)
julia> n = Normal(Double64(1), Double64(0.1))
Normal{DoubleFloat{Float64}}(μ=1.0, σ=0.1)

julia> x = rand(n)
ERROR: MethodError: no method matching randn(::Random.MersenneTwister, ::Type{DoubleFloat{Float64}})

julia> n32 = Normal(1f0, 0.1f0)
Normal{Float32}(μ=1.0f0, σ=0.1f0)

julia> x32 = rand(n32)
0.9599364f0

julia> typeof(x32)
Float32
```

So the previous behavior was both inconsistent, and not accurate in the case of the DoubleFloats. The return type was correct due to the type promotion, but the random number wasn't being generated with the precision of the DoubleFloat. `randn` support for DoubleFloats was added in v0.8.1.