### PR TITLE
Make PoissonBinomial support ForwardDiff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,10 +25,11 @@ julia = "1"
 [extras]
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Calculus", "Distributed", "ForwardDiff", "JSON", "StaticArrays", "Test"]
+test = ["Calculus", "Distributed", "FiniteDifferences", "ForwardDiff", "JSON", "StaticArrays", "Test"]

--- a/src/univariate/discrete/poissonbinomial.jl
+++ b/src/univariate/discrete/poissonbinomial.jl
@@ -123,11 +123,11 @@ end
 #     On computing the distribution function for the Poisson binomial
 #     distribution. Computational Statistics and Data Analysis, 59, 41–51.
 #
-function poissonbinomial_pdf_fft(p::AbstractArray)
+function poissonbinomial_pdf_fft(p::AbstractArray{T}) where {T}
     n = length(p)
     ω = 2 / (n + 1)
 
-    x = Vector{Complex{Float64}}(undef, n+1)
+    x = Vector{Complex{T}}(undef, n+1)
     lmax = ceil(Int, n/2)
     x[1] = 1/(n + 1)
     for l=1:lmax

--- a/src/univariate/discrete/poissonbinomial.jl
+++ b/src/univariate/discrete/poissonbinomial.jl
@@ -123,16 +123,16 @@ end
 #     On computing the distribution function for the Poisson binomial
 #     distribution. Computational Statistics and Data Analysis, 59, 41–51.
 #
-function poissonbinomial_pdf_fft(p::AbstractArray{T}) where {T}
+function poissonbinomial_pdf_fft(p::AbstractArray{T}) where {T <: Real}
     n = length(p)
-    ω = 2 / (n + 1)
+    ω = 2 * one(T) / (n + 1)
 
     x = Vector{Complex{T}}(undef, n+1)
     lmax = ceil(Int, n/2)
-    x[1] = 1/(n + 1)
+    x[1] = one(T)/(n + 1)
     for l=1:lmax
-        logz = 0.
-        argz = 0.
+        logz = zero(T)
+        argz = zero(T)
         for j=1:n
             zjl = 1 - p[j] + p[j] * cospi(ω*l) + im * p[j] * sinpi(ω * l)
             logz += log(abs(zjl))

--- a/test/poissonbinomial.jl
+++ b/test/poissonbinomial.jl
@@ -1,6 +1,6 @@
 using Distributions
+using FiniteDifferences, ForwardDiff
 using Test
-
 
 # Test the special base where PoissonBinomial distribution reduces
 # to Binomial distribution
@@ -92,3 +92,9 @@ end
                 -4.0 - 9.65685424949238im]
     @test x ≈ fftw_fft
 end
+
+# Test autodiff using ForwardDiff
+f = x -> logpdf(PoissonBinomial(x), 0)
+at = [0.5, 0.5]
+fdm(i) = central_fdm(5, 1)(x -> f([at[1:i-1]; x; at[i+1:end]]), at[i])
+@test isapprox(ForwardDiff.gradient(f, at), fdm.(1:2), atol=1e-6)


### PR DESCRIPTION
This PR enables forward differentiation through the `PoissonBinomial` distribution.