### PR TITLE
Allow AbstractVector for mean of MvTDist

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,8 @@ Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Calculus", "Distributed", "ForwardDiff", "JSON", "Test"]
+test = ["Calculus", "Distributed", "ForwardDiff", "JSON", "StaticArrays", "Test"]

--- a/src/multivariate/mvtdist.jl
+++ b/src/multivariate/mvtdist.jl
@@ -48,9 +48,9 @@ end
 
 ## Construction of multivariate normal with specific covariance type
 
-const IsoTDist  = GenericMvTDist{Float64, ScalMat{Float64}}
-const DiagTDist = GenericMvTDist{Float64, PDiagMat{Float64,Vector{Float64}}}
-const MvTDist = GenericMvTDist{Float64, PDMat{Float64,Matrix{Float64}}}
+const IsoTDist  = GenericMvTDist{Float64, ScalMat{Float64}, Vector{Float64}}
+const DiagTDist = GenericMvTDist{Float64, PDiagMat{Float64,Vector{Float64}}, Vector{Float64}}
+const MvTDist = GenericMvTDist{Float64, PDMat{Float64,Matrix{Float64}}, Vector{Float64}}
 
 MvTDist(df::Real, μ::Vector{<:Real}, C::PDMat) = GenericMvTDist(df, μ, C)
 MvTDist(df::Real, C::PDMat) = GenericMvTDist(df, C)

--- a/src/multivariate/mvtdist.jl
+++ b/src/multivariate/mvtdist.jl
@@ -34,6 +34,9 @@ function GenericMvTDist(df::T, Σ::Cov) where {Cov<:AbstractPDMat, T<:Real}
     GenericMvTDist(df, zeros(R,dim(Σ)), Σ, true)
 end
 
+GenericMvTDist{T,Cov,Mean}(df, μ, Σ) where {T,Cov,Mean} =
+    GenericMvTDist(convert(T,df), convert(Mean, μ), convert(Cov, Σ))
+
 ### Conversion
 function convert(::Type{GenericMvTDist{T}}, d::GenericMvTDist) where T<:Real
     S = convert(AbstractArray{T}, d.Σ)

--- a/src/multivariate/mvtdist.jl
+++ b/src/multivariate/mvtdist.jl
@@ -4,33 +4,30 @@
 
 abstract type AbstractMvTDist <: ContinuousMultivariateDistribution end
 
-struct GenericMvTDist{T<:Real, Cov<:AbstractPDMat} <: AbstractMvTDist
+struct GenericMvTDist{T<:Real, Cov<:AbstractPDMat, Mean<:AbstractVector} <: AbstractMvTDist
     df::T # non-integer degrees of freedom allowed
     dim::Int
     zeromean::Bool
-    μ::Vector{T}
+    μ::Mean
     Σ::Cov
 
-    function GenericMvTDist{T,Cov}(df::T, dim::Int, zmean::Bool, μ::Vector{T}, Σ::AbstractPDMat{T}) where {T,Cov}
+    function GenericMvTDist{T,Cov,Mean}(df::T, dim::Int, zmean::Bool, μ::Mean, Σ::AbstractPDMat{T}) where {T,Cov,Mean}
       df > zero(df) || error("df must be positive")
-      new{T,Cov}(df, dim, zmean, μ, Σ)
+      new{T,Cov,Mean}(df, dim, zmean, μ, Σ)
     end
 end
 
-function GenericMvTDist(df::T, μ::Vector{T}, Σ::Cov, zmean::Bool) where {Cov<:AbstractPDMat, T<:Real}
+function GenericMvTDist(df::T, μ::Mean, Σ::Cov, zmean::Bool) where {Cov<:AbstractPDMat, Mean<:AbstractVector, T<:Real}
     d = length(μ)
     dim(Σ) == d || throw(DimensionMismatch("The dimensions of μ and Σ are inconsistent."))
-    R = Base.promote_eltype(T, Σ)
+    R = Base.promote_eltype(T, μ, Σ)
     S = convert(AbstractArray{R}, Σ)
-    GenericMvTDist{R, typeof(S)}(R(df), d, zmean, convert(AbstractArray{R}, μ), S)
+    m = convert(AbstractArray{R}, μ)
+    GenericMvTDist{R, typeof(S), typeof(m)}(R(df), d, zmean, m, S)
 end
 
-function GenericMvTDist(df::T, μ::Vector{S}, Σ::Cov, zmean::Bool) where {Cov<:AbstractPDMat, T<:Real, S<:Real}
-    R = promote_type(T, S)
-    GenericMvTDist(R(df), Vector{R}(μ), Σ, zmean)
-end
-
-GenericMvTDist(df::Real, μ::Vector{S}, Σ::Cov) where {Cov<:AbstractPDMat, S<:Real} = GenericMvTDist(df, μ, Σ, allzeros(μ))
+GenericMvTDist(df::Real, μ::Mean, Σ::Cov) where {Cov<:AbstractPDMat, Mean<:AbstractVector} =
+    GenericMvTDist(df, μ, Σ, allzeros(μ))
 
 function GenericMvTDist(df::T, Σ::Cov) where {Cov<:AbstractPDMat, T<:Real}
     R = Base.promote_eltype(T, Σ)
@@ -40,11 +37,13 @@ end
 ### Conversion
 function convert(::Type{GenericMvTDist{T}}, d::GenericMvTDist) where T<:Real
     S = convert(AbstractArray{T}, d.Σ)
-    GenericMvTDist{T, typeof(S)}(T(d.df), d.dim, d.zeromean, convert(AbstractArray{T}, d.μ), S)
+    m = convert(AbstractArray{T}, d.μ)
+    GenericMvTDist{T, typeof(S), typeof(m)}(T(d.df), d.dim, d.zeromean, m, S)
 end
 function convert(::Type{GenericMvTDist{T}}, df, dim, zeromean, μ::AbstractVector, Σ::AbstractPDMat) where T<:Real
     S = convert(AbstractArray{T}, Σ)
-    GenericMvTDist{T, typeof(S)}(T(df), dim, zeromean, convert(AbstractArray{T}, μ), S)
+    m = convert(AbstractArray{T}, μ)
+    GenericMvTDist{T, typeof(S), typeof(m)}(T(df), dim, zeromean, m, S)
 end
 
 ## Construction of multivariate normal with specific covariance type

--- a/test/mvtdist.jl
+++ b/test/mvtdist.jl
@@ -56,6 +56,8 @@ for i in 1:length(df)
     d = GenericMvTDist(df[i], mu_static, PDMat(Sigma))
     @test d.μ isa SVector
     @test isapprox(logpdf(d, [-2., 3]), rvalues[i], atol=1.0e-8)
-    # can't round-trip:
-    @test_broken dd = typeof(d)(params(d))
+    dd = typeof(d)(params(d)...)
+    @test d.df == dd.df
+    @test d.μ == dd.μ
+    @test Matrix(d.Σ) == Matrix(dd.Σ)
 end

--- a/test/mvtdist.jl
+++ b/test/mvtdist.jl
@@ -1,4 +1,4 @@
-using Distributions, Random
+using Distributions, Random, StaticArrays, LinearAlgebra
 using Test
 
 import Distributions: GenericMvTDist
@@ -46,3 +46,16 @@ d = GenericMvTDist(1, Array{Float32}(mu), PDMat(Array{Float32}(Sigma)))
 @test size(rand(MvTDist(1., mu, Sigma), 10)) == (2,10)
 @test size(rand(MersenneTwister(123), MvTDist(1., mu, Sigma))) == (2,)
 @test size(rand(MersenneTwister(123), MvTDist(1., mu, Sigma), 10)) == (2,10)
+
+# static array for mean/variance
+mu_static = @SVector [1., 2]
+# depends on PDMats#101 (merged but not released)
+# Sigma_static = @SMatrix [4. 2; 2 3]
+
+for i in 1:length(df)
+    d = GenericMvTDist(df[i], mu_static, PDMat(Sigma))
+    @test d.μ isa SVector
+    @test isapprox(logpdf(d, [-2., 3]), rvalues[i], atol=1.0e-8)
+    # can't round-trip:
+    @test_broken dd = typeof(d)(params(d))
+end


### PR DESCRIPTION
In my continuing quest to use static arrays in distributions, this widens the
mean of GenericMvTDist to be any `<:AbstractVector`, and adds a type parameter
to indicate the actual type.  I didn't widen the "convenience constructor"
methods, so anyone not calling the (un-exported) `GenericMvTDist` constructor
directly shouldn't be affected by this.