### PR TITLE
matrix-variate cleanup

### DIFF
--- a/src/matrix/inversewishart.jl
+++ b/src/matrix/inversewishart.jl
@@ -1,7 +1,6 @@
 """
+    InverseWishart(ν, Ψ)
 ```julia
-InverseWishart(ν, Ψ)
-
 ν::Real   degrees of freedom (greater than p - 1)
 Ψ::PDMat  p x p scale matrix
 ```

--- a/src/matrix/matrixbeta.jl
+++ b/src/matrix/matrixbeta.jl
@@ -1,7 +1,6 @@
 """
+    MatrixBeta(p, n1, n2)
 ```julia
-MatrixBeta(p, n1, n2)
-
 p::Int    dimension
 n1::Real  degrees of freedom (greater than p - 1)
 n2::Real  degrees of freedom (greater than p - 1)
@@ -36,18 +35,13 @@ end
 #  -----------------------------------------------------------------------------
 
 function MatrixBeta(p::Int, n1::Real, n2::Real)
-
     p > 0 || throw(ArgumentError("dim must be positive: got $(p)."))
-
     logc0 = matrixbeta_logc0(p, n1, n2)
-
     T = Base.promote_eltype(n1, n2, logc0)
     Ip = PDMat( Matrix{T}(I, p, p) )
     W1 = Wishart(T(n1), Ip)
     W2 = Wishart(T(n2), Ip)
-
     MatrixBeta{T, typeof(W1)}(W1, W2, T(logc0))
-
 end
 
 #  -----------------------------------------------------------------------------
@@ -96,19 +90,13 @@ mean(d::MatrixBeta) = ((n1, n2) = params(d); Matrix((n1 / (n1 + n2)) * I, dim(d)
 
 function matrixbeta_logc0(p::Int, n1::Real, n2::Real)
     #  returns the natural log of the normalizing constant for the pdf
-
     return logmvgamma(p, (n1 + n2)/2) - logmvgamma(p, n1/2) - logmvgamma(p, n2/2)
-    #return -logmvbeta(p, n1 / 2, n2 / 2)
-
 end
 
 function logkernel(d::MatrixBeta, U::AbstractMatrix)
-
     p = dim(d)
     n1, n2 = params(d)
-
     ((n1 - p - 1) / 2) * logdet(U) + ((n2 - p - 1) / 2) * logdet(I - U)
-
 end
 
 _logpdf(d::MatrixBeta, U::AbstractMatrix) = logkernel(d, U) + d.logc0
@@ -120,12 +108,9 @@ _logpdf(d::MatrixBeta, U::AbstractMatrix) = logkernel(d, U) + d.logc0
 #  Mitra (1970 Sankhyā)
 
 function _rand!(rng::AbstractRNG, d::MatrixBeta, A::AbstractMatrix)
-
     S1   = PDMat( rand(rng, d.W1) )
     S2   = PDMat( rand(rng, d.W2) )
     S    = S1 + S2
     invL = Matrix( inv(S.chol.L) )
-
     A .= X_A_Xt(S1, invL)
-
 end

--- a/src/matrix/matrixnormal.jl
+++ b/src/matrix/matrixnormal.jl
@@ -1,7 +1,6 @@
 """
+    MatrixNormal(M, U, V)
 ```julia
-MatrixNormal(M, U, V)
-
 M::AbstractMatrix  n x p mean
 U::PDMat           n x n row covariance
 V::PDMat           p x p column covariance
@@ -17,13 +16,10 @@ f(\\mathbf{X};\\mathbf{M}, \\mathbf{U}, \\mathbf{V}) = \\frac{\\exp\\left( -\\fr
 ``\\mathbf{X}\\sim MN_{n,p}(\\mathbf{M},\\mathbf{U},\\mathbf{V})`` if and only if ``\\text{vec}(\\mathbf{X})\\sim N(\\text{vec}(\\mathbf{M}),\\mathbf{V}\\otimes\\mathbf{U})``.
 """
 struct MatrixNormal{T <: Real, TM <: AbstractMatrix, ST <: AbstractPDMat} <: ContinuousMatrixDistribution
-
     M::TM
     U::ST
     V::ST
-
     logc0::T
-
 end
 
 #  -----------------------------------------------------------------------------
@@ -31,30 +27,20 @@ end
 #  -----------------------------------------------------------------------------
 
 function MatrixNormal(M::AbstractMatrix{T}, U::AbstractPDMat{T}, V::AbstractPDMat{T}) where T <: Real
-
     n, p = size(M)
-
     n == dim(U) || throw(ArgumentError("Number of rows of M must equal dim of U."))
     p == dim(V) || throw(ArgumentError("Number of columns of M must equal dim of V."))
-
     logc0 = matrixnormal_logc0(U, V)
-
     R = Base.promote_eltype(T, logc0)
-
     prom_M = convert(AbstractArray{R}, M)
     prom_U = convert(AbstractArray{R}, U)
     prom_V = convert(AbstractArray{R}, V)
-
     MatrixNormal{R, typeof(prom_M), typeof(prom_U)}(prom_M, prom_U, prom_V, R(logc0))
-
 end
 
 function MatrixNormal(M::AbstractMatrix, U::AbstractPDMat, V::AbstractPDMat)
-
     T = Base.promote_eltype(M, U, V)
-
     MatrixNormal(convert(AbstractArray{T}, M), convert(AbstractArray{T}, U), convert(AbstractArray{T}, V))
-
 end
 
 MatrixNormal(M::AbstractMatrix, U::Union{AbstractMatrix, LinearAlgebra.Cholesky}, V::Union{AbstractMatrix, LinearAlgebra.Cholesky}) = MatrixNormal(M, PDMat(U), PDMat(V))
@@ -110,20 +96,14 @@ params(d::MatrixNormal) = (d.M, d.U, d.V)
 #  -----------------------------------------------------------------------------
 
 function matrixnormal_logc0(U::AbstractPDMat, V::AbstractPDMat)
-
     n = dim(U)
     p = dim(V)
-
     -(n * p / 2) * (logtwo + logπ) - (n / 2) * logdet(V) - (p / 2) * logdet(U)
-
 end
 
 function logkernel(d::MatrixNormal, X::AbstractMatrix)
-
     A  = X - d.M
-
     -0.5 * tr( (d.V \ A') * (d.U \ A) )
-
 end
 
 _logpdf(d::MatrixNormal, X::AbstractMatrix) = logkernel(d, X) + d.logc0
@@ -133,13 +113,9 @@ _logpdf(d::MatrixNormal, X::AbstractMatrix) = logkernel(d, X) + d.logc0
 #  -----------------------------------------------------------------------------
 
 function _rand!(rng::AbstractRNG, d::MatrixNormal, A::AbstractMatrix)
-
     n, p = size(d)
-
     X = randn(rng, n, p)
-
     A .= d.M + d.U.chol.L * X * d.V.chol.U
-
 end
 
 #  -----------------------------------------------------------------------------

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -3,9 +3,8 @@
 #   following the Wikipedia parameterization
 #
 """
+    Wishart(ν, S)
 ```julia
-Wishart(ν, S)
-
 ν::Real   degrees of freedom (greater than p - 1)
 S::PDMat  p x p scale matrix
 ```

--- a/test/matrixnormal.jl
+++ b/test/matrixnormal.jl
@@ -142,11 +142,9 @@ end
 end
 
 @testset "MatrixNormal conversion" for elty in (Float32, Float64, BigFloat)
-
     Del1 = convert(MatrixNormal{elty}, D)
     Del2 = convert(MatrixNormal{elty}, M, PDU, PDV, D.logc0)
 
     @test partype(Del1) == elty
     @test partype(Del2) == elty
-
 end


### PR DESCRIPTION
Following suggestions made on JuliaStats/Distributions.jl#935, moves type names to the top of docstrings and eliminates extra whitespace.