### PR TITLE
Add `MatrixFDist`

### DIFF
--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -24,6 +24,7 @@ InverseWishart
 MatrixNormal
 MatrixTDist
 MatrixBeta
+MatrixFDist
 ```
 
 ## Internal Methods (for creating your own matrix-variate distributions)

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -4,7 +4,7 @@ using StatsBase, PDMats, StatsFuns, Statistics
 using StatsFuns: logtwo, invsqrt2, invsqrt2π
 
 import QuadGK: quadgk
-import Base: size, eltype, length, convert, show, getindex, rand, vec
+import Base: size, eltype, length, convert, show, getindex, rand, vec, inv
 import Base: sum, maximum, minimum, extrema, +, -, ==
 import Base.Math: @horner
 
@@ -109,6 +109,7 @@ export
     LogNormal,
     LogitNormal,
     MatrixBeta,
+    MatrixFDist,
     MatrixNormal,
     MatrixTDist,
     MixtureModel,
@@ -310,7 +311,7 @@ Supported distributions:
     GeneralizedExtremeValue, Geometric, Gumbel, Hypergeometric,
     InverseWishart, InverseGamma, InverseGaussian, IsoNormal,
     IsoNormalCanon, Kolmogorov, KSDist, KSOneSided, Laplace, Levy,
-    Logistic, LogNormal, MatrixBeta, MatrixNormal, MatrixTDist, MixtureModel,
+    Logistic, LogNormal, MatrixBeta, MatrixFDist, MatrixNormal, MatrixTDist, MixtureModel,
     Multinomial, MultivariateNormal, MvLogNormal, MvNormal, MvNormalCanon,
     MvNormalKnownCov, MvTDist, NegativeBinomial, NoncentralBeta, NoncentralChisq,
     NoncentralF, NoncentralHypergeometric, NoncentralT, Normal, NormalCanon,

--- a/src/matrix/matrixfdist.jl
+++ b/src/matrix/matrixfdist.jl
@@ -111,7 +111,6 @@ function matrixfdist_logc0(n1::Real, n2::Real, B::AbstractPDMat)
     term1 = logmvgamma(p, (n1 + n2)/2) - logmvgamma(p, n1/2) - logmvgamma(p, n2/2)
     term2 = (n2 / 2) * logdet(B)
     return term1 + term2
-    #-logmvbeta(dim(B), n1 / 2, n2 / 2) + (n2 / 2) * logdet(B)
 end
 
 function logkernel(d::MatrixFDist, Σ::AbstractMatrix)

--- a/src/matrix/matrixfdist.jl
+++ b/src/matrix/matrixfdist.jl
@@ -1,0 +1,143 @@
+"""
+```julia
+MatrixFDist(n1, n2, B)
+
+n1::Real  degrees of freedom (greater than p - 1)
+n2::Real  degrees of freedom (greater than p - 1)
+B::PDMat  p x p scale
+```
+The [matrix *F*-Distribution](https://projecteuclid.org/euclid.ba/1515747744)
+(sometimes called the matrix beta type II distribution) generalizes the
+*F*-Distribution to ``p\\times p`` real, positive definite matrices ``\\boldsymbol{\\Sigma}``.
+If ``\\boldsymbol{\\Sigma}\\sim MF_{p}(n_1/2,n_2/2,\\mathbf{B})``, then its probability density function is
+
+```math
+f(\\boldsymbol{\\Sigma} ; n_1,n_2,\\mathbf{B}) =
+\\frac{\\Gamma_p(\\frac{n_1+n_2}{2})}{\\Gamma_p(\\frac{n_1}{2})\\Gamma_p(\\frac{n_2}{2})}
+|\\mathbf{B}|^{n_2/2}|\\boldsymbol{\\Sigma}|^{(n_1-p-1)/2}|\\mathbf{B}+\\boldsymbol{\\Sigma}|^{-(n_1+n_2)/2}
+```
+
+If the joint distribution ``p(\\boldsymbol{\\Psi},\\boldsymbol{\\Sigma})=p(\\boldsymbol{\\Psi})p(\\boldsymbol{\\Sigma}|\\boldsymbol{\\Psi})``
+is given by
+
+```math
+\\begin{align*}
+\\boldsymbol{\\Psi}&\\sim W_p(n_1, \\mathbf{B})\\\\
+\\boldsymbol{\\Sigma}|\\boldsymbol{\\Psi}&\\sim IW_p(n_2, \\boldsymbol{\\Psi}),
+\\end{align*}
+```
+
+then the marginal distribution of ``\\boldsymbol{\\Sigma}`` is
+``MF_{p}(n_1/2,n_2/2,\\mathbf{B})``.
+"""
+struct MatrixFDist{T <: Real, TW <: Wishart} <: ContinuousMatrixDistribution
+    W::TW
+    n2::T
+    logc0::T
+end
+
+#  -----------------------------------------------------------------------------
+#  Constructors
+#  -----------------------------------------------------------------------------
+
+function MatrixFDist(n1::Real, n2::Real, B::AbstractPDMat)
+
+    p = dim(B)
+
+    n1 > p - 1 || throw(ArgumentError("first degrees of freedom must be larger than $(p - 1)"))
+    n2 > p - 1 || throw(ArgumentError("second degrees of freedom must be larger than $(p - 1)"))
+
+    logc0 = matrixfdist_logc0(n1, n2, B)
+    T = Base.promote_eltype(n1, n2, logc0, B)
+    prom_B = convert(AbstractArray{T}, B)
+    W = Wishart(T(n1), prom_B)
+
+    MatrixFDist{T, typeof(W)}(W, T(n2), T(logc0))
+
+end
+
+MatrixFDist(n1::Real, n2::Real, B::Union{AbstractMatrix, LinearAlgebra.Cholesky}) = MatrixFDist(n1, n2, PDMat(B))
+
+#  -----------------------------------------------------------------------------
+#  REPL display
+#  -----------------------------------------------------------------------------
+
+ show(io::IO, d::MatrixFDist) = show_multline(io, d, [(:n1, d.W.df), (:n2, d.n2), (:B, d.W.S.mat)])
+
+#  -----------------------------------------------------------------------------
+#  Conversion
+#  -----------------------------------------------------------------------------
+
+function convert(::Type{MatrixFDist{T}}, d::MatrixFDist) where T <: Real
+    W = convert(Wishart{T}, d.W)
+    MatrixFDist{T, typeof(W)}(W, T(d.n2), T(d.logc0))
+end
+
+function convert(::Type{MatrixFDist{T}}, W::Wishart, n2, logc0) where T <: Real
+    WW = convert(Wishart{T}, W)
+    MatrixFDist{T, typeof(WW)}(WW, T(n2), T(logc0))
+end
+
+#  -----------------------------------------------------------------------------
+#  Properties
+#  -----------------------------------------------------------------------------
+
+dim(d::MatrixFDist) = dim(d.W)
+
+size(d::MatrixFDist) = size(d.W)
+
+rank(d::MatrixFDist) = dim(d)
+
+insupport(d::MatrixFDist, Σ::AbstractMatrix) = isreal(Σ) && size(Σ) == size(d) && isposdef(Σ)
+
+params(d::MatrixFDist) = (d.W.df, d.n2, d.W.S)
+
+function mean(d::MatrixFDist)
+    p = dim(d)
+    n1, n2, B = params(d)
+
+    (n2 > p + 1) ? (return (n1 / (n2 - p - 1)) * B.mat) : throw(ArgumentError("mean only defined for df2 > dim + 1"))
+end
+
+@inline partype(d::MatrixFDist{T}) where {T <: Real} = T
+
+#  -----------------------------------------------------------------------------
+#  Evaluation
+#  -----------------------------------------------------------------------------
+
+function matrixfdist_logc0(n1::Real, n2::Real, B::AbstractPDMat)
+    #  returns the natural log of the normalizing constant for the pdf
+    p = dim(B)
+    term1 = logmvgamma(p, (n1 + n2)/2) - logmvgamma(p, n1/2) - logmvgamma(p, n2/2)
+    term2 = (n2 / 2) * logdet(B)
+    return term1 + term2
+    #-logmvbeta(dim(B), n1 / 2, n2 / 2) + (n2 / 2) * logdet(B)
+end
+
+function logkernel(d::MatrixFDist, Σ::AbstractMatrix)
+
+    p = dim(d)
+    n1, n2, B = params(d)
+
+    ((n1 - p - 1) / 2) * logdet(Σ) - ((n1 + n2) / 2) * logdet(pdadd(Σ, B))
+
+end
+
+_logpdf(d::MatrixFDist, Σ::AbstractMatrix) = logkernel(d, Σ) + d.logc0
+
+#  -----------------------------------------------------------------------------
+#  Sampling
+#  -----------------------------------------------------------------------------
+
+function _rand!(rng::AbstractRNG, d::MatrixFDist, A::AbstractMatrix)
+
+    Ψ = rand(rng, d.W)
+    A .= rand(rng, InverseWishart(d.n2, Ψ) )
+
+end
+
+#  -----------------------------------------------------------------------------
+#  Transformation
+#  -----------------------------------------------------------------------------
+
+inv(d::MatrixFDist) = ( (n1, n2, B) = params(d); MatrixFDist(n2, n1, inv(B)) )

--- a/src/matrix/matrixfdist.jl
+++ b/src/matrix/matrixfdist.jl
@@ -14,7 +14,7 @@ If ``\\boldsymbol{\\Sigma}\\sim MF_{p}(n_1/2,n_2/2,\\mathbf{B})``, then its prob
 ```math
 f(\\boldsymbol{\\Sigma} ; n_1,n_2,\\mathbf{B}) =
 \\frac{\\Gamma_p(\\frac{n_1+n_2}{2})}{\\Gamma_p(\\frac{n_1}{2})\\Gamma_p(\\frac{n_2}{2})}
-|\\mathbf{B}|^{n_2/2}|\\boldsymbol{\\Sigma}|^{(n_1-p-1)/2}|\\mathbf{B}+\\boldsymbol{\\Sigma}|^{-(n_1+n_2)/2}
+|\\mathbf{B}|^{n_2/2}|\\boldsymbol{\\Sigma}|^{(n_1-p-1)/2}|\\mathbf{B}+\\boldsymbol{\\Sigma}|^{-(n_1+n_2)/2}.
 ```
 
 If the joint distribution ``p(\\boldsymbol{\\Psi},\\boldsymbol{\\Sigma})=p(\\boldsymbol{\\Psi})p(\\boldsymbol{\\Sigma}|\\boldsymbol{\\Psi})``

--- a/src/matrix/matrixfdist.jl
+++ b/src/matrix/matrixfdist.jl
@@ -41,19 +41,14 @@ end
 #  -----------------------------------------------------------------------------
 
 function MatrixFDist(n1::Real, n2::Real, B::AbstractPDMat)
-
     p = dim(B)
-
     n1 > p - 1 || throw(ArgumentError("first degrees of freedom must be larger than $(p - 1)"))
     n2 > p - 1 || throw(ArgumentError("second degrees of freedom must be larger than $(p - 1)"))
-
     logc0 = matrixfdist_logc0(n1, n2, B)
     T = Base.promote_eltype(n1, n2, logc0, B)
     prom_B = convert(AbstractArray{T}, B)
     W = Wishart(T(n1), prom_B)
-
     MatrixFDist{T, typeof(W)}(W, T(n2), T(logc0))
-
 end
 
 MatrixFDist(n1::Real, n2::Real, B::Union{AbstractMatrix, LinearAlgebra.Cholesky}) = MatrixFDist(n1, n2, PDMat(B))
@@ -114,12 +109,9 @@ function matrixfdist_logc0(n1::Real, n2::Real, B::AbstractPDMat)
 end
 
 function logkernel(d::MatrixFDist, Σ::AbstractMatrix)
-
     p = dim(d)
     n1, n2, B = params(d)
-
     ((n1 - p - 1) / 2) * logdet(Σ) - ((n1 + n2) / 2) * logdet(pdadd(Σ, B))
-
 end
 
 _logpdf(d::MatrixFDist, Σ::AbstractMatrix) = logkernel(d, Σ) + d.logc0
@@ -129,10 +121,8 @@ _logpdf(d::MatrixFDist, Σ::AbstractMatrix) = logkernel(d, Σ) + d.logc0
 #  -----------------------------------------------------------------------------
 
 function _rand!(rng::AbstractRNG, d::MatrixFDist, A::AbstractMatrix)
-
     Ψ = rand(rng, d.W)
     A .= rand(rng, InverseWishart(d.n2, Ψ) )
-
 end
 
 #  -----------------------------------------------------------------------------

--- a/src/matrix/matrixfdist.jl
+++ b/src/matrix/matrixfdist.jl
@@ -1,7 +1,6 @@
 """
+    MatrixFDist(n1, n2, B)
 ```julia
-MatrixFDist(n1, n2, B)
-
 n1::Real  degrees of freedom (greater than p - 1)
 n2::Real  degrees of freedom (greater than p - 1)
 B::PDMat  p x p scale

--- a/src/matrix/matrixfdist.jl
+++ b/src/matrix/matrixfdist.jl
@@ -96,7 +96,7 @@ function mean(d::MatrixFDist)
     p = dim(d)
     n1, n2, B = params(d)
 
-    (n2 > p + 1) ? (return (n1 / (n2 - p - 1)) * B.mat) : throw(ArgumentError("mean only defined for df2 > dim + 1"))
+    (n2 <= p + 1) ? throw(ArgumentError("mean only defined for df2 > dim + 1")) : (return (n1 / (n2 - p - 1)) * B.mat)
 end
 
 @inline partype(d::MatrixFDist{T}) where {T <: Real} = T

--- a/src/matrix/matrixfdist.jl
+++ b/src/matrix/matrixfdist.jl
@@ -95,10 +95,7 @@ params(d::MatrixFDist) = (d.W.df, d.n2, d.W.S)
 function mean(d::MatrixFDist)
     p = dim(d)
     n1, n2, B = params(d)
-
-    if n2 <= p + 1
-        throw(ArgumentError("mean only defined for df2 > dim + 1"))
-    end
+    n2 > p + 1 || throw(ArgumentError("mean only defined for df2 > dim + 1"))
     return (n1 / (n2 - p - 1)) * B.mat
 end
 

--- a/src/matrix/matrixfdist.jl
+++ b/src/matrix/matrixfdist.jl
@@ -96,7 +96,10 @@ function mean(d::MatrixFDist)
     p = dim(d)
     n1, n2, B = params(d)
 
-    (n2 <= p + 1) ? throw(ArgumentError("mean only defined for df2 > dim + 1")) : (return (n1 / (n2 - p - 1)) * B.mat)
+    if n2 <= p + 1
+        throw(ArgumentError("mean only defined for df2 > dim + 1"))
+    end
+    return (n1 / (n2 - p - 1)) * B.mat
 end
 
 @inline partype(d::MatrixFDist{T}) where {T <: Real} = T

--- a/src/matrixvariates.jl
+++ b/src/matrixvariates.jl
@@ -24,6 +24,14 @@ distribution of vec(X), where X is a random matrix with distribution `d`.
 Base.vec(d::MatrixDistribution)
 
 """
+    inv(d::MatrixDistribution)
+
+If known, returns a `MatrixDistribution` instance representing the
+distribution of inv(X), where X is a random matrix with distribution `d`.
+"""
+Base.inv(d::MatrixDistribution)
+
+"""
     mean(d::MatrixDistribution)
 
 Return the mean matrix of `d`.
@@ -161,6 +169,7 @@ _logpdf(d::MatrixDistribution, x::AbstractArray)
 
 ##### Specific distributions #####
 
-for fname in ["wishart.jl", "inversewishart.jl", "matrixnormal.jl", "matrixtdist.jl", "matrixbeta.jl"]
+for fname in ["wishart.jl", "inversewishart.jl", "matrixnormal.jl",
+              "matrixtdist.jl", "matrixbeta.jl", "matrixfdist.jl"]
     include(joinpath("matrix", fname))
 end

--- a/test/matrixfdist.jl
+++ b/test/matrixfdist.jl
@@ -1,0 +1,75 @@
+using Distributions, Random
+using Test, LinearAlgebra, PDMats
+
+p  = 3
+n1 = p + abs(10randn())
+n2 = p + 1 + abs(10randn())
+B  = rand( InverseWishart(p + 2, Matrix(1.0I, p, p)) )
+b  = Matrix((n2 / n1) * I, 1, 1)
+
+G = MatrixFDist(n1, n2, B)
+F = MatrixFDist(n1, n2, b)
+f = FDist(n1, n2)
+
+@testset "MatrixFDist promotion during construction" begin
+    R = MatrixFDist(Float32(n1), BigFloat(n2), Matrix{Float64}(B))
+    @test partype(R) == BigFloat
+end
+
+@testset "MatrixFDist construction errors" begin
+    @test_throws ArgumentError MatrixFDist(1, n2, B)
+    @test_throws ArgumentError MatrixFDist(n1, 1, B)
+    @test_throws ArgumentError mean(MatrixFDist(n1, p, B))
+end
+
+@testset "MatrixFDist params" begin
+    df1, df2, PDB = params(G)
+    @test df1 == n1
+    @test df2 == n2
+    @test PDB.mat == B
+end
+
+@testset "MatrixFDist dim" begin
+    @test dim(G) == p
+    @test dim(F) == 1
+end
+
+@testset "MatrixFDist size" begin
+    @test size(G) == (p, p)
+    @test size(F) == (1, 1)
+end
+
+@testset "MatrixFDist rank" begin
+    @test rank(G) == p
+    @test rank(F) == 1
+    @test rank(G) == rank(rand(G))
+    @test rank(F) == rank(rand(F))
+end
+
+@testset "MatrixFDist insupport" begin
+    @test insupport(G, rand(G))
+    @test insupport(F, rand(F))
+
+    @test !insupport(G, rand(G) + rand(G) * im)
+    @test !insupport(G, randn(p, p + 1))
+    @test !insupport(G, randn(p, p))
+
+end
+
+@testset "MatrixFDist logpdf" begin
+    Z = rand(F)
+    z = Z[1, 1]
+    @test logpdf(F, Z) ≈ logpdf(f, z)
+end
+
+@testset "MatrixFDist sample moments" begin
+    @test isapprox(mean(rand(G, 100000)), mean(G) , atol = 0.1)
+end
+
+@testset "MatrixFDist conversion" for elty in (Float32, Float64, BigFloat)
+    Gel1 = convert(MatrixFDist{elty}, G)
+    Gel2 = convert(MatrixFDist{elty}, G.W, n2, G.logc0)
+
+    @test partype(Gel1) == elty
+    @test partype(Gel2) == elty
+end

--- a/test/matrixfdist.jl
+++ b/test/matrixfdist.jl
@@ -70,6 +70,8 @@ end
     Gel1 = convert(MatrixFDist{elty}, G)
     Gel2 = convert(MatrixFDist{elty}, G.W, n2, G.logc0)
 
+    @test Gel1 isa MatrixFDist{elty, Wishart{elty, PDMat{elty,Array{elty,2}}}}
+    @test Gel2 isa MatrixFDist{elty, Wishart{elty, PDMat{elty,Array{elty,2}}}}
     @test partype(Gel1) == elty
     @test partype(Gel2) == elty
 end

--- a/test/matrixfdist.jl
+++ b/test/matrixfdist.jl
@@ -53,7 +53,6 @@ end
     @test !insupport(G, rand(G) + rand(G) * im)
     @test !insupport(G, randn(p, p + 1))
     @test !insupport(G, randn(p, p))
-
 end
 
 @testset "MatrixFDist logpdf" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ const tests = [
     "edgeworth",
     "wisharts",
     "matrixbeta",
+    "matrixfdist",
     "matrixnormal",
     "matrixtdist",
     "vonmisesfisher",


### PR DESCRIPTION
Implements the basic features of the matrix *F*-distribution. See [here](https://projecteuclid.org/euclid.ba/1515747744), and also the "generalized beta type II" distribution in chapter 5 of [Gupta and Nagar (1999)](https://www.crcpress.com/Matrix-Variate-Distributions/Gupta-Nagar/p/book/9781584880462).

(This would also make use of JuliaStats/StatsFuns.jl#72 in the long-run.)