### PR TITLE
RFC: Allow `DiscreteNonParametric` to have non-`Real` support

### DIFF
--- a/src/samplers/discretenonparametric.jl
+++ b/src/samplers/discretenonparametric.jl
@@ -4,19 +4,19 @@
 Data structure for efficiently sampling from an arbitrary probability mass
 function defined by support `xs` and probabilities `ps`.
 """
-struct DiscreteNonParametricSampler{T<:Real, S<:AbstractVector{T}, A<:AliasTable} <: Sampleable{Univariate,Discrete}
+struct DiscreteNonParametricSampler{T, S<:AbstractVector{T}, A<:AliasTable} <: Sampleable{Univariate,Discrete}
     support::S
     aliastable::A
 
     function DiscreteNonParametricSampler{T,S}(support::S, probs::AbstractVector{<:Real}
-    ) where {T<:Real,S<:AbstractVector{T}}
+    ) where {T,S<:AbstractVector{T}}
         aliastable = AliasTable(probs)
         new{T,S,typeof(aliastable)}(support, aliastable)
     end
 end
 
 DiscreteNonParametricSampler(support::S, probs::AbstractVector{<:Real}
-    ) where {T<:Real,S<:AbstractVector{T}} =
+    ) where {T,S<:AbstractVector{T}} =
     DiscreteNonParametricSampler{T,S}(support, probs)
 
 rand(rng::AbstractRNG, s::DiscreteNonParametricSampler) =

--- a/src/univariate/discrete/discretenonparametric.jl
+++ b/src/univariate/discrete/discretenonparametric.jl
@@ -2,7 +2,7 @@
     DiscreteNonParametric(xs, ps)
 
 A *Discrete nonparametric distribution* explicitly defines an arbitrary
-probability mass function in terms of a list of real support values and their
+probability mass function in terms of a list of support values and their
 corresponding probabilities
 
 ```julia
@@ -17,16 +17,16 @@ External links
 
 * [Probability mass function on Wikipedia](http://en.wikipedia.org/wiki/Probability_mass_function)
 """
-struct DiscreteNonParametric{T<:Real,P<:Real,Ts<:AbstractVector{T},Ps<:AbstractVector{P}} <: DiscreteUnivariateDistribution
+struct DiscreteNonParametric{T,P<:Real,Ts<:AbstractVector{T},Ps<:AbstractVector{P}} <: DiscreteUnivariateDistribution
     support::Ts
     p::Ps
 
     DiscreteNonParametric{T,P,Ts,Ps}(vs::Ts, ps::Ps, ::NoArgCheck) where {
-        T<:Real,P<:Real,Ts<:AbstractVector{T},Ps<:AbstractVector{P}} =
+        T,P<:Real,Ts<:AbstractVector{T},Ps<:AbstractVector{P}} =
         new{T,P,Ts,Ps}(vs, ps)
 
     function DiscreteNonParametric{T,P,Ts,Ps}(vs::Ts, ps::Ps) where {
-        T<:Real,P<:Real,Ts<:AbstractVector{T},Ps<:AbstractVector{P}}
+        T,P<:Real,Ts<:AbstractVector{T},Ps<:AbstractVector{P}}
         @check_args(DiscreteNonParametric, length(vs) == length(ps))
         @check_args(DiscreteNonParametric, isprobvec(ps))
         @check_args(DiscreteNonParametric, allunique(vs))
@@ -36,11 +36,11 @@ struct DiscreteNonParametric{T<:Real,P<:Real,Ts<:AbstractVector{T},Ps<:AbstractV
 end
 
 DiscreteNonParametric(vs::Ts, ps::Ps) where {
-    T<:Real,P<:Real,Ts<:AbstractVector{T},Ps<:AbstractVector{P}} =
+    T,P<:Real,Ts<:AbstractVector{T},Ps<:AbstractVector{P}} =
     DiscreteNonParametric{T,P,Ts,Ps}(vs, ps)
 
 DiscreteNonParametric(vs::Ts, ps::Ps, a::NoArgCheck) where {
-    T<:Real,P<:Real,Ts<:AbstractVector{T},Ps<:AbstractVector{P}} =
+    T,P<:Real,Ts<:AbstractVector{T},Ps<:AbstractVector{P}} =
     DiscreteNonParametric{T,P,Ts,Ps}(vs, ps, a)
 
 eltype(d::DiscreteNonParametric{T}) where T = T
@@ -113,6 +113,7 @@ function _pdf(d::DiscreteNonParametric{T,P}, x::T) where {T,P}
 end
 pdf(d::DiscreteNonParametric{T}, x::Int) where T  = _pdf(d, convert(T, x))
 pdf(d::DiscreteNonParametric{T}, x::Real) where T = _pdf(d, convert(T, x))
+pdf(d::DiscreteNonParametric{T}, x) where T = _pdf(d, convert(T, x))
 
 function _cdf(d::DiscreteNonParametric{T,P}, x::T) where {T,P}
     x > maximum(d) && return 1.0
@@ -126,6 +127,7 @@ function _cdf(d::DiscreteNonParametric{T,P}, x::T) where {T,P}
 end
 cdf(d::DiscreteNonParametric{T}, x::Integer) where T = _cdf(d, convert(T, x))
 cdf(d::DiscreteNonParametric{T}, x::Real) where T = _cdf(d, convert(T, x))
+cdf(d::DiscreteNonParametric{T}, x) where T = _cdf(d, convert(T, x))
 
 function _ccdf(d::DiscreteNonParametric{T,P}, x::T) where {T,P}
     x < minimum(d) && return 1.0
@@ -139,6 +141,7 @@ function _ccdf(d::DiscreteNonParametric{T,P}, x::T) where {T,P}
 end
 ccdf(d::DiscreteNonParametric{T}, x::Integer) where T = _ccdf(d, convert(T, x))
 ccdf(d::DiscreteNonParametric{T}, x::Real) where T = _ccdf(d, convert(T, x))
+ccdf(d::DiscreteNonParametric{T}, x) where T = _ccdf(d, convert(T, x))
 
 function quantile(d::DiscreteNonParametric, q::Real)
     0 <= q <= 1 || throw(DomainError())

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -332,6 +332,7 @@ Relying on this fallback is not recommended in general, as it is prone to overfl
 """
 logpdf(d::UnivariateDistribution, x::Real) = log(pdf(d, x))
 logpdf(d::DiscreteUnivariateDistribution, x::Integer) = log(pdf(d, x))
+logpdf(d::DiscreteUnivariateDistribution, x) = log(pdf(d, x))
 logpdf(d::DiscreteUnivariateDistribution, x::Real) = isinteger(x) ? logpdf(d, round(Int, x)) : -Inf
 
 """
@@ -388,6 +389,7 @@ The logarithm of the cumulative function value(s) evaluated at `x`, i.e. `log(cd
 logcdf(d::UnivariateDistribution, x::Real) = log(cdf(d, x))
 logcdf(d::DiscreteUnivariateDistribution, x::Integer) = log(cdf(d, x))
 logcdf(d::DiscreteUnivariateDistribution, x::Real) = logcdf(d, floor(Int,x))
+logcdf(d::DiscreteUnivariateDistribution, x) = log(cdf(d, x))
 
 """
     logccdf(d::UnivariateDistribution, x::Real)
@@ -397,6 +399,7 @@ The logarithm of the complementary cumulative function values evaluated at x, i.
 logccdf(d::UnivariateDistribution, x::Real) = log(ccdf(d, x))
 logccdf(d::DiscreteUnivariateDistribution, x::Integer) = log(ccdf(d, x))
 logccdf(d::DiscreteUnivariateDistribution, x::Real) = logccdf(d, floor(Int,x))
+logccdf(d::DiscreteUnivariateDistribution, x) = log(ccdf(d, x))
 
 """
     quantile(d::UnivariateDistribution, q::Real)

--- a/test/discretenonparametric.jl
+++ b/test/discretenonparametric.jl
@@ -9,31 +9,47 @@ rng = MersenneTwister(123)
          "rand(rng, ...)" => [dist -> rand(rng, dist), (dist, n) -> rand(rng, dist, n)])
 
 d = DiscreteNonParametric([40., 80., 120., -60.], [.4, .3, .1,  .2])
+d_string = DiscreteNonParametric(["forty", "eighty", "one hundred and twenty", "negative sixty"], [.4, .3, .1,  .2])
 
 @test !(d ≈ DiscreteNonParametric([40., 80, 120, -60], [.4, .3, .1, .2], Distributions.NoArgCheck()))
 @test d ≈ DiscreteNonParametric([-60., 40., 80, 120], [.2, .4, .3, .1], Distributions.NoArgCheck())
 
 # Invalid probability
 @test_throws ArgumentError DiscreteNonParametric([40., 80, 120, -60], [.5, .3, .1, .2])
+@test_throws ArgumentError DiscreteNonParametric(["forty", "eighty", "one hundred and twenty", "negative sixty"], [.5, .3, .1, .2])
 
 # Invalid probability, but no arg check
 DiscreteNonParametric([40., 80, 120, -60], [.5, .3, .1, .2], Distributions.NoArgCheck())
+DiscreteNonParametric(["forty", "eighty", "one hundred and twenty", "negative sixty"], [.5, .3, .1, .2], Distributions.NoArgCheck())
 
 test_range(d)
 vs = Distributions.get_evalsamples(d, 0.00001)
+vs_string = Distributions.get_evalsamples(d_string, 0.00001)
 test_evaluation(d, vs, true)
+test_evaluation(d_string, vs_string, true)
 test_stats(d, vs)
 test_params(d)
+test_params(d_string)
 
 @test func[1](d) ∈ [40., 80., 120., -60.]
+@test func[1](d_string) ∈ ["forty", "eighty", "one hundred and twenty", "negative sixty"]
+@test func[1](d) ∈ [40., 80., 120., -60.]
+@test func[1](d_string) ∈ ["forty", "eighty", "one hundred and twenty", "negative sixty"]
 @test func[1](sampler(d)) ∈ [40., 80., 120., -60.]
+@test func[1](sampler(d_string)) ∈ ["forty", "eighty", "one hundred and twenty", "negative sixty"]
 
 @test pdf(d, -100.) == 0.
+@test pdf(d_string, "negative one hundred") == 0.
 @test pdf(d, -100) == 0.
+@test pdf(d_string, "negative one hundred") == 0.
 @test pdf(d, -60.) == .2
+@test pdf(d_string, "negative sixty") == .2
 @test pdf(d, -60) == .2
+@test pdf(d_string, "negative sixty") == .2
 @test pdf(d, 100.) == 0.
+@test pdf(d_string, "one hundred") == 0.
 @test pdf(d, 120.) == .1
+@test pdf(d_string, "one hundred and twenty") == .1
 
 @test cdf(d, -100.) == 0.
 @test cdf(d, -100) == 0.
@@ -59,20 +75,28 @@ test_params(d)
 
 @test insupport(d, -60)
 @test insupport(d, -60.)
+@test in("negative sixty", support(d_string))
 @test !insupport(d, 20)
 @test !insupport(d, 20.)
+@test !in("twenty", support(d_string))
 @test insupport(d, 80)
+@test in("eighty", support(d_string))
 @test !insupport(d, 150)
+@test !in("one hundred and fifty", support(d_string))
 
 xs = support(d)
+xs_string = support(d_string)
 ws = ProbabilityWeights(probs(d))
+ws_string = ProbabilityWeights(probs(d_string))
 @test mean(d) ≈ mean(xs, ws)
 @test var(d) ≈ var(xs, ws, corrected=false)
 @test skewness(d) ≈ skewness(xs, ws)
 @test kurtosis(d) ≈ kurtosis(xs, ws)
 @test entropy(d) ≈ 1.2798542258336676
 @test mode(d) == 40
+@test mode(d_string) == "forty"
 @test modes(d) == [40]
+@test modes(d_string) == ["forty"]
 @test mgf(d, 0) ≈ 1.0
 @test mgf(d, 0.17) ≈ 7.262034e7
 @test cf(d, 0) ≈ 1.0


### PR DESCRIPTION
## Description

Let `vs` denote the list of support values used when creating an instance of `DiscreteNonParametric`. Currently, we require that:
- `vs::Ts` where `Ts<:AbstractVector{T}` and `T<:Real`.

This pull request relaxes the requirement so that it is now:
- `vs::Ts` where `Ts<:AbstractVector{T}`

This allows you to create instances of `DiscreteNonParametric` that have non-`Real` support.

All of the existing `DiscreteNonParametric` tests are preserved, to show that this change is backwards compatible and will have no effect on DiscreteNonParametric when `T<:Real`.

I also add some tests for `DiscreteNonParametric` when `T` is `String`.

## Motivation

Suppose you have trained a multiclass classifier, and you would now like run the classifier on a single sample. For each of the classes, the classifier will output the probability of that class. For example, the output might be `setosa=0.1, versicolor=0.7, verginica=0.2`.

Since the output of a multiclass classifier (when run on a single sample) is a discrete non-parametric distribution on the set of classes, it would be natural to store it in a `DiscreteNonParametric`. However, currently `DiscreteNonParametric` requires that the support be a list of real values. This pull request relaxes the requirement and allows you to create a `DiscreteNonParametric` where the support values can be of any type (such as `String`).