### PR TITLE
Make Multinomial support Tracker AD

### DIFF
--- a/src/multivariate/multinomial.jl
+++ b/src/multivariate/multinomial.jl
@@ -22,10 +22,7 @@ Multinomial(n, k)   # Multinomial distribution for n trials with equal probabili
 struct Multinomial{T<:Real, TV<:AbstractVector{T}} <: DiscreteMultivariateDistribution
     n::Int
     p::TV
-
-    Multinomial{T}(n::Integer, p::TV) where {T, TV<:AbstractVector{T}} = new{T, TV}(Int(n), p)
 end
-
 function Multinomial(n::Integer, p::AbstractVector{T}; check_args=true) where {T<:Real}
     if check_args
         if n < 0
@@ -52,8 +49,9 @@ params(d::Multinomial) = (d.n, d.p)
 
 ### Conversions
 convert(::Type{Multinomial{T, TV}}, d::Multinomial) where {T<:Real, TV<:AbstractVector{T}} = Multinomial(d.n, TV(d.p))
-convert(::Type{Multinomial{T, TV}}, n, p::Vector) where {T<:Real, TV<:AbstractVector} = Multinomial(n, TV(p))
-
+convert(::Type{Multinomial{T, TV}}, n, p::AbstractVector) where {T<:Real, TV<:AbstractVector} = Multinomial(n, TV(p))
+convert(::Type{Multinomial{T}}, d::Multinomial) where {T<:Real} = Multinomial(d.n, T.(d.p))
+convert(::Type{Multinomial{T}}, n, p::AbstractVector) where {T<:Real} = Multinomial(n, T.(p))
 # Statistics
 
 mean(d::Multinomial) = d.n .* d.p

--- a/src/multivariate/multinomial.jl
+++ b/src/multivariate/multinomial.jl
@@ -19,14 +19,14 @@ Multinomial(n, k)   # Multinomial distribution for n trials with equal probabili
                     # over 1:k
 ```
 """
-struct Multinomial{T<:Real} <: DiscreteMultivariateDistribution
+struct Multinomial{T<:Real, TV<:AbstractVector{T}} <: DiscreteMultivariateDistribution
     n::Int
-    p::Vector{T}
+    p::TV
 
-    Multinomial{T}(n::Integer, p::Vector{T}) where {T} = new{T}(Int(n), p)
+    Multinomial{T}(n::Integer, p::TV) where {T, TV<:AbstractVector{T}} = new{T, TV}(Int(n), p)
 end
 
-function Multinomial(n::Integer, p::Vector{T}; check_args=true) where {T<:Real}
+function Multinomial(n::Integer, p::AbstractVector{T}; check_args=true) where {T<:Real}
     if check_args
         if n < 0
             throw(ArgumentError("n must be a nonnegative integer."))
@@ -51,8 +51,8 @@ params(d::Multinomial) = (d.n, d.p)
 @inline partype(d::Multinomial{T}) where {T<:Real} = T
 
 ### Conversions
-convert(::Type{Multinomial{T}}, d::Multinomial) where {T<:Real} = Multinomial(d.n, Vector{T}(d.p))
-convert(::Type{Multinomial{T}}, n, p::Vector) where {T<:Real} = Multinomial(n, Vector{T}(p))
+convert(::Type{Multinomial{T, TV}}, d::Multinomial) where {T<:Real, TV<:AbstractVector{T}} = Multinomial(d.n, TV(d.p))
+convert(::Type{Multinomial{T, TV}}, n, p::Vector) where {T<:Real, TV<:AbstractVector} = Multinomial(n, TV(p))
 
 # Statistics
 

--- a/src/samplers/multinomial.jl
+++ b/src/samplers/multinomial.jl
@@ -1,5 +1,5 @@
 
-function multinom_rand!(n::Int, p::Vector{Float64},
+function multinom_rand!(n::Int, p::AbstractVector{Float64},
                         x::AbstractVector{T}) where T<:Real
     k = length(p)
     length(x) == k || throw(DimensionMismatch("Invalid argument dimension."))
@@ -39,7 +39,7 @@ function multinom_rand!(n::Int, p::Vector{Float64},
     return x
 end
 
-function multinom_rand!(rng::AbstractRNG, n::Int, p::Vector{Float64},
+function multinom_rand!(rng::AbstractRNG, n::Int, p::AbstractVector{Float64},
                         x::AbstractVector{T}) where T<:Real
     k = length(p)
     length(x) == k || throw(DimensionMismatch("Invalid argument dimension."))

--- a/test/multinomial.jl
+++ b/test/multinomial.jl
@@ -27,10 +27,12 @@ rng = MersenneTwister(123)
 @test partype(Multinomial(nt, Vector{Float32}(p))) == Float32
 
 # Conversion
-@test typeof(d) == Multinomial{Float64}
-@test typeof(Multinomial(nt, Vector{Float32}(p))) == Multinomial{Float32}
-@test typeof(convert(Multinomial{Float32}, d)) == Multinomial{Float32}
-@test typeof(convert(Multinomial{Float32}, params(d)...)) == Multinomial{Float32}
+@test typeof(d) == Multinomial{Float64, Vector{Float64}}
+@test typeof(Multinomial(nt, Vector{Float32}(p))) == Multinomial{Float32, Vector{Float32}}
+@test typeof(convert(Multinomial{Float32}, d)) == Multinomial{Float32, Vector{Float32}}
+@test typeof(convert(Multinomial{Float32, Vector{Float32}}, d)) == Multinomial{Float32, Vector{Float32}}
+@test typeof(convert(Multinomial{Float32}, params(d)...)) == Multinomial{Float32, Vector{Float32}}
+@test typeof(convert(Multinomial{Float32, Vector{Float32}}, params(d)...)) == Multinomial{Float32, Vector{Float32}}
 
 # random sampling
 

--- a/test/multinomial.jl
+++ b/test/multinomial.jl
@@ -1,6 +1,6 @@
 # Tests for Multinomial
 
-using Distributions, Random
+using Distributions, Random, StaticArrays
 using Test
 
 
@@ -136,6 +136,11 @@ d0 = Multinomial(0, p)
 @test insupport(d0, [0, 0, 4]) == false
 @test length(d0) == 3
 @test size(d0) == (3,)
+
+# Abstract vector p
+
+@test typeof(Multinomial(nt, SVector{length(p), Float64}(p))) == Multinomial{Float64, SVector{3, Float64}}
+
 end
 
 @testset "Testing Multinomial with $key" for (key, func) in


### PR DESCRIPTION
This PR makes the `Multinomial` distribution support `Tracker` AD. Here is an example that works with this PR but not on `master`:
```julia
using Tracker, Distributions
Tracker.gradient((p) -> logpdf(Multinomial(2, p / sum(p)), [2, 0]), fill(0.5, 2))
```