### PR TITLE
Update `MatrixNormal`

### DIFF
--- a/src/matrix/matrixnormal.jl
+++ b/src/matrix/matrixnormal.jl
@@ -95,7 +95,7 @@ size(d::MatrixNormal) = size(d.M)
 
 rank(d::MatrixNormal) = minimum( size(d) )
 
-insupport(d::MatrixNormal, X::Matrix) = isreal(X) && size(X) == size(d)
+insupport(d::MatrixNormal, X::AbstractMatrix) = isreal(X) && size(X) == size(d)
 
 mean(d::MatrixNormal) = d.M
 

--- a/src/matrix/matrixnormal.jl
+++ b/src/matrix/matrixnormal.jl
@@ -22,7 +22,7 @@ struct MatrixNormal{T <: Real, TM <: AbstractMatrix, ST <: AbstractPDMat} <: Con
     U::ST
     V::ST
 
-    c0::T
+    logc0::T
 
 end
 
@@ -41,15 +41,15 @@ function MatrixNormal(M::AbstractMatrix{T}, U::AbstractPDMat{T}, V::AbstractPDMa
     n != n₀ && error("Number of rows of M must equal dim of U.")
     p != p₀ && error("Number of columns of M must equal dim of V.")
 
-    c₀ = _matrixnormal_c₀(U, V)
+    logc0 = matrixnormal_logc0(U, V)
 
-    R = Base.promote_eltype(T, c₀)
+    R = Base.promote_eltype(T, logc0)
 
     prom_M = convert(AbstractArray{R}, M)
     prom_U = convert(AbstractArray{R}, U)
     prom_V = convert(AbstractArray{R}, V)
 
-    MatrixNormal{R, typeof(prom_M), typeof(prom_U)}(prom_M, prom_U, prom_V, R(c₀))
+    MatrixNormal{R, typeof(prom_M), typeof(prom_U)}(prom_M, prom_U, prom_V, R(logc0))
 
 end
 
@@ -86,14 +86,14 @@ function convert(::Type{MatrixNormal{T}}, d::MatrixNormal) where T <: Real
     MM = convert(AbstractArray{T}, d.M)
     UU = convert(AbstractArray{T}, d.U)
     VV = convert(AbstractArray{T}, d.V)
-    MatrixNormal{T, typeof(MM), typeof(UU)}(MM, UU, VV, T(d.c0))
+    MatrixNormal{T, typeof(MM), typeof(UU)}(MM, UU, VV, T(d.logc0))
 end
 
-function convert(::Type{MatrixNormal{T}}, M::AbstractMatrix, U::AbstractPDMat, V::AbstractPDMat, c0) where T <: Real
+function convert(::Type{MatrixNormal{T}}, M::AbstractMatrix, U::AbstractPDMat, V::AbstractPDMat, logc0) where T <: Real
     MM = convert(AbstractArray{T}, M)
     UU = convert(AbstractArray{T}, U)
     VV = convert(AbstractArray{T}, V)
-    MatrixNormal{T, typeof(MM), typeof(UU)}(MM, UU, VV, T(c0))
+    MatrixNormal{T, typeof(MM), typeof(UU)}(MM, UU, VV, T(logc0))
 end
 
 #  -----------------------------------------------------------------------------
@@ -118,7 +118,7 @@ params(d::MatrixNormal) = (d.M, d.U, d.V)
 #  Evaluation
 #  -----------------------------------------------------------------------------
 
-function _matrixnormal_c₀(U::AbstractPDMat, V::AbstractPDMat)
+function matrixnormal_logc0(U::AbstractPDMat, V::AbstractPDMat)
 
     n = dim(U)
     p = dim(V)
@@ -136,7 +136,7 @@ function logkernel(d::MatrixNormal, X::AbstractMatrix)
 
 end
 
-_logpdf(d::MatrixNormal, X::AbstractMatrix) = logkernel(d, X) + d.c0
+_logpdf(d::MatrixNormal, X::AbstractMatrix) = logkernel(d, X) + d.logc0
 
 #  -----------------------------------------------------------------------------
 #  Sampling

--- a/src/matrix/matrixnormal.jl
+++ b/src/matrix/matrixnormal.jl
@@ -57,14 +57,9 @@ function MatrixNormal(M::AbstractMatrix, U::AbstractPDMat, V::AbstractPDMat)
 
 end
 
-MatrixNormal(M::AbstractMatrix, U::AbstractMatrix,         V::AbstractMatrix)         = MatrixNormal(M, PDMat(U), PDMat(V))
-MatrixNormal(M::AbstractMatrix, U::AbstractMatrix,         V::LinearAlgebra.Cholesky) = MatrixNormal(M, PDMat(U), PDMat(V))
-MatrixNormal(M::AbstractMatrix, U::AbstractMatrix,         V::AbstractPDMat)          = MatrixNormal(M, PDMat(U), V)
-MatrixNormal(M::AbstractMatrix, U::LinearAlgebra.Cholesky, V::AbstractMatrix)         = MatrixNormal(M, PDMat(U), PDMat(V))
-MatrixNormal(M::AbstractMatrix, U::LinearAlgebra.Cholesky, V::LinearAlgebra.Cholesky) = MatrixNormal(M, PDMat(U), PDMat(V))
-MatrixNormal(M::AbstractMatrix, U::LinearAlgebra.Cholesky, V::AbstractPDMat)          = MatrixNormal(M, PDMat(U), V)
-MatrixNormal(M::AbstractMatrix, U::AbstractPDMat,          V::AbstractMatrix)         = MatrixNormal(M, U,        PDMat(V))
-MatrixNormal(M::AbstractMatrix, U::AbstractPDMat,          V::LinearAlgebra.Cholesky) = MatrixNormal(M, U,        PDMat(V))
+MatrixNormal(M::AbstractMatrix, U::Union{AbstractMatrix, LinearAlgebra.Cholesky}, V::Union{AbstractMatrix, LinearAlgebra.Cholesky}) = MatrixNormal(M, PDMat(U), PDMat(V))
+MatrixNormal(M::AbstractMatrix, U::Union{AbstractMatrix, LinearAlgebra.Cholesky}, V::AbstractPDMat) = MatrixNormal(M, PDMat(U), V)
+MatrixNormal(M::AbstractMatrix, U::AbstractPDMat, V::Union{AbstractMatrix, LinearAlgebra.Cholesky}) = MatrixNormal(M, U, PDMat(V))
 
 MatrixNormal(m::Int, n::Int) = MatrixNormal(zeros(m, n), Matrix(1.0I, m, m), Matrix(1.0I, n, n))
 

--- a/src/matrix/matrixnormal.jl
+++ b/src/matrix/matrixnormal.jl
@@ -1,20 +1,20 @@
 """
-    MatrixNormal{T <: Real, TM <: AbstractMatrix, ST <: AbstractPDMat} <: ContinuousMatrixDistribution
+```julia
+MatrixNormal(M, U, V)
 
-[Matrix Normal Distribution](https://en.wikipedia.org/wiki/Matrix_normal_distribution)
+M::AbstractMatrix  n x p mean
+U::PDMat           n x n row covariance
+V::PDMat           p x p column covariance
+```
+The [matrix normal distribution](https://en.wikipedia.org/wiki/Matrix_normal_distribution) generalizes the multivariate normal distribution to ``n\\times p`` real matrices ``\\mathbf{X}``.
+If ``\\mathbf{X}\\sim MN(\\mathbf{M}, \\mathbf{U}, \\mathbf{V})``, then its
+probability density function is
 
-`X ~ MN(M, U, V)`
+```math
+f(\\mathbf{X};\\mathbf{M}, \\mathbf{U}, \\mathbf{V}) = \\frac{\\exp\\left( -\\frac{1}{2} \\, \\mathrm{tr}\\left[ \\mathbf{V}^{-1} (\\mathbf{X} - \\mathbf{M})^{\\rm{T}} \\mathbf{U}^{-1} (\\mathbf{X} - \\mathbf{M}) \\right] \\right)}{(2\\pi)^{np/2} |\\mathbf{V}|^{n/2} |\\mathbf{U}|^{p/2}}.
+```
 
-M: n x p
-
-U: n x n positive definite
-
-V: p x p positive definite
-
-f(X) = c0 * exp( -0.5 tr[inv(V) (X - M)' inv(U) (X - M)] )
-
-c0   = (2pi) ^ {-np / 2} |V| ^ {-n / 2} |U| ^ {-p / 2}
-
+``\\mathbf{X}\\sim MN(\\mathbf{M},\\mathbf{U},\\mathbf{V})`` if and only if ``\\text{vec}(\\mathbf{X})\\sim N(\\text{vec}(\\mathbf{M}),\\mathbf{V}\\otimes\\mathbf{U})``.
 """
 struct MatrixNormal{T <: Real, TM <: AbstractMatrix, ST <: AbstractPDMat} <: ContinuousMatrixDistribution
 

--- a/src/matrix/matrixnormal.jl
+++ b/src/matrix/matrixnormal.jl
@@ -121,9 +121,8 @@ end
 function logkernel(d::MatrixNormal, X::AbstractMatrix)
 
     A  = X - d.M
-    At = Matrix(A')
 
-    -0.5 * tr( (d.V \ At) * (d.U \ A) )
+    -0.5 * tr( (d.V \ A') * (d.U \ A) )
 
 end
 

--- a/src/matrix/matrixnormal.jl
+++ b/src/matrix/matrixnormal.jl
@@ -32,14 +32,10 @@ end
 
 function MatrixNormal(M::AbstractMatrix{T}, U::AbstractPDMat{T}, V::AbstractPDMat{T}) where T <: Real
 
-    n = size(M, 1)
-    p = size(M, 2)
+    n, p = size(M)
 
-    n₀ = size(U, 1)
-    p₀ = size(V, 1)
-
-    n != n₀ && error("Number of rows of M must equal dim of U.")
-    p != p₀ && error("Number of columns of M must equal dim of V.")
+    n == dim(U) || throw(ArgumentError("Number of rows of M must equal dim of U."))
+    p == dim(V) || throw(ArgumentError("Number of columns of M must equal dim of V."))
 
     logc0 = matrixnormal_logc0(U, V)
 

--- a/test/matrixnormal.jl
+++ b/test/matrixnormal.jl
@@ -91,6 +91,12 @@ end
     @test rank(L) == 1
     @test rank(H) == 1
     @test rank(K) == 1
+
+    @test rank(D) == rank(rand(D))
+    @test rank(G) == rank(rand(G))
+    @test rank(L) == rank(rand(L))
+    @test rank(H) == rank(rand(H))
+    @test rank(K) == rank(rand(K))
 end
 
 @testset "MatrixNormal insupport" begin

--- a/test/matrixnormal.jl
+++ b/test/matrixnormal.jl
@@ -66,8 +66,8 @@ end
 end
 
 @testset "MatrixNormal construction errors" begin
-    @test_throws ErrorException MatrixNormal(M, V, U)
-    @test_throws ErrorException MatrixNormal(M, U, U)
+    @test_throws ArgumentError MatrixNormal(M, V, U)
+    @test_throws ArgumentError MatrixNormal(M, U, U)
 end
 
 @testset "MatrixNormal params" begin

--- a/test/matrixnormal.jl
+++ b/test/matrixnormal.jl
@@ -138,7 +138,7 @@ end
 @testset "MatrixNormal conversion" for elty in (Float32, Float64, BigFloat)
 
     Del1 = convert(MatrixNormal{elty}, D)
-    Del2 = convert(MatrixNormal{elty}, M, PDU, PDV, D.c0)
+    Del2 = convert(MatrixNormal{elty}, M, PDU, PDV, D.logc0)
 
     @test partype(Del1) == elty
     @test partype(Del2) == elty


### PR DESCRIPTION
Following suggestions for the recently merged `MatrixTDist`, this PR applies several small improvements to the `MatrixNormal`:
- eliminate unicode subscripts;
- use TeX for the math in the docstring;
- don't call `Matrix(A')` in `logkernel()`;
- use `Union` types to consolidate constructors;
- change `_matrixnormal_c0` to `matrixnormal_logc0`;
- throw `ArgumentError`s when checking dims during construction;
- add a unit test confirming that the rank of samples from `d::MatrixNormal` is equal to `rank(d)`.