### PR TITLE
Make Truncated support autodiff

### DIFF
--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -8,28 +8,31 @@ Construct a truncated distribution.
 - `l::Real`: The lower bound of the truncation, which can be a finite value or `-Inf`.
 - `u::Real`: The upper bound of the truncation, which can be a finite value of `Inf`.
 """
-struct Truncated{D<:UnivariateDistribution, S<:ValueSupport} <: UnivariateDistribution{S}
+struct Truncated{D<:UnivariateDistribution, S<:ValueSupport, T <: Real} <: UnivariateDistribution{S}
     untruncated::D      # the original distribution (untruncated)
-    lower::Float64      # lower bound
-    upper::Float64      # upper bound
-    lcdf::Float64       # cdf of lower bound
-    ucdf::Float64       # cdf of upper bound
+    lower::T      # lower bound
+    upper::T      # upper bound
+    lcdf::T       # cdf of lower bound
+    ucdf::T       # cdf of upper bound
 
-    tp::Float64         # the probability of the truncated part, i.e. ucdf - lcdf
-    logtp::Float64      # log(tp), i.e. log(ucdf - lcdf)
+    tp::T         # the probability of the truncated part, i.e. ucdf - lcdf
+    logtp::T      # log(tp), i.e. log(ucdf - lcdf)
+    function Truncated(d::UnivariateDistribution, l::T, u::T, lcdf::T, ucdf::T, tp::T, logtp::T) where {T <: Real}
+        new{typeof(d), value_support(typeof(d)), T}(d, l, u, lcdf, ucdf, tp, logtp)
+    end
 end
 
 ### Constructors
-
-function Truncated(d::UnivariateDistribution, l::Float64, u::Float64)
+function Truncated(d::UnivariateDistribution, l::T, u::T) where {T <: Real}
     l < u || error("lower bound should be less than upper bound.")
-    lcdf = isinf(l) ? 0.0 : cdf(d, l)
-    ucdf = isinf(u) ? 1.0 : cdf(d, u)
+    T2 = promote_type(T, eltype(d))
+    lcdf = isinf(l) ? zero(T2) : T2(cdf(d, l))
+    ucdf = isinf(u) ? one(T2) : T2(cdf(d, u))
     tp = ucdf - lcdf
-    Truncated{typeof(d),value_support(typeof(d))}(d, l, u, lcdf, ucdf, tp, log(tp))
+    Truncated(d, promote(l, u, lcdf, ucdf, tp, log(tp))...)
 end
-
-Truncated(d::UnivariateDistribution, l::Real, u::Real) = Truncated(d, Float64(l), Float64(u))
+Truncated(d::UnivariateDistribution, l::Real, u::Real) = Truncated(d, promote(l, u)...)
+Truncated(d::UnivariateDistribution, l::Integer, u::Integer) = Truncated(d, Float64.((l, u))...)
 
 params(d::Truncated) = tuple(params(d.untruncated)..., d.lower, d.upper)
 partype(d::Truncated) = partype(d.untruncated)

--- a/src/truncated/normal.jl
+++ b/src/truncated/normal.jl
@@ -6,11 +6,8 @@ The *truncated normal distribution* is a particularly important one in the famil
 We provide additional support for this type with `TruncatedNormal` which calls `Truncated(Normal(mu, sigma), l, u)`.
 Unlike the general case, truncated normal distributions support `mean`, `mode`, `modes`, `var`, `std`, and `entropy`.
 """
-TruncatedNormal(mu::Float64, sigma::Float64, a::Float64, b::Float64) =
-    Truncated(Normal(mu, sigma), a, b)
-
 TruncatedNormal(mu::Real, sigma::Real, a::Real, b::Real) =
-    TruncatedNormal(Float64(mu), Float64(sigma), Float64(a), Float64(b))
+    Truncated(Normal(mu, sigma), a, b)
 
 ### statistics
 

--- a/src/truncated/uniform.jl
+++ b/src/truncated/uniform.jl
@@ -2,4 +2,4 @@
 ##### Shortcut for truncating uniform distributions.
 #####
 
-Truncated(d::Uniform, l::Float64, u::Float64) = Uniform(max(l, d.a), min(u, d.b))
+Truncated(d::Uniform, l::Real, u::Real) = Uniform(promote(max(l, d.a), min(u, d.b))...)

--- a/src/truncated/uniform.jl
+++ b/src/truncated/uniform.jl
@@ -3,3 +3,4 @@
 #####
 
 Truncated(d::Uniform, l::Real, u::Real) = Uniform(promote(max(l, d.a), min(u, d.b))...)
+Truncated(d::Uniform, l::Integer, u::Integer) = Uniform(max(l, d.a), min(u, d.b))

--- a/test/poissonbinomial.jl
+++ b/test/poissonbinomial.jl
@@ -96,5 +96,4 @@ end
 # Test autodiff using ForwardDiff
 f = x -> logpdf(PoissonBinomial(x), 0)
 at = [0.5, 0.5]
-fdm(i) = central_fdm(5, 1)(x -> f([at[1:i-1]; x; at[i+1:end]]), at[i])
-@test isapprox(ForwardDiff.gradient(f, at), fdm.(1:2), atol=1e-6)
+@test isapprox(ForwardDiff.gradient(f, at), fdm(f, at), atol=1e-6)

--- a/test/poissonbinomial.jl
+++ b/test/poissonbinomial.jl
@@ -1,5 +1,4 @@
 using Distributions
-using FiniteDifferences, ForwardDiff
 using Test
 
 # Test the special base where PoissonBinomial distribution reduces

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -557,3 +557,10 @@ function test_params(d::Truncated)
     d_new = Truncated(D(pars...), d.lower, d.upper)
     @test d_new == d
 end
+
+# Finite difference differentiation
+function fdm(f, at)
+    map(1:length(at)) do i 
+        central_fdm(5, 1)(x -> f([at[1:i-1]; x; at[i+1:end]]), at[i])
+    end
+end

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -1,6 +1,6 @@
 # Utilities to support the testing of distributions and samplers
 
-using Printf
+using Printf, FiniteDifferences
 import Test: @test
 
 # auxiliary functions

--- a/test/truncate.jl
+++ b/test/truncate.jl
@@ -3,7 +3,7 @@
 module TestTruncate
 
 using Distributions
-using ForwardDiff: Dual
+using ForwardDiff: Dual, ForwardDiff
 import JSON
 using Test
 

--- a/test/truncate.jl
+++ b/test/truncate.jl
@@ -136,4 +136,10 @@ for c in ["discrete",
     println()
 end
 
+## automatic differentiation
+
+f = x -> logpdf(Truncated(Normal(x[1], x[2]), x[3], x[4]), mean(x))
+at = [0.0, 1.0, 0.0, 1.0]
+@test isapprox(ForwardDiff.gradient(f, at), fdm(f, at), atol=1e-6)
+
 end

--- a/test/truncate.jl
+++ b/test/truncate.jl
@@ -6,7 +6,7 @@ using Distributions
 using ForwardDiff: Dual, ForwardDiff
 import JSON
 using Test
-
+using ..Main: fdm
 
 function verify_and_test_drive(jsonfile, selected, n_tsamples::Int,lower::Int,upper::Int)
     R = JSON.parsefile(jsonfile)

--- a/test/truncate.jl
+++ b/test/truncate.jl
@@ -78,10 +78,10 @@ function verify_and_test(d::UnivariateDistribution, dct::Dict, n_tsamples::Int)
         end
         @test isapprox(cdf(d, x)   , cf, atol=sqrt(eps()))
         # NOTE: some distributions use pdf() in StatsFuns.jl which have no generic support yet
-        if !(typeof(d) in [Distributions.Truncated{Distributions.NoncentralChisq{Float64},Distributions.Continuous},
-                           Distributions.Truncated{Distributions.NoncentralF{Float64},Distributions.Continuous},
-                           Distributions.Truncated{Distributions.NoncentralT{Float64},Distributions.Continuous},
-                           Distributions.Truncated{Distributions.StudentizedRange{Float64},Distributions.Continuous}])
+        if !(typeof(d) in [Distributions.Truncated{Distributions.NoncentralChisq{Float64},Distributions.Continuous, Float64},
+                           Distributions.Truncated{Distributions.NoncentralF{Float64},Distributions.Continuous, Float64},
+                           Distributions.Truncated{Distributions.NoncentralT{Float64},Distributions.Continuous, Float64},
+                           Distributions.Truncated{Distributions.StudentizedRange{Float64},Distributions.Continuous, Float64}])
             @test isapprox(logpdf(d, Dual(float(x))), lp, atol=sqrt(eps()))
         end
         # NOTE: this test is disabled as StatsFuns.jl doesn't have generic support for cdf()


### PR DESCRIPTION
This PR allows autodiff to be used with `Truncated` to find the derivative of the `logpdf` function wrt to any of the continuous parameters of `Truncated`.