### PR TITLE
Make TDist(Inf) behave like Normal(0,1) (addresses Issue #929)

### DIFF
--- a/src/univariate/continuous/tdist.jl
+++ b/src/univariate/continuous/tdist.jl
@@ -50,6 +50,7 @@ mode(d::TDist{T}) where {T<:Real} = zero(T)
 
 function var(d::TDist{T}) where T<:Real
     ν = d.ν
+    isinf(ν) && return one(T)
     ν > 2 ? ν / (ν - 2) :
     ν > 1 ? T(Inf) : T(NaN)
 end

--- a/src/univariate/continuous/tdist.jl
+++ b/src/univariate/continuous/tdist.jl
@@ -63,7 +63,8 @@ function kurtosis(d::TDist{T}) where T<:Real
     ν > 2 ? T(Inf) : T(NaN)
 end
 
-function entropy(d::TDist)
+function entropy(d::TDist{T}) where T <: Real
+    isinf(d.ν) && return entropy( Normal(zero(T), one(T)) )
     h = d.ν/2
     h1 = h + 1//2
     h1 * (digamma(h1) - digamma(h)) + log(d.ν)/2 + lbeta(h, 1//2)
@@ -76,11 +77,12 @@ end
 
 rand(rng::AbstractRNG, d::TDist) = randn(rng) / ( isinf(d.ν) ? 1 : sqrt(rand(rng, Chisq(d.ν))/d.ν) )
 
-function cf(d::TDist, t::Real)
+function cf(d::TDist{T}, t::Real) where T <: Real
+    isinf(d.ν) && return cf(Normal(zero(T), one(T)), t)
     t == 0 && return complex(1)
     h = d.ν/2
     q = d.ν/4
     complex(2(q*t^2)^q * besselk(h, sqrt(d.ν) * abs(t)) / gamma(h))
 end
 
-gradlogpdf(d::TDist, x::Real) = -((d.ν + 1) * x) / (x^2 + d.ν)
+gradlogpdf(d::TDist{T}, x::Real) where {T<:Real} = isinf(d.ν) ? gradlogpdf(Normal(zero(T), one(T)), x) : -((d.ν + 1) * x) / (x^2 + d.ν)

--- a/src/univariate/continuous/tdist.jl
+++ b/src/univariate/continuous/tdist.jl
@@ -73,7 +73,7 @@ end
 
 @_delegate_statsfuns TDist tdist ν
 
-rand(rng::AbstractRNG, d::TDist) = randn(rng) / sqrt(rand(rng, Chisq(d.ν))/d.ν)
+rand(rng::AbstractRNG, d::TDist) = randn(rng) / ( isinf(d.ν) ? 1 : sqrt(rand(rng, Chisq(d.ν))/d.ν) )
 
 function cf(d::TDist, t::Real)
     t == 0 && return complex(1)

--- a/test/edgecases.jl
+++ b/test/edgecases.jl
@@ -1,0 +1,25 @@
+using Test, Distributions, StatsBase
+
+@testset "TDist(Inf) is Normal(0,1)" begin
+    T = TDist(Inf)
+    N = Normal(0, 1)
+
+    x = rand(N)
+    z = rand(T, 10000000)
+
+    @test mean(T) == mean(N)
+    @test median(T) == median(N)
+    @test mode(T) == mode(N)
+    #@test var(T) == var(N)
+    @test skewness(T) == skewness(N)
+    @test kurtosis(T) == kurtosis(N)
+    #@test entropy(T) == entropy(N)
+    @test pdf(T, x) ≈ pdf(N, x)
+    @test logpdf(T, x) ≈ logpdf(N, x)
+    #@test gradlogpdf(T, x) ≈ gradlogpdf(N, x)
+    #@test cf(T, x) ≈ cf(N, x)
+
+    fnecdf = ecdf(z)
+    y = [-1.96, -1.644854, -1.281552, -0.6744898, 0, 0.6744898, 1.281552, 1.644854, 1.96]
+    @test isapprox(fnecdf(y), [0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95, 0.975], atol=1e-3)
+end

--- a/test/edgecases.jl
+++ b/test/edgecases.jl
@@ -13,11 +13,11 @@ using Test, Distributions, StatsBase
     @test var(T) == var(N)
     @test skewness(T) == skewness(N)
     @test kurtosis(T) == kurtosis(N)
-    #@test entropy(T) == entropy(N)
+    @test entropy(T) == entropy(N)
     @test pdf(T, x) ≈ pdf(N, x)
     @test logpdf(T, x) ≈ logpdf(N, x)
-    #@test gradlogpdf(T, x) ≈ gradlogpdf(N, x)
-    #@test cf(T, x) ≈ cf(N, x)
+    @test gradlogpdf(T, x) ≈ gradlogpdf(N, x)
+    @test cf(T, x) ≈ cf(N, x)
 
     fnecdf = ecdf(z)
     y = [-1.96, -1.644854, -1.281552, -0.6744898, 0, 0.6744898, 1.281552, 1.644854, 1.96]

--- a/test/edgecases.jl
+++ b/test/edgecases.jl
@@ -10,7 +10,7 @@ using Test, Distributions, StatsBase
     @test mean(T) == mean(N)
     @test median(T) == median(N)
     @test mode(T) == mode(N)
-    #@test var(T) == var(N)
+    @test var(T) == var(N)
     @test skewness(T) == skewness(N)
     @test kurtosis(T) == kurtosis(N)
     #@test entropy(T) == entropy(N)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ const tests = [
     "categorical",
     "univariates",
     "continuous",
+    "edgecases",
     "fit",
     "multinomial",
     "binomial",


### PR DESCRIPTION
#929 wants `rand( TDist(Inf) )` to return standard normal draws like it used to (currently returns `NaN`). This PR brings that back, and also introduces unit tests for confirming that `TDist(Inf)` behaves like `Normal(0,1)` in other ways: `mean`, `var`, `pdf`, etc. They currently *do not* agree on `entropy`, `gradlogpdf`, `cf`. Not sure if/how we want to handle that. Let me know.