### PR TITLE
Make MvNormal accept Symmetric and Diagonal matrices

### DIFF
--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -216,6 +216,8 @@ function MvNormal(μ::AbstractVector{<:Real}, σ::UniformScaling{<:Real})
     MvNormal(convert(AbstractArray{R}, μ), R(σ.λ))
 end
 MvNormal(Σ::Matrix{<:Real}) = MvNormal(PDMat(Σ))
+MvNormal(Σ::Union{Symmetric{<:Real}, Hermitian{<:Real}}) = MvNormal(PDMat(Σ))
+MvNormal(Σ::Diagonal{<:Real}) = MvNormal(PDiagMat(diag(Σ)))
 MvNormal(σ::Vector{<:Real}) = MvNormal(PDiagMat(abs2.(σ)))
 MvNormal(d::Int, σ::Real) = MvNormal(ScalMat(d, abs2(σ)))
 

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -106,6 +106,8 @@ end
         (MvNormal(mu, C), mu, C),
         (MvNormal(mu_r, C), mu_r, C),
         (MvNormal(C), zeros(3), C),
+        (MvNormal(Symmetric(C)), zeros(3), Matrix(Symmetric(C))),
+        (MvNormal(Diagonal(dv)), zeros(3), Matrix(Diagonal(dv))),
         (MvNormalCanon(h, 2.0), h ./ 2.0, Matrix(0.5I, 3, 3)),
         (MvNormalCanon(mu_r, 2.0), mu_r ./ 2.0, Matrix(0.5I, 3, 3)),
         (MvNormalCanon(3, 2.0), zeros(3), Matrix(0.5I, 3, 3)),


### PR DESCRIPTION
Fixes the issue #995 and also makes MvNormal accept Diagonal matrices. I additionally updated the tests. 

I'm new to Julia and never made a pull request before so please let me know if I can do anything to improve this pull request.