### PR TITLE
Add rank

### DIFF
--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -19,6 +19,7 @@ All distributions implement the same set of methods:
 ```@docs
 size(::MatrixDistribution)
 length(::MatrixDistribution)
+rank(::MatrixDistribution)
 mean(::MatrixDistribution)
 pdf{T<:Real}(d::MatrixDistribution, x::AbstractMatrix{T})
 logpdf{T<:Real}(d::MatrixDistribution, x::AbstractMatrix{T})

--- a/src/matrix/inversewishart.jl
+++ b/src/matrix/inversewishart.jl
@@ -56,6 +56,7 @@ insupport(d::InverseWishart, X::Matrix) = size(X) == size(d) && isposdef(X)
 dim(d::InverseWishart) = dim(d.Ψ)
 size(d::InverseWishart) = (p = dim(d); (p, p))
 size(d::InverseWishart, i) = size(d)[i]
+rank(d::InverseWishart) = dim(d)
 params(d::InverseWishart) = (d.df, d.Ψ, d.c0)
 @inline partype(d::InverseWishart{T}) where {T<:Real} = T
 

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -67,6 +67,7 @@ insupport(d::Wishart, X::Matrix) = size(X) == size(d) && isposdef(X)
 dim(d::Wishart) = dim(d.S)
 size(d::Wishart) = (p = dim(d); (p, p))
 size(d::Wishart, i) = size(d)[i]
+rank(d::Wishart) = dim(d)
 params(d::Wishart) = (d.df, d.S, d.c0)
 @inline partype(d::Wishart{T}) where {T<:Real} = T
 

--- a/src/matrixvariates.jl
+++ b/src/matrixvariates.jl
@@ -16,6 +16,13 @@ The length (*i.e* number of elements) of each sample from the distribution `d`.
 Base.length(d::MatrixDistribution)
 
 """
+    rank(d::MatrixDistribution)
+
+The rank of each sample from the distribution `d`.
+"""
+LinearAlgebra.rank(d::MatrixDistribution)
+
+"""
     vec(d::MatrixDistribution)
 
 If known, returns a `MultivariateDistribution` instance representing the

--- a/test/wisharts.jl
+++ b/test/wisharts.jl
@@ -19,6 +19,7 @@ rng = MersenneTwister(123)
         local d
         @test size(d) == size(func[1](d))
         @test length(d) == length(func[1](d))
+        @test rank(d) == rank(func[1](d))
         @test typeof(d)(params(d)...) == d
         @test partype(d) == Float64
     end


### PR DESCRIPTION
Make `rank` a standard method for matrix variate distributions.

Similar in spirit to `size` and `length`, `rank(d::MatrixDistribution)` returns the rank of each sample from `d`. Right now all of `Distributions.jl`'s matrix variate distributions are non-singular, so this functionality is a bit boring. But if/when we implement some singular matrix variate distributions (whose samples are reduced-rank matrices), then this will be more obviously useful.

This already exists for `MatrixNormal`, `MatrixTDist`, `MatrixBeta`, and `MatrixFDist`. This PR adds it for `Wishart` and `InverseWishart` and lists it in the docs. I am also in favor of re-exporting `rank` in the same way that we re-export `mean`, `var`, etc from `Statistics.jl`, but I know that this is more controversial, so for now I haven't done that.
