### PR TITLE
Possible replacement for #945

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -1,5 +1,7 @@
 module Distributions
 
+Base.ceil(::Type{Any}, x) = error("nonsensical")
+
 using StatsBase, PDMats, StatsFuns, Statistics
 using StatsFuns: logtwo, invsqrt2, invsqrt2π
 
@@ -35,6 +37,7 @@ export
     Matrixvariate,
     Discrete,
     Continuous,
+    Mixture,
     Sampleable,
     Distribution,
     UnivariateDistribution,

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -1,7 +1,5 @@
 module Distributions
 
-Base.ceil(::Type{Any}, x) = error("nonsensical")
-
 using StatsBase, PDMats, StatsFuns, Statistics
 using StatsFuns: logtwo, invsqrt2, invsqrt2π
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -57,7 +57,7 @@ The default element type of a sample. This is the type of elements of the sample
 by the `rand` method. However, one can provide an array of different element types to
 store the samples using `rand!`.
 """
-#Base.eltype(s::Sampleable{F,Discrete}) where {F} = Int
+Base.eltype(s::Sampleable{F,Discrete}) where {F} = Int # this is only a fallback
 Base.eltype(s::Sampleable{F,Continuous}) where {F} = Float64
 
 """

--- a/src/common.jl
+++ b/src/common.jl
@@ -10,12 +10,14 @@ struct Multivariate  <: VariateForm end
 struct Matrixvariate <: VariateForm end
 
 """
-`S <: ValueSupport` specifies the support of sample elements,
-either discrete or continuous.
+`S <: ValueSupport` specifies the type of the Distribution, whether it is
+discrete, continuous or a mixture of those.
 """
 abstract type ValueSupport end
 struct Discrete   <: ValueSupport end
 struct Continuous <: ValueSupport end
+struct Mixture <: ValueSupport end
+
 
 ## Sampleable
 
@@ -55,7 +57,7 @@ The default element type of a sample. This is the type of elements of the sample
 by the `rand` method. However, one can provide an array of different element types to
 store the samples using `rand!`.
 """
-Base.eltype(s::Sampleable{F,Discrete}) where {F} = Int
+#Base.eltype(s::Sampleable{F,Discrete}) where {F} = Int
 Base.eltype(s::Sampleable{F,Continuous}) where {F} = Float64
 
 """

--- a/src/functionals.jl
+++ b/src/functionals.jl
@@ -1,25 +1,25 @@
-function getEndpoints(distr::UnivariateDistribution, epsilon::Real)
+function support(distr::DiscreteUnivariateDistribution, epsilon::Real)
     (left,right) = map(x -> quantile(distr,x), (0,1))
     leftEnd = left!=-Inf ? left : quantile(distr, epsilon)
     rightEnd = right!=-Inf ? right : quantile(distr, 1-epsilon)
-    (leftEnd, rightEnd)
+    leftEnd:rightEnd
+end
+function support(distr::ContinuousUnivariateDistribution, epsilon::Real)
+    (left,right) = map(x -> quantile(distr,x), (0,1))
+    leftEnd = left!=-Inf ? left : quantile(distr, epsilon)
+    rightEnd = right!=-Inf ? right : quantile(distr, 1-epsilon)
+    RealInterval(leftEnd, rightEnd)
 end
 
-function expectation(distr::ContinuousUnivariateDistribution, g::Function, epsilon::Real)
-    f = x->pdf(distr,x)
-    (leftEnd, rightEnd) = getEndpoints(distr, epsilon)
-    integrate(x -> f(x)*g(x), leftEnd, rightEnd)
+
+function expectation(distr::ContinuousUnivariateDistribution, g::Function, epsilon::Real=1e-10)
+    s = support(distr, epsilon)
+    integrate(x -> pdf(distr, x)*g(x), s.lb, s.ub)
 end
 
-## Assuming that discrete distributions only take integer values.
-function expectation(distr::DiscreteUnivariateDistribution, g::Function, epsilon::Real)
-    f = x->pdf(distr,x)
-    (leftEnd, rightEnd) = getEndpoints(distr, epsilon)
-    sum(x -> f(x)*g(x), leftEnd:rightEnd)
-end
-
-function expectation(distr::UnivariateDistribution, g::Function)
-    expectation(distr, g, 1e-10)
+## Not assuming that discrete distributions only take integer values.
+function expectation(distr::DiscreteUnivariateDistribution, g::Function, epsilon::Real = 0)
+    sum(x -> pdf(distr, x)*g(x), support(distr, epsilon))
 end
 
 ## Leave undefined until we've implemented a numerical integration procedure

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -125,7 +125,7 @@ the components given by ``params``, and a prior probability vector.
 If no `prior` is provided then all components will have the same prior probabilities.
 """
 function MixtureModel(::Type{C}, params::AbstractArray) where C<:Distribution
-    components = C[_construct_component(C, a) for a in params]
+    components = [_construct_component(C, a) for a in params]
     MixtureModel(components)
 end
 
@@ -142,7 +142,7 @@ _construct_component(::Type{C}, arg) where {C<:Distribution} = C(arg)
 _construct_component(::Type{C}, args::Tuple) where {C<:Distribution} = C(args...)
 
 function MixtureModel(::Type{C}, params::AbstractArray, p::Vector{T}) where {C<:Distribution,T<:Real}
-    components = C[_construct_component(C, a) for a in params]
+    components = [_construct_component(C, a) for a in params]
     MixtureModel(components, p)
 end
 

--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -41,9 +41,8 @@ isupperbounded(d::Truncated) = isupperbounded(d.untruncated) || isfinite(d.upper
 minimum(d::Truncated) = max(minimum(d.untruncated), d.lower)
 maximum(d::Truncated) = min(maximum(d.untruncated), d.upper)
 
-insupport(d::Truncated{D,Union{Discrete,Continuous}}, x::Real) where {D<:UnivariateDistribution} =
-    d.lower <= x <= d.upper && insupport(d.untruncated, x)
-
+insupport(d::Truncated{D,VS}, x::Real) where {VS<:ValueSupport, D<:UnivariateDistribution{VS}} =
+	    d.lower <= x <= d.upper && insupport(d.untruncated, x)
 
 ### evaluation
 

--- a/src/univariate/discrete/categorical.jl
+++ b/src/univariate/discrete/categorical.jl
@@ -24,7 +24,7 @@ External links:
 
 * [Categorical distribution on Wikipedia](http://en.wikipedia.org/wiki/Categorical_distribution)
 """
-const Categorical{P,Ps} = DiscreteNonParametric{Int,P,Base.OneTo{Int},Ps}
+const Categorical{P,Ps} = DiscreteNonParametric{Int,Univariate,P,Base.OneTo{Int},Ps}
 
 Categorical{P,Ps}(p::Ps, ::NoArgCheck) where {P<:Real, Ps<:AbstractVector{P}} =
     Categorical{P,Ps}(Base.OneTo(length(p)), p, NoArgCheck())

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -123,12 +123,16 @@ end
 
 insupport(d::Union{D,Type{D}}, X::AbstractArray) where {D<:UnivariateDistribution} =
      insupport!(BitArray(undef, size(X)), d, X)
+insupport(d::Distribution{Univariate,Discrete}, X::AbstractArray) =
+     insupport!(BitArray(undef, size(X)), d, X)
 
 insupport(d::Union{D,Type{D}},x::Real) where {D<:ContinuousUnivariateDistribution} = minimum(d) <= x <= maximum(d)
-insupport(d::Union{D,Type{D}},x::Real) where {D<:DiscreteUnivariateDistribution} = isinteger(x) && minimum(d) <= x <= maximum(d)
+insupport(d::DiscreteUnivariateDistribution, x) = isinteger(x) && minimum(d) <= x <= maximum(d)
+insupport(d::Type{<:DiscreteUnivariateDistribution}, x) = isinteger(x) && minimum(d) <= x <= maximum(d)
 
 support(d::Union{D,Type{D}}) where {D<:ContinuousUnivariateDistribution} = RealInterval(minimum(d), maximum(d))
-support(d::Union{D,Type{D}}) where {D<:DiscreteUnivariateDistribution} = round(Int, minimum(d)):round(Int, maximum(d))
+support(d::DiscreteUnivariateDistribution) = round(Int, minimum(d)):round(Int, maximum(d))
+support(d::Type{<:DiscreteUnivariateDistribution}) = round(Int, minimum(d)):round(Int, maximum(d))
 
 # Type used for dispatch on finite support
 # T = true or false

--- a/test/locationscale.jl
+++ b/test/locationscale.jl
@@ -39,6 +39,7 @@ function test_location_scale_normal(μ::Real, σ::Real, μD::Real, σD::Real,
     #### Evaluation & Sampling
 
     insupport(d,0.4) == insupport(dref,0.4)
+    insupport(d,0.4) == insupport(dref,Dual(0.4))
     @test pdf(d,0.1) ≈ pdf(dref,0.1)
     @test pdf.(d,2:4) ≈ pdf.(dref,2:4)
     @test logpdf(d,0.4) ≈ logpdf(dref,0.4)

--- a/test/matrixnormal.jl
+++ b/test/matrixnormal.jl
@@ -10,6 +10,7 @@ p = 6
 
 M    = randn(n, p)
 U    = rand(InverseWishart(n + 2, Matrix(1.0I, n, n)))
+@test nsamples(InverseWishart, U) == 1
 V    = rand(InverseWishart(p + 2, Matrix(1.0I, p, p)))
 UF32 = Matrix{Float32}(U)
 VBF  = Matrix{BigFloat}(V)
@@ -138,6 +139,7 @@ end
 
 @testset "MatrixNormal sample moments" begin
     @test isapprox(mean(rand(D, 100000)), mean(D) , atol = 0.1)
+    @test nsamples(typeof(D), rand(D, 100)) == 100
     @test isapprox(cov(hcat(vec.(rand(D, 100000))...)'), kron(V, U) , atol = 0.1)
 end
 

--- a/test/mixture.jl
+++ b/test/mixture.jl
@@ -169,8 +169,18 @@ end
          "rand(rng, ...)" => MersenneTwister(123))
 
     @testset "Testing UnivariateMixture" begin
+        g_u32 = MixtureModel(Normal, [(0.0f0, 1.0f0), (2.0f0, 1.0f0), (-4.0f0, 1.5f0)])
+        @test isa(g_u32, MixtureModel{Univariate,
+                                      <: ContinuousSupport,
+                                      <: Normal})
+        @test isa(g_u32, MixtureModel{Univariate, ContinuousSupport{Float32},
+                                      Normal{Float32}})
         g_u = MixtureModel(Normal, [(0.0, 1.0), (2.0, 1.0), (-4.0, 1.5)], [0.2, 0.5, 0.3])
-        @test isa(g_u, MixtureModel{Univariate, Continuous, Normal})
+        @test isa(g_u, MixtureModel{Univariate,
+                                    <: ContinuousSupport,
+                                    <: Normal})
+        @test isa(g_u, MixtureModel{Univariate, <: ContinuousSupport{Float64},
+                                    Normal{Float64}})
         @test ncomponents(g_u) == 3
         test_mixture(g_u, 1000, 10^6, rng)
         test_params(g_u)

--- a/test/multinomial.jl
+++ b/test/multinomial.jl
@@ -142,6 +142,7 @@ end
     # random sampling
     X = Matrix{Int}(undef, length(p), 100)
     x = func(d, X)
+    @test nsamples(typeof(d), x) == 100
     @test x ≡ X
     @test isa(x, Matrix{Int})
     @test all(sum(x, dims=1) .== nt)
@@ -163,6 +164,7 @@ end
     @test x ≡ X
     @test all(sum.(x) .== nt)
     @test all(insupport(d, a) for a in x)
+    @test nsamples(typeof(d), x) == 100
 end
 
 @testset "Testing Multinomial with $key" for (key, func) in
@@ -175,6 +177,7 @@ end
     @test x1 ≡ X[1]
     @test all(sum.(x) .== nt)
     @test all(insupport(d, a) for a in x)
+    @test nsamples(typeof(d), x) == 100
 end
 
 repeats = 10
@@ -195,3 +198,5 @@ nt = 10
 d = Multinomial(nt, p)
 @test_throws DimensionMismatch rand!(d, m, false)
 @test_nowarn rand!(d, m)
+@test Distributions.variate_form(typeof(d)) ≡ Multivariate
+@test Distributions.value_support(typeof(d)) ≡ Discrete

--- a/test/multivariate_stats.jl
+++ b/test/multivariate_stats.jl
@@ -26,6 +26,7 @@ for d in [
     dent = entropy(d)
 
     x = rand(d, n_samples)
+    @test nsamples(d, x) == n_samples
     xmean = vec(mean(x, 2))
     z = x .- xmean
     xcov = (z * z') * (1 / n_samples)

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -25,7 +25,7 @@ end
 
 # testing the implementation of a discrete univariate distribution
 #
-function test_distr(distr::CountableUnivariateDistribution, n::Int;
+function test_distr(distr::DiscreteUnivariateDistribution, n::Int;
                     testquan::Bool=true)
 
     test_range(distr)
@@ -44,7 +44,7 @@ end
 
 # testing the implementation of a continuous univariate distribution
 #
-function test_distr(distr::UnivariateDistribution{<:ContinuousSupport}, n::Int;
+function test_distr(distr::ContinuousUnivariateDistribution, n::Int;
                     testquan::Bool=true, rng::AbstractRNG=MersenneTwister(123))
     test_range(distr)
     vs = get_evalsamples(distr, 0.01, 2000)
@@ -73,8 +73,8 @@ end
 
 # for discrete samplers
 #
-function test_samples(s::Sampleable{Univariate, <:CountableSupport}, # the sampleable instance
-                      distr::CountableUnivariateDistribution,        # corresponding distribution
+function test_samples(s::Sampleable{Univariate, Discrete}, # the sampleable instance
+                      distr::DiscreteUnivariateDistribution,        # corresponding distribution
                       n::Int;                                        # number of samples to generate
                       q::Float64=1.0e-7,                             # confidence interval, 1 - q as confidence
                       verbose::Bool=false,                           # show intermediate info (for debugging)
@@ -145,13 +145,13 @@ function test_samples(s::Sampleable{Univariate, <:CountableSupport}, # the sampl
     return samples
 end
 
-test_samples(distr::CountableUnivariateDistribution, n::Int;
+test_samples(distr::DiscreteUnivariateDistribution, n::Int;
              q::Float64=1.0e-6, verbose::Bool=false, rng=missing) =
     test_samples(distr, distr, n; q=q, verbose=verbose, rng=rng)
 
 # for continuous samplers
 #
-function test_samples(s::Sampleable{Univariate, <: ContinuousSupport}, # the sampleable instance
+function test_samples(s::Sampleable{Univariate, Continuous}, # the sampleable instance
                       distr::ContinuousUnivariateDistribution,  # corresponding distribution
                       n::Int;                                   # number of samples to generate
                       nbins::Int=50,                            # divide the main interval into nbins
@@ -239,7 +239,7 @@ function test_samples(s::Sampleable{Univariate, <: ContinuousSupport}, # the sam
     return samples
 end
 
-test_samples(distr::UnivariateDistribution{<:ContinuousSupport},
+test_samples(distr::UnivariateDistribution{Continuous},
              n::Int; nbins::Int=50, q::Float64=1.0e-6, verbose::Bool=false,
              rng=missing) =
     test_samples(distr, distr, n; nbins=nbins, q=q, verbose=verbose, rng=rng)
@@ -260,7 +260,7 @@ function test_range(d::UnivariateDistribution)
     @test isbounded(d) == (is_lb && is_ub)
 end
 
-function get_evalsamples(d::CountableUnivariateDistribution, q::Float64)
+function get_evalsamples(d::DiscreteUnivariateDistribution, q::Float64)
     # samples for testing evaluation functions (even spacing)
 
     T = eltype(d)
@@ -270,7 +270,7 @@ function get_evalsamples(d::CountableUnivariateDistribution, q::Float64)
     return lv:hv
 end
 
-function get_evalsamples(d::UnivariateDistribution{<:ContinuousSupport},
+function get_evalsamples(d::UnivariateDistribution{Continuous},
                          q::Float64, n::Int)
     # samples for testing evaluation functions (even spacing)
 
@@ -303,14 +303,14 @@ function test_support(d::UnivariateDistribution, vs::AbstractVector)
     @test isbounded(d) == (isupperbounded(d) && islowerbounded(d))
 
     if isbounded(d)
-        if isa(d, CountableUnivariateDistribution)
+        if isa(d, DiscreteUnivariateDistribution)
             s = support(d)
             @test isa(s, AbstractUnitRange)
             @test first(s) == minimum(d)
             @test last(s) == maximum(d)
         end
     end
-    if isa(d, UnivariateDistribution{<:ContinuousSupport})
+    if isa(d, ContinuousUnivariateDistribution)
         @test support(d) == RealInterval(minimum(d), maximum(d))
     end
 end
@@ -318,7 +318,7 @@ end
 
 #### Testing evaluation methods
 
-function test_range_evaluation(d::UnivariateDistribution{<:CountableSupport})
+function test_range_evaluation(d::DiscreteUnivariateDistribution)
     # check the consistency between range-based and ordinary pdf
     vmin = minimum(d)
     vmax = maximum(d)
@@ -350,7 +350,7 @@ function test_range_evaluation(d::UnivariateDistribution{<:CountableSupport})
 end
 
 
-function test_evaluation(d::CountableUnivariateDistribution,
+function test_evaluation(d::DiscreteUnivariateDistribution,
                          vs::AbstractVector, testquan::Bool=true)
     nv  = length(vs)
     p   = Vector{Float64}(undef, nv)
@@ -403,7 +403,7 @@ function test_evaluation(d::CountableUnivariateDistribution,
 end
 
 
-function test_evaluation(d::UnivariateDistribution{<:ContinuousSupport},
+function test_evaluation(d::ContinuousUnivariateDistribution,
                          vs::AbstractVector, testquan::Bool=true)
     nv  = length(vs)
     p   = Vector{Float64}(undef, nv)
@@ -479,7 +479,7 @@ end
 
 #### Testing statistics methods
 
-function test_stats(d::CountableUnivariateDistribution, vs::AbstractVector)
+function test_stats(d::DiscreteUnivariateDistribution, vs::AbstractVector)
     # using definition (or an approximation)
 
     vf = Float64[v for v in vs]
@@ -517,7 +517,7 @@ allow_test_stats(d::UnivariateDistribution) = true
 allow_test_stats(d::NoncentralBeta) = false
 allow_test_stats(::StudentizedRange) = false
 
-function test_stats(d::UnivariateDistribution{<:ContinuousSupport},
+function test_stats(d::ContinuousUnivariateDistribution,
                     xs::AbstractVector{Float64})
     # using Monte Carlo methods
 

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -25,7 +25,7 @@ end
 
 # testing the implementation of a discrete univariate distribution
 #
-function test_distr(distr::DiscreteUnivariateDistribution, n::Int;
+function test_distr(distr::CountableUnivariateDistribution, n::Int;
                     testquan::Bool=true)
 
     test_range(distr)
@@ -44,7 +44,7 @@ end
 
 # testing the implementation of a continuous univariate distribution
 #
-function test_distr(distr::ContinuousUnivariateDistribution, n::Int;
+function test_distr(distr::UnivariateDistribution{<:ContinuousSupport}, n::Int;
                     testquan::Bool=true, rng::AbstractRNG=MersenneTwister(123))
     test_range(distr)
     vs = get_evalsamples(distr, 0.01, 2000)
@@ -73,12 +73,12 @@ end
 
 # for discrete samplers
 #
-function test_samples(s::Sampleable{Univariate, Discrete},      # the sampleable instance
-                      distr::DiscreteUnivariateDistribution,    # corresponding distribution
-                      n::Int;                                   # number of samples to generate
-                      q::Float64=1.0e-7,                        # confidence interval, 1 - q as confidence
-                      verbose::Bool=false,                      # show intermediate info (for debugging)
-                      rng::Union{AbstractRNG, Missing}=missing) # add an rng?
+function test_samples(s::Sampleable{Univariate, <:CountableSupport}, # the sampleable instance
+                      distr::CountableUnivariateDistribution,        # corresponding distribution
+                      n::Int;                                        # number of samples to generate
+                      q::Float64=1.0e-7,                             # confidence interval, 1 - q as confidence
+                      verbose::Bool=false,                           # show intermediate info (for debugging)
+                      rng::Union{AbstractRNG, Missing}=missing)      # add an rng?
 
     # The basic idea
     # ------------------
@@ -145,13 +145,13 @@ function test_samples(s::Sampleable{Univariate, Discrete},      # the sampleable
     return samples
 end
 
-test_samples(distr::DiscreteUnivariateDistribution, n::Int;
+test_samples(distr::CountableUnivariateDistribution, n::Int;
              q::Float64=1.0e-6, verbose::Bool=false, rng=missing) =
     test_samples(distr, distr, n; q=q, verbose=verbose, rng=rng)
 
 # for continuous samplers
 #
-function test_samples(s::Sampleable{Univariate, Continuous},    # the sampleable instance
+function test_samples(s::Sampleable{Univariate, <: ContinuousSupport}, # the sampleable instance
                       distr::ContinuousUnivariateDistribution,  # corresponding distribution
                       n::Int;                                   # number of samples to generate
                       nbins::Int=50,                            # divide the main interval into nbins
@@ -239,7 +239,9 @@ function test_samples(s::Sampleable{Univariate, Continuous},    # the sampleable
     return samples
 end
 
-test_samples(distr::ContinuousUnivariateDistribution, n::Int; nbins::Int=50, q::Float64=1.0e-6, verbose::Bool=false, rng=missing) =
+test_samples(distr::UnivariateDistribution{<:ContinuousSupport},
+             n::Int; nbins::Int=50, q::Float64=1.0e-6, verbose::Bool=false,
+             rng=missing) =
     test_samples(distr, distr, n; nbins=nbins, q=q, verbose=verbose, rng=rng)
 
 
@@ -258,7 +260,7 @@ function test_range(d::UnivariateDistribution)
     @test isbounded(d) == (is_lb && is_ub)
 end
 
-function get_evalsamples(d::DiscreteUnivariateDistribution, q::Float64)
+function get_evalsamples(d::CountableUnivariateDistribution, q::Float64)
     # samples for testing evaluation functions (even spacing)
 
     T = eltype(d)
@@ -268,7 +270,8 @@ function get_evalsamples(d::DiscreteUnivariateDistribution, q::Float64)
     return lv:hv
 end
 
-function get_evalsamples(d::ContinuousUnivariateDistribution, q::Float64, n::Int)
+function get_evalsamples(d::UnivariateDistribution{<:ContinuousSupport},
+                         q::Float64, n::Int)
     # samples for testing evaluation functions (even spacing)
 
     lv = quantile(d, q/2)
@@ -280,8 +283,11 @@ end
 function test_support(d::UnivariateDistribution, vs::AbstractVector)
     for v in vs
         @test insupport(d, v)
+        @test nsamples(typeof(d), v) == 1
     end
+    @test length(d) == 1
     @test all(insupport(d, vs))
+    @test nsamples(typeof(d), collect(vs)) == length(vs)
 
     if islowerbounded(d)
         @test isfinite(minimum(d))
@@ -297,19 +303,22 @@ function test_support(d::UnivariateDistribution, vs::AbstractVector)
     @test isbounded(d) == (isupperbounded(d) && islowerbounded(d))
 
     if isbounded(d)
-        if isa(d, DiscreteUnivariateDistribution)
+        if isa(d, CountableUnivariateDistribution)
             s = support(d)
             @test isa(s, AbstractUnitRange)
             @test first(s) == minimum(d)
             @test last(s) == maximum(d)
         end
     end
+    if isa(d, UnivariateDistribution{<:ContinuousSupport})
+        @test support(d) == RealInterval(minimum(d), maximum(d))
+    end
 end
 
 
 #### Testing evaluation methods
 
-function test_range_evaluation(d::DiscreteUnivariateDistribution)
+function test_range_evaluation(d::UnivariateDistribution{<:CountableSupport})
     # check the consistency between range-based and ordinary pdf
     vmin = minimum(d)
     vmax = maximum(d)
@@ -341,7 +350,8 @@ function test_range_evaluation(d::DiscreteUnivariateDistribution)
 end
 
 
-function test_evaluation(d::DiscreteUnivariateDistribution, vs::AbstractVector, testquan::Bool=true)
+function test_evaluation(d::CountableUnivariateDistribution,
+                         vs::AbstractVector, testquan::Bool=true)
     nv  = length(vs)
     p   = Vector{Float64}(undef, nv)
     c   = Vector{Float64}(undef, nv)
@@ -393,7 +403,8 @@ function test_evaluation(d::DiscreteUnivariateDistribution, vs::AbstractVector, 
 end
 
 
-function test_evaluation(d::ContinuousUnivariateDistribution, vs::AbstractVector, testquan::Bool=true)
+function test_evaluation(d::UnivariateDistribution{<:ContinuousSupport},
+                         vs::AbstractVector, testquan::Bool=true)
     nv  = length(vs)
     p   = Vector{Float64}(undef, nv)
     c   = Vector{Float64}(undef, nv)
@@ -429,10 +440,14 @@ function test_evaluation(d::ContinuousUnivariateDistribution, vs::AbstractVector
             qtol = isa(d, InverseGaussian) ? 1.0e-4 : 1.0e-10
             qtol = isa(d, StudentizedRange) ? 1.0e-5 : qtol
             if p[i] > 1.0e-6
-                @test isapprox(quantile(d, c[i])    , v, atol=qtol * (abs(v) + 1.0))
-                @test isapprox(cquantile(d, cc[i])  , v, atol=qtol * (abs(v) + 1.0))
-                @test isapprox(invlogcdf(d, lc[i])  , v, atol=qtol * (abs(v) + 1.0))
-                @test isapprox(invlogccdf(d, lcc[i]), v, atol=qtol * (abs(v) + 1.0))
+                @test isapprox(quantile(d, c[i])    , v,
+                               atol=qtol * (abs(v) + 1.0))
+                @test isapprox(cquantile(d, cc[i])  , v,
+                               atol=qtol * (abs(v) + 1.0))
+                @test isapprox(invlogcdf(d, lc[i])  , v,
+                               atol=qtol * (abs(v) + 1.0))
+                @test isapprox(invlogccdf(d, lcc[i]), v,
+                               atol=qtol * (abs(v) + 1.0))
             end
         end
     end
@@ -464,7 +479,7 @@ end
 
 #### Testing statistics methods
 
-function test_stats(d::DiscreteUnivariateDistribution, vs::AbstractVector)
+function test_stats(d::CountableUnivariateDistribution, vs::AbstractVector)
     # using definition (or an approximation)
 
     vf = Float64[v for v in vs]
@@ -502,7 +517,8 @@ allow_test_stats(d::UnivariateDistribution) = true
 allow_test_stats(d::NoncentralBeta) = false
 allow_test_stats(::StudentizedRange) = false
 
-function test_stats(d::ContinuousUnivariateDistribution, xs::AbstractVector{Float64})
+function test_stats(d::UnivariateDistribution{<:ContinuousSupport},
+                    xs::AbstractVector{Float64})
     # using Monte Carlo methods
 
     if !(isfinite(mean(d)) && isfinite(var(d)))
@@ -511,6 +527,7 @@ function test_stats(d::ContinuousUnivariateDistribution, xs::AbstractVector{Floa
     vd = var(d)
 
     n = length(xs)
+    @test length(d) == 1
     xmean = mean(xs)
     xvar = var(xs)
     xstd = sqrt(xvar)


### PR DESCRIPTION
This is how I would approach #945, just as a start. It basically shows how to get the support business working without making the `eltype` a type parameter of the `support`. It helps to define `support(d, epsilon)` to find the numerical relevant support of unbounded distributions.

I illustrate how the type signature of `DiscreteNonParametric` can be extended to allow uni- and multivariate nonparametric distributions. 

The crux is, that `Discrete` does not need to imply that the support is only `Int`. All discrete distributions in the original meaning of the word (outcomes can be enumerated, e.g https://en.wikipedia.org/wiki/Probability_mass_function) can also by of `ValueSupport` type `Discrete`. I introduced some errors, so this is really just a sketch.