### PR TITLE
Implement `eltype` for types instead of instances

### DIFF
--- a/docs/src/multivariate.md
+++ b/docs/src/multivariate.md
@@ -18,7 +18,7 @@ The methods listed as below are implemented for each multivariate distribution, 
 ```@docs
 length(::MultivariateDistribution)
 size(::MultivariateDistribution)
-eltype(d::MultivariateDistribution)
+eltype(::Type{MultivariateDistribution})
 mean(::MultivariateDistribution)
 var(::MultivariateDistribution)
 cov(::MultivariateDistribution)

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -51,8 +51,8 @@ The basic functionalities that a sampleable object provides is to *retrieve info
 ```@docs
 length(::Sampleable)
 size(::Sampleable)
-nsamples(::Type{Sampleable}, x::Any)
-eltype(::Sampleable)
+nsamples(::Type{Sampleable}, ::Any)
+eltype(::Type{Sampleable})
 rand(::AbstractRNG, ::Sampleable)
 rand!(::AbstractRNG, ::Sampleable, ::AbstractArray)
 ```

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -4,7 +4,7 @@ using StatsBase, PDMats, StatsFuns, Statistics
 using StatsFuns: logtwo, invsqrt2, invsqrt2π
 
 import QuadGK: quadgk
-import Base: size, eltype, length, convert, show, getindex, rand, vec, inv
+import Base: size, length, convert, show, getindex, rand, vec, inv
 import Base: sum, maximum, minimum, extrema, +, -, ==
 import Base.Math: @horner
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -49,14 +49,14 @@ Base.size(s::Sampleable{Univariate}) = ()
 Base.size(s::Sampleable{Multivariate}) = (length(s),)
 
 """
-    eltype(s::Sampleable)
+    eltype(::Type{Sampleable})
 
 The default element type of a sample. This is the type of elements of the samples generated
 by the `rand` method. However, one can provide an array of different element types to
 store the samples using `rand!`.
 """
-Base.eltype(s::Sampleable{F,Discrete}) where {F} = Int
-Base.eltype(s::Sampleable{F,Continuous}) where {F} = Float64
+Base.eltype(::Type{<:Sampleable{F,Discrete}}) where {F} = Int
+Base.eltype(::Type{<:Sampleable{F,Continuous}}) where {F} = Float64
 
 """
     nsamples(s::Sampleable)

--- a/src/multivariate/dirichlet.jl
+++ b/src/multivariate/dirichlet.jl
@@ -57,7 +57,8 @@ end
 
 length(d::DirichletCanon) = length(d.alpha)
 
-eltype(::Dirichlet{T}) where {T} = T
+Base.eltype(::Type{Dirichlet{T}}) where {T} = T
+
 #### Conversions
 convert(::Type{Dirichlet{Float64}}, cf::DirichletCanon) = Dirichlet(cf.alpha)
 convert(::Type{Dirichlet{T}}, alpha::Vector{S}) where {T<:Real, S<:Real} =

--- a/src/multivariate/mvlognormal.jl
+++ b/src/multivariate/mvlognormal.jl
@@ -176,7 +176,8 @@ MvLogNormal(σ::AbstractVector) = MvLogNormal(MvNormal(σ))
 MvLogNormal(d::Int,s::Real) = MvLogNormal(MvNormal(d,s))
 
 
-eltype(::MvLogNormal{T}) where {T} = T
+Base.eltype(::Type{<:MvLogNormal{T}}) where {T} = T
+
 ### Conversion
 function convert(::Type{MvLogNormal{T}}, d::MvLogNormal) where T<:Real
     MvLogNormal(convert(MvNormal{T}, d.normal))

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -220,7 +220,8 @@ MvNormal(σ::Vector{<:Real}) = MvNormal(PDiagMat(abs2.(σ)))
 MvNormal(d::Int, σ::Real) = MvNormal(ScalMat(d, abs2(σ)))
 
 
-eltype(::MvNormal{T}) where {T} = T
+Base.eltype(::Type{<:MvNormal{T}}) where {T} = T
+
 ### Conversion
 function convert(::Type{MvNormal{T}}, d::MvNormal) where T<:Real
     MvNormal(convert(AbstractArray{T}, d.μ), convert(AbstractArray{T}, d.Σ))

--- a/src/multivariate/mvnormalcanon.jl
+++ b/src/multivariate/mvnormalcanon.jl
@@ -157,7 +157,7 @@ length(d::MvNormalCanon) = length(d.μ)
 mean(d::MvNormalCanon) = convert(Vector{eltype(d.μ)}, d.μ)
 params(d::MvNormalCanon) = (d.μ, d.h, d.J)
 @inline partype(d::MvNormalCanon{T}) where {T<:Real} = T
-eltype(::MvNormalCanon{T}) where {T} = T
+Base.eltype(::Type{<:MvNormalCanon{T}}) where {T} = T
 
 var(d::MvNormalCanon) = diag(inv(d.J))
 cov(d::MvNormalCanon) = Matrix(inv(d.J))

--- a/src/multivariate/mvtdist.jl
+++ b/src/multivariate/mvtdist.jl
@@ -103,7 +103,7 @@ logdet_cov(d::GenericMvTDist) = d.df>2 ? logdet((d.df/(d.df-2))*d.Σ) : NaN
 
 params(d::GenericMvTDist) = (d.df, d.μ, d.Σ)
 @inline partype(d::GenericMvTDist{T}) where {T} = T
-eltype(::GenericMvTDist{T}) where {T} = T
+Base.eltype(::Type{<:GenericMvTDist{T}}) where {T} = T
 
 # For entropy calculations see "Multivariate t Distributions and their Applications", S. Kotz & S. Nadarajah
 function entropy(d::GenericMvTDist)

--- a/src/multivariates.jl
+++ b/src/multivariates.jl
@@ -14,13 +14,6 @@ Return the sample size of distribution `d`, *i.e* `(length(d),)`.
 """
 size(d::MultivariateDistribution)
 
-"""
-    eltype(d::MultivariateDistribution)
-Return the sample type of distribution `d`
-"""
-eltype(d::MultivariateDistribution)
-
-
 ## sampling
 
 """

--- a/src/univariate/continuous/normal.jl
+++ b/src/univariate/continuous/normal.jl
@@ -60,7 +60,7 @@ params(d::Normal) = (d.μ, d.σ)
 location(d::Normal) = d.μ
 scale(d::Normal) = d.σ
 
-eltype(::Normal{T}) where {T} = T
+Base.eltype(::Type{Normal{T}}) where {T} = T
 
 #### Statistics
 

--- a/src/univariate/discrete/discretenonparametric.jl
+++ b/src/univariate/discrete/discretenonparametric.jl
@@ -36,7 +36,7 @@ DiscreteNonParametric(vs::Ts, ps::Ps; check_args=true) where {
         T<:Real,P<:Real,Ts<:AbstractVector{T},Ps<:AbstractVector{P}} =
     DiscreteNonParametric{T,P,Ts,Ps}(vs, ps, check_args=check_args)
 
-eltype(::DiscreteNonParametric{T}) where T = T
+Base.eltype(::Type{<:DiscreteNonParametric{T}}) where T = T
 
 # Conversion
 convert(::Type{DiscreteNonParametric{T,P,Ts,Ps}}, d::DiscreteNonParametric) where {T,P,Ts,Ps} =

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -19,7 +19,6 @@ end
 
 ZeroVector(::Type{T}, n::Int) where {T} = ZeroVector{T}(n)
 
-Base.eltype(v::ZeroVector{T}) where {T} = T
 Base.length(v::ZeroVector) = v.len
 Base.size(v::ZeroVector) = (v.len,)
 Base.getindex(v::ZeroVector{T}, i) where {T} = zero(T)

--- a/test/continuous.jl
+++ b/test/continuous.jl
@@ -16,7 +16,7 @@ n_tsamples = 100
                                           Triweight(2),
                                           Triweight(1, 3),
                                           Triweight(1)]
-    
+
     test_distr(distr, n_tsamples; testquan=false)
 end
 
@@ -32,11 +32,11 @@ using ForwardDiff
     n64 = Normal(1., 0.1)
     nbig = Normal(big(pi), big(ℯ))
 
-    @test eltype(n32) === Float32
+    @test eltype(typeof(n32)) === Float32
     @test eltype(rand(n32)) === Float32
     @test eltype(rand(n32, 4)) === Float32
 
-    @test eltype(n64) === Float64
+    @test eltype(typeof(n64)) === Float64
     @test eltype(rand(n64)) === Float64
     @test eltype(rand(n64, 4)) === Float64
 end

--- a/test/mixture.jl
+++ b/test/mixture.jl
@@ -10,7 +10,7 @@ function test_mixture(g::UnivariateMixture, n::Int, ns::Int,
     if g isa UnivariateGMM
         T = eltype(g.means)
     else
-        T = eltype(g)
+        T = eltype(typeof(g))
     end
     X = zeros(T, n)
     for i = 1:n

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -260,7 +260,7 @@ end
 function get_evalsamples(d::DiscreteUnivariateDistribution, q::Float64)
     # samples for testing evaluation functions (even spacing)
 
-    T = eltype(d)
+    T = eltype(typeof(d))
     lv = (islowerbounded(d) ? minimum(d) : floor(T,quantile(d, q/2)))::T
     hv = (isupperbounded(d) ? maximum(d) : ceil(T,cquantile(d, q/2)))::T
     @assert lv <= hv

--- a/test/types.jl
+++ b/test/types.jl
@@ -10,7 +10,7 @@ using ForwardDiff: Dual
 @assert DiscreteDistribution <: Distribution
 @assert ContinuousDistribution <: Distribution
 
-@assert DiscreteUnivariateDistribution <: DiscreteDistribution 
+@assert DiscreteUnivariateDistribution <: DiscreteDistribution
 @assert DiscreteUnivariateDistribution <: UnivariateDistribution
 @assert ContinuousUnivariateDistribution <: ContinuousDistribution
 @assert ContinuousUnivariateDistribution <: UnivariateDistribution
@@ -28,11 +28,11 @@ using ForwardDiff: Dual
         @testset "Type $T" begin
             for d in (MvNormal,MvLogNormal,MvNormalCanon,Dirichlet)
                 dist = d(map(T,ones(2)))
-                @test eltype(dist) == T
+                @test eltype(typeof(dist)) == T
                 @test eltype(rand(dist)) == eltype(dist)
             end
             dist = Distributions.mvtdist(map(T,1.0),map(T,[1.0 0.0; 0.0 1.0]))
-            @test eltype(dist) == T
+            @test eltype(typeof(dist)) == T
             @test eltype(rand(dist)) == eltype(dist)
         end
     end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -31,7 +31,7 @@ for v in (15, π, 0x33, 14.0)
 end
 
 for idx in eachindex(Z)
-    @test Z[idx] == zero(eltype(Z))
+    @test Z[idx] == zero(eltype(typeof(Z)))
 end
 
 # Ensure that utilities functions works with abstract arrays


### PR DESCRIPTION
Currently `eltype` is implemented for instances instead of types, although [according to the documentation](https://docs.julialang.org/en/v1/base/collections/#Base.eltype)

>  the form that accepts a type argument should be defined for new types.

I noticed this issue when I tried to implement a sampling algorithm as an iterator by following the example in the [documentation](https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-iteration-1) which advises to implement `eltype(IterType)`. Due to the missing implementation of `eltype` for types in Distributions.jl an implementation such as `eltype(::Type{<:CustomIterator{S}}) where S = eltype(S)` just leads to an element type of `Any`.

(BTW, even if the type-based implementation is added, Distributions.jl still requires some special casing due to the fact that `rand(dist::Distribution)` does not necessarily return a sample of type `eltype(dist)`, as opposed to when, e.g., [sampling from a collection](https://docs.julialang.org/en/v1/stdlib/Random/#Generating-values-from-a-collection-1)).