### PR TITLE
Fix `convert` method for `Wishart` and `InverseWishart`

### DIFF
--- a/src/matrix/inversewishart.jl
+++ b/src/matrix/inversewishart.jl
@@ -50,11 +50,11 @@ params(d::InverseWishart) = (d.df, d.Ψ, d.c0)
 
 ### Conversion
 function convert(::Type{InverseWishart{T}}, d::InverseWishart) where T<:Real
-    P = Wishart{T}(d.Ψ)
+    P = convert(AbstractArray{T}, d.Ψ)
     InverseWishart{T, typeof(P)}(T(d.df), P, T(d.c0))
 end
 function convert(::Type{InverseWishart{T}}, df, Ψ::AbstractPDMat, c0) where T<:Real
-    P = Wishart{T}(Ψ)
+    P = convert(AbstractArray{T}, Ψ)
     InverseWishart{T, typeof(P)}(T(df), P, T(c0))
 end
 

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -55,11 +55,11 @@ params(d::Wishart) = (d.df, d.S, d.c0)
 
 ### Conversion
 function convert(::Type{Wishart{T}}, d::Wishart) where T<:Real
-    P = AbstractMatrix{T}(d.S)
+    P = convert(AbstractArray{T}, d.S)
     Wishart{T, typeof(P)}(T(d.df), P, T(d.c0))
 end
 function convert(::Type{Wishart{T}}, df, S::AbstractPDMat, c0) where T<:Real
-    P = AbstractMatrix{T}(S)
+    P = convert(AbstractArray{T}, S)
     Wishart{T, typeof(P)}(T(df), P, T(c0))
 end
 

--- a/test/wisharts.jl
+++ b/test/wisharts.jl
@@ -1,5 +1,5 @@
 using Distributions, Random
-using Test, LinearAlgebra
+using Test, LinearAlgebra, PDMats
 
 
 v = 7.0
@@ -131,4 +131,22 @@ m1 = m[1]
 rand!(W, m, false)
 @test m1 ≡ m[1]
 
+@testset "Wishart conversion" for elty in (Float32, Float64, BigFloat)
 
+    Del1 = convert(Wishart{elty}, W)
+    Del2 = convert(Wishart{elty}, v, PDMat(S), W.c0)
+
+    @test partype(Del1) == elty
+    @test partype(Del2) == elty
+
+end
+
+@testset "InverseWishart conversion" for elty in (Float32, Float64, BigFloat)
+
+    Del1 = convert(InverseWishart{elty}, IW)
+    Del2 = convert(InverseWishart{elty}, v, PDMat(S), IW.c0)
+
+    @test partype(Del1) == elty
+    @test partype(Del2) == elty
+
+end


### PR DESCRIPTION
`convert` doesn't work for `Wishart` and `InverseWishart`. 

MWE:

```julia
using Distributions, LinearAlgebra

d = Wishart(Float32(10), Matrix{Float32}(I, 3, 3))
g = InverseWishart(Float32(10), Matrix{Float32}(I, 3, 3))
```
Then
```julia
julia> convert(Wishart{Float64}, d)
ERROR: MethodError: no method matching AbstractArray{Float64,2}(::PDMats.PDMat{Float32,Array{Float32,2}})
Closest candidates are:
  AbstractArray{Float64,2}(::SymTridiagonal) where T at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.1/LinearAlgebra/src/tridiag.jl:94
  AbstractArray{Float64,2}(::Tridiagonal) where T at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.1/LinearAlgebra/src/tridiag.jl:629
  AbstractArray{Float64,2}(::LinearAlgebra.QRPackedQ{T,S} where S<:AbstractArray{T,2}) where T at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.1/LinearAlgebra/src/qr.jl:500
  ...
Stacktrace:
 [1] convert(::Type{Wishart{Float64,ST} where ST<:PDMats.AbstractPDMat}, ::Wishart{Float32,PDMats.PDMat{Float32,Array{Float32,2}}}) at /Users/johnczito/.julia/packages/Distributions/Iltex/src/matrix/wishart.jl:58
 [2] top-level scope at none:0

julia> convert(InverseWishart{Float64}, g)
ERROR: MethodError: no method matching Wishart{Float64,ST} where ST<:PDMats.AbstractPDMat(::PDMats.PDMat{Float32,Array{Float32,2}})
Stacktrace:
 [1] convert(::Type{InverseWishart{Float64,ST} where ST<:PDMats.AbstractPDMat}, ::InverseWishart{Float32,PDMats.PDMat{Float32,Array{Float32,2}}}) at /Users/johnczito/.julia/packages/Distributions/Iltex/src/matrix/inversewishart.jl:53
 [2] top-level scope at none:0
```