### PR TITLE
Use `kron` for PDMats

### DIFF
--- a/src/matrix/matrixnormal.jl
+++ b/src/matrix/matrixnormal.jl
@@ -122,4 +122,4 @@ end
 #  Transformation
 #  -----------------------------------------------------------------------------
 
-vec(d::MatrixNormal) = MvNormal(vec(d.M), kron(d.V.mat, d.U.mat))
+vec(d::MatrixNormal) = MvNormal(vec(d.M), kron(d.V, d.U))

--- a/src/matrix/matrixtdist.jl
+++ b/src/matrix/matrixtdist.jl
@@ -162,5 +162,5 @@ function MvTDist(MT::MatrixTDist)
     n, p = size(MT)
     all([n, p] .> 1) && error("Row or col dim of `MatrixTDist` must be 1 to coerce to `MvTDist`")
     ν, M, Σ, Ω = params(MT)
-    MvTDist(ν, vec(M), (1 / ν) * kron(Σ.mat, Ω.mat))
+    MvTDist(ν, vec(M), (1 / ν) * kron(Σ, Ω))
 end


### PR DESCRIPTION
The latest release of `PDMats` includes JuliaStats/PDMats.jl#100, which adds a `kron` method that takes `PDMat` instances. This PR uses this to improve two spots [here](https://github.com/johnczito/Distributions.jl/blob/a15c8ba2ced774910d0bd6e47087946a7ac8824a/src/matrix/matrixnormal.jl#L125) and [here](https://github.com/johnczito/Distributions.jl/blob/a15c8ba2ced774910d0bd6e47087946a7ac8824a/src/matrix/matrixtdist.jl#L165).