### PR TITLE
Added insupport for Product-type distributions

### DIFF
--- a/src/multivariate/product.jl
+++ b/src/multivariate/product.jl
@@ -33,6 +33,7 @@ mean(d::Product) = mean.(d.v)
 var(d::Product) = var.(d.v)
 cov(d::Product) = Diagonal(var(d))
 entropy(d::Product) = sum(entropy, d.v)
+insupport(d::Product, x::AbstractArray) = all(insupport.(d.v, x))
 
 """
     product_distribution(dists::AbstractVector{<:UnivariateDistribution})

--- a/test/product.jl
+++ b/test/product.jl
@@ -38,5 +38,7 @@ let
     @test var(d_product) == var.(ds)
     @test cov(d_product) == Diagonal(var.(ds))
     @test entropy(d_product) == sum(entropy.(ds))
+    @test insupport(d_product, ubound) == true
+    @test insupport(d_product, ubound .+ 1) == false
 end
 end


### PR DESCRIPTION
Currently insupport is not defined for distributions constructed with product_distribution, e.g.

```
prod = product_distribution([Uniform(0,1), Uniform(2,3)])  
insupport(prod, [0.5, 2.5]) 
```
yields:
```
ERROR: MethodError: no method matching insupport(::Product{Continuous,Uniform{Float64},Array{Uniform{Float64},1}}, ::Array{Float64,1})
```

This does work for a product of Normal distributions however, since the MvNormal constructor is called instead.

I fixed the problem with:
```
insupport(d::Product, x::AbstractArray) = all(insupport.(d.v, x))
```
Hopefully that's the intended behaviour of product distributions.