### PR TITLE
Fixes out of bounds error for loop in rand(DiscreteNonParametric)

### DIFF
--- a/src/univariate/discrete/discretenonparametric.jl
+++ b/src/univariate/discrete/discretenonparametric.jl
@@ -72,10 +72,11 @@ Base.isapprox(c1::D, c2::D) where D<:DiscreteNonParametric =
 function rand(rng::AbstractRNG, d::DiscreteNonParametric{T,P}) where {T,P}
     x = support(d)
     p = probs(d)
+    n = length(p)
     draw = rand(rng, P)
     cp = zero(P)
     i = 0
-    while cp < draw
+    while cp < draw && i <= n
         cp += p[i +=1]
     end
     x[max(i,1)]

--- a/src/univariate/discrete/discretenonparametric.jl
+++ b/src/univariate/discrete/discretenonparametric.jl
@@ -76,7 +76,7 @@ function rand(rng::AbstractRNG, d::DiscreteNonParametric{T,P}) where {T,P}
     draw = rand(rng, P)
     cp = zero(P)
     i = 0
-    while cp < draw && i <= n
+    while cp < draw && i < n
         cp += p[i +=1]
     end
     x[max(i,1)]

--- a/test/discretenonparametric.jl
+++ b/test/discretenonparametric.jl
@@ -112,4 +112,14 @@ p = [1 - eps(Float32), eps(Float32)]
 d = Categorical(p)
 @test ([rand(d) for _ = 1:100_000]; true)
 
+# Numerical stability w/ large prob vectors;
+# see issue #1017
+n = 20000 # large vector length
+p = Float32[0.5; fill(0.5/(n ÷ 2) - 3e-8, n ÷ 2); fill(eps(Float64), n ÷ 2)]
+d = Categorical(p)
+struct DumbRNG <: AbstractRNG end
+Base.rand(::DumbRNG, ::Type{T}) where {T<:Number} = one(T)
+rng = DumbRNG()
+@test (rand(rng, d); true)
+
 end

--- a/test/discretenonparametric.jl
+++ b/test/discretenonparametric.jl
@@ -2,6 +2,10 @@ import StatsBase: ProbabilityWeights
 using Random, Distributions
 using Test
 
+# A dummy RNG that always outputs 1
+struct AllOneRNG <: AbstractRNG end
+Base.rand(::AllOneRNG, ::Type{T}) where {T<:Number} = one(T)
+
 rng = MersenneTwister(123)
 
 @testset "Testing matrix-variates with $key" for (key, func) in
@@ -117,9 +121,7 @@ d = Categorical(p)
 n = 20000 # large vector length
 p = Float32[0.5; fill(0.5/(n ÷ 2) - 3e-8, n ÷ 2); fill(eps(Float64), n ÷ 2)]
 d = Categorical(p)
-struct DumbRNG <: AbstractRNG end
-Base.rand(::DumbRNG, ::Type{T}) where {T<:Number} = one(T)
-rng = DumbRNG()
+rng = AllOneRNG()
 @test (rand(rng, d); true)
 
 end


### PR DESCRIPTION
Fixes #1017 

Changes:
- Add condition `i < length(p)` to while loop in `rand(DiscreteNonParametric)`