### PR TITLE
upgrade matrix-variate docs

### DIFF
--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -2,6 +2,13 @@
 
 *Matrix-variate distributions* are the distributions whose variate forms are `Matrixvariate` (*i.e* each sample is a matrix). Abstract types for matrix-variate distributions:
 
+```julia
+const MatrixDistribution{S<:ValueSupport} = Distribution{Matrixvariate,S}
+
+const DiscreteMatrixDistribution   = Distribution{Matrixvariate, Discrete}
+const ContinuousMatrixDistribution = Distribution{Matrixvariate, Continuous}
+```
+
 ## Common Interface
 
 All distributions implement the same set of methods:

--- a/src/matrix/inversewishart.jl
+++ b/src/matrix/inversewishart.jl
@@ -1,9 +1,21 @@
 """
-    InverseWishart(nu, P)
+```julia
+InverseWishart(ν, Ψ)
 
-The [Inverse Wishart distribution](http://en.wikipedia.org/wiki/Inverse-Wishart_distribution)
-is usually used as the conjugate prior for the covariance matrix of a multivariate normal
-distribution, which is characterized by a degree of freedom ν, and a base matrix Φ.
+ν::Real   degrees of freedom (greater than p - 1)
+Ψ::PDMat  p x p scale matrix
+```
+The [inverse Wishart distribution](http://en.wikipedia.org/wiki/Inverse-Wishart_distribution)
+generalizes the inverse gamma distribution to ``p\\times p`` real, positive definite
+matrices ``\\boldsymbol{\\Sigma}``. If ``\\boldsymbol{\\Sigma}\\sim IW_p(\\nu,\\boldsymbol{\\Psi})``,
+then its probability density function is
+
+```math
+f(\\boldsymbol{\\Sigma}; \\nu,\\boldsymbol{\\Psi}) =
+\\frac{\\left|\\boldsymbol{\\Psi}\\right|^{\\nu/2}}{2^{\\nu p/2}\\Gamma_p(\\frac{\\nu}{2})} \\left|\\boldsymbol{\\Sigma}\\right|^{-(\\nu+p+1)/2} e^{-\\frac{1}{2}\\operatorname{tr}(\\boldsymbol{\\Psi}\\boldsymbol{\\Sigma}^{-1})}.
+```
+
+``\\mathbf{H}\\sim W_p(\\nu, \\mathbf{S})`` if and only if ``\\mathbf{H}^{-1}\\sim IW_p(\\nu, \\mathbf{S}^{-1})``.
 """
 struct InverseWishart{T<:Real, ST<:AbstractPDMat} <: ContinuousMatrixDistribution
     df::T     # degree of freedom

--- a/src/matrix/matrixbeta.jl
+++ b/src/matrix/matrixbeta.jl
@@ -9,21 +9,21 @@ n2::Real  degrees of freedom (greater than p - 1)
 The [matrix beta distribution](https://en.wikipedia.org/wiki/Matrix_variate_beta_distribution)
 generalizes the beta distribution to ``p\\times p`` real matrices ``\\mathbf{U}``
 for which ``\\mathbf{U}`` and ``\\mathbf{I}_p-\\mathbf{U}`` are both positive definite.
-If ``\\mathbf{U}\\sim MB(n_1/2, n_2/2)``, then its probability density function is
+If ``\\mathbf{U}\\sim MB_p(n_1/2, n_2/2)``, then its probability density function is
 
 ```math
 f(\\mathbf{U}; n_1,n_2) = \\frac{\\Gamma_p(\\frac{n_1+n_2}{2})}{\\Gamma_p(\\frac{n_1}{2})\\Gamma_p(\\frac{n_2}{2})}
 |\\mathbf{U}|^{(n_1-p-1)/2}\\left|\\mathbf{I}_p-\\mathbf{U}\\right|^{(n_2-p-1)/2}.
 ```
 
-If ``\\mathbf{S}_1\\sim W(n_1,\\mathbf{I}_p)`` and ``\\mathbf{S}_2\\sim W(n_2,\\mathbf{I}_p)``
+If ``\\mathbf{S}_1\\sim W_p(n_1,\\mathbf{I}_p)`` and ``\\mathbf{S}_2\\sim W_p(n_2,\\mathbf{I}_p)``
 are independent, and we use ``\\mathcal{L}(\\cdot)`` to denote the lower Cholesky factor, then
 
 ```math
 \\mathbf{U}=\\mathcal{L}(\\mathbf{S}_1+\\mathbf{S}_2)^{-1}\\mathbf{S}_1\\mathcal{L}(\\mathbf{S}_1+\\mathbf{S}_2)^{-\\rm{T}}
 ```
 
-has ``\\mathbf{U}\\sim MB(n_1/2, n_2/2)``.
+has ``\\mathbf{U}\\sim MB_p(n_1/2, n_2/2)``.
 """
 struct MatrixBeta{T <: Real, TW <: Wishart} <: ContinuousMatrixDistribution
     W1::TW

--- a/src/matrix/matrixnormal.jl
+++ b/src/matrix/matrixnormal.jl
@@ -7,14 +7,14 @@ U::PDMat           n x n row covariance
 V::PDMat           p x p column covariance
 ```
 The [matrix normal distribution](https://en.wikipedia.org/wiki/Matrix_normal_distribution) generalizes the multivariate normal distribution to ``n\\times p`` real matrices ``\\mathbf{X}``.
-If ``\\mathbf{X}\\sim MN(\\mathbf{M}, \\mathbf{U}, \\mathbf{V})``, then its
+If ``\\mathbf{X}\\sim MN_{n,p}(\\mathbf{M}, \\mathbf{U}, \\mathbf{V})``, then its
 probability density function is
 
 ```math
 f(\\mathbf{X};\\mathbf{M}, \\mathbf{U}, \\mathbf{V}) = \\frac{\\exp\\left( -\\frac{1}{2} \\, \\mathrm{tr}\\left[ \\mathbf{V}^{-1} (\\mathbf{X} - \\mathbf{M})^{\\rm{T}} \\mathbf{U}^{-1} (\\mathbf{X} - \\mathbf{M}) \\right] \\right)}{(2\\pi)^{np/2} |\\mathbf{V}|^{n/2} |\\mathbf{U}|^{p/2}}.
 ```
 
-``\\mathbf{X}\\sim MN(\\mathbf{M},\\mathbf{U},\\mathbf{V})`` if and only if ``\\text{vec}(\\mathbf{X})\\sim N(\\text{vec}(\\mathbf{M}),\\mathbf{V}\\otimes\\mathbf{U})``.
+``\\mathbf{X}\\sim MN_{n,p}(\\mathbf{M},\\mathbf{U},\\mathbf{V})`` if and only if ``\\text{vec}(\\mathbf{X})\\sim N(\\text{vec}(\\mathbf{M}),\\mathbf{V}\\otimes\\mathbf{U})``.
 """
 struct MatrixNormal{T <: Real, TM <: AbstractMatrix, ST <: AbstractPDMat} <: ContinuousMatrixDistribution
 

--- a/src/matrix/matrixtdist.jl
+++ b/src/matrix/matrixtdist.jl
@@ -9,12 +9,12 @@ M::AbstractMatrix  n x p location
 ```
 The [matrix *t*-Distribution](https://en.wikipedia.org/wiki/Matrix_t-distribution)
 generalizes the multivariate *t*-Distribution to ``n\\times p`` real
-matrices ``\\mathbf{X}``. If ``\\mathbf{X}\\sim MT(\\nu,\\mathbf{M},\\boldsymbol{\\Sigma},
+matrices ``\\mathbf{X}``. If ``\\mathbf{X}\\sim MT_{n,p}(\\nu,\\mathbf{M},\\boldsymbol{\\Sigma},
 \\boldsymbol{\\Omega})``, then its probability density function is
 
 ```math
 f(\\mathbf{X} ; \\nu,\\mathbf{M},\\boldsymbol{\\Sigma}, \\boldsymbol{\\Omega}) =
-c_0 \\left|\\mathbf{I}_n + \\boldsymbol{\\Sigma}^{-1}(\\mathbf{X} - \\mathbf{M})\\boldsymbol{\\Omega}^{-1}(\\mathbf{X}-\\mathbf{M})'\\right|^{-\\frac{\\nu+n+p-1}{2}},
+c_0 \\left|\\mathbf{I}_n + \\boldsymbol{\\Sigma}^{-1}(\\mathbf{X} - \\mathbf{M})\\boldsymbol{\\Omega}^{-1}(\\mathbf{X}-\\mathbf{M})^{\\rm{T}}\\right|^{-\\frac{\\nu+n+p-1}{2}},
 ```
 
 where
@@ -28,13 +28,13 @@ is given by
 
 ```math
 \\begin{align*}
-\\mathbf{S}&\\sim IW(\\nu + n - 1, \\boldsymbol{\\Sigma})\\\\
-\\mathbf{X}|\\mathbf{S}&\\sim MN(\\mathbf{M}, \\mathbf{S}, \\boldsymbol{\\Omega}),
+\\mathbf{S}&\\sim IW_n(\\nu + n - 1, \\boldsymbol{\\Sigma})\\\\
+\\mathbf{X}|\\mathbf{S}&\\sim MN_{n,p}(\\mathbf{M}, \\mathbf{S}, \\boldsymbol{\\Omega}),
 \\end{align*}
 ```
 
 then the marginal distribution of ``\\mathbf{X}`` is
-``MT(\\nu,\\mathbf{M},\\boldsymbol{\\Sigma},\\boldsymbol{\\Omega})``.
+``MT_{n,p}(\\nu,\\mathbf{M},\\boldsymbol{\\Sigma},\\boldsymbol{\\Omega})``.
 """
 struct MatrixTDist{T <: Real, TM <: AbstractMatrix, ST <: AbstractPDMat} <: ContinuousMatrixDistribution
 

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -21,7 +21,7 @@ f(\\mathbf{H};\\nu,\\mathbf{S}) = \\frac{1}{2^{\\nu p/2} \\left|\\mathbf{S}\\rig
 If ``\\nu`` is an integer, then a random matrix ``\\mathbf{H}`` given by
 
 ```math
-\\mathbf{H} = \\mathbf{X}\\mathbf{X}', \\quad\\mathbf{X} \\sim MN_{p,\\nu}(\\mathbf{0}, \\mathbf{S}, \\mathbf{I}_{\\nu})
+\\mathbf{H} = \\mathbf{X}\\mathbf{X}^{\\rm{T}}, \\quad\\mathbf{X} \\sim MN_{p,\\nu}(\\mathbf{0}, \\mathbf{S}, \\mathbf{I}_{\\nu})
 ```
 
 has ``\\mathbf{H}\\sim W_p(\\nu, \\mathbf{S})``. For non-integer degrees of freedom,

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -3,11 +3,29 @@
 #   following the Wikipedia parameterization
 #
 """
-    Wishart(nu, S)
+```julia
+Wishart(ν, S)
 
-The [Wishart distribution](http://en.wikipedia.org/wiki/Wishart_distribution) is a
-multidimensional generalization of the Chi-square distribution, which is characterized by
-a degree of freedom ν, and a base matrix S.
+ν::Real   degrees of freedom (greater than p - 1)
+S::PDMat  p x p scale matrix
+```
+The [Wishart distribution](http://en.wikipedia.org/wiki/Wishart_distribution)
+generalizes the gamma distribution to ``p\\times p`` real, positive definite
+matrices ``\\mathbf{H}``. If ``\\mathbf{H}\\sim W_p(\\nu,\\mathbf{S})``, then its
+probability density function is
+
+```math
+f(\\mathbf{H};\\nu,\\mathbf{S}) = \\frac{1}{2^{\\nu p/2} \\left|\\mathbf{S}\\right|^{\\nu/2} \\Gamma_p\\left(\\frac {\\nu}{2}\\right ) }{\\left|\\mathbf{H}\\right|}^{(\\nu-p-1)/2} e^{-(1/2)\\operatorname{tr}(\\mathbf{S}^{-1}\\mathbf{H})}.
+```
+
+If ``\\nu`` is an integer, then a random matrix ``\\mathbf{H}`` given by
+
+```math
+\\mathbf{H} = \\mathbf{X}\\mathbf{X}', \\quad\\mathbf{X} \\sim MN_{p,\\nu}(\\mathbf{0}, \\mathbf{S}, \\mathbf{I}_{\\nu})
+```
+
+has ``\\mathbf{H}\\sim W_p(\\nu, \\mathbf{S})``. For non-integer degrees of freedom,
+Wishart matrices can be generated via the [Bartlett decomposition](https://en.wikipedia.org/wiki/Wishart_distribution#Bartlett_decomposition).
 """
 struct Wishart{T<:Real, ST<:AbstractPDMat} <: ContinuousMatrixDistribution
     df::T     # degree of freedom


### PR DESCRIPTION
Bring the documentation of `Wishart` and `InverseWishart` up to the standard of the documentation for [`FDist`](https://juliastats.github.io/Distributions.jl/stable/univariate/#Distributions.FDist), [`MvNormal`](https://juliastats.github.io/Distributions.jl/stable/multivariate/#Distributions.AbstractMvNormal), [`MatrixNormal`](https://juliastats.github.io/Distributions.jl/latest/matrix/#Distributions.MatrixNormal), [`MatrixBeta`](https://juliastats.github.io/Distributions.jl/latest/matrix/#Distributions.MatrixBeta), etc.