### PR TITLE
Allow for SpecialFunctions v0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 [compat]
 PDMats = "0.9"
 QuadGK = "2"
-SpecialFunctions = "0.7"
+SpecialFunctions = "0.7, 0.8"
 StatsBase = "0.32"
 StatsFuns = "0.8"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.21.5"
+version = "0.21.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
Changes version bounds on SpecialFunctions to include v0.8s. Fixes #1006.

Also increases version of Distributions to v0.21.6, for a quick patch release (I hope that's not presumptuous).
