### PR TITLE
[Breaking] Treat `UniformScaling` in constructor of `MvNormal` as matrix

### DIFF
--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -196,31 +196,24 @@ function MvNormal(μ::AbstractVector, Σ::AbstractPDMat)
     MvNormal(convert(AbstractArray{R}, μ), convert(AbstractArray{R}, Σ))
 end
 
-function MvNormal(Σ::Cov) where {T, Cov<:AbstractPDMat{T}}
-    MvNormal{T,Cov,ZeroVector{T}}(ZeroVector(T, dim(Σ)), Σ)
-end
-
-MvNormal(μ::AbstractVector{<:Real}, Σ::Matrix{<:Real}) = MvNormal(μ, PDMat(Σ))
+# constructor with general covariance matrix
+MvNormal(μ::AbstractVector{<:Real}, Σ::AbstractMatrix{<:Real}) = MvNormal(μ, PDMat(Σ))
 MvNormal(μ::AbstractVector{<:Real}, Σ::Union{Symmetric{<:Real}, Hermitian{<:Real}}) = MvNormal(μ, PDMat(Σ))
 MvNormal(μ::AbstractVector{<:Real}, Σ::Diagonal{<:Real}) = MvNormal(μ, PDiagMat(diag(Σ)))
-MvNormal(μ::AbstractVector{<:Real}, σ::Vector{<:Real}) = MvNormal(μ, PDiagMat(abs2.(σ)))
+MvNormal(μ::AbstractVector{<:Real}, Σ::UniformScaling{<:Real}) =
+    MvNormal(μ, ScalMat(length(μ), Σ.λ))
+
+# constructor with vector of standard deviations
+MvNormal(μ::AbstractVector{<:Real}, σ::AbstractVector{<:Real}) = MvNormal(μ, PDiagMat(abs2.(σ)))
+
+# constructor with scalar standard deviation
 MvNormal(μ::AbstractVector{<:Real}, σ::Real) = MvNormal(μ, ScalMat(length(μ), abs2(σ)))
 
-function MvNormal(μ::AbstractVector{<:Real}, Σ::VecOrMat{<:Real})
-    R = Base.promote_eltype(μ, Σ)
-    MvNormal(convert(AbstractArray{R}, μ), convert(AbstractArray{R}, Σ))
-end
+# constructor without mean vector
+MvNormal(Σ::AbstractVecOrMat{<:Real}) = MvNormal(ZeroVector(eltype(Σ), size(Σ, 1)), Σ)
 
-function MvNormal(μ::AbstractVector{<:Real}, σ::UniformScaling{<:Real})
-    R = Base.promote_eltype(μ, σ.λ)
-    MvNormal(convert(AbstractArray{R}, μ), R(σ.λ))
-end
-MvNormal(Σ::Matrix{<:Real}) = MvNormal(PDMat(Σ))
-MvNormal(Σ::Union{Symmetric{<:Real}, Hermitian{<:Real}}) = MvNormal(PDMat(Σ))
-MvNormal(Σ::Diagonal{<:Real}) = MvNormal(PDiagMat(diag(Σ)))
-MvNormal(σ::Vector{<:Real}) = MvNormal(PDiagMat(abs2.(σ)))
-MvNormal(d::Int, σ::Real) = MvNormal(ScalMat(d, abs2(σ)))
-
+# special constructor
+MvNormal(d::Int, σ::Real) = MvNormal(ZeroVector(typeof(σ), d), σ)
 
 Base.eltype(::Type{<:MvNormal{T}}) where {T} = T
 

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -198,7 +198,6 @@ end
 
 # constructor with general covariance matrix
 MvNormal(μ::AbstractVector{<:Real}, Σ::AbstractMatrix{<:Real}) = MvNormal(μ, PDMat(Σ))
-MvNormal(μ::AbstractVector{<:Real}, Σ::Union{Symmetric{<:Real}, Hermitian{<:Real}}) = MvNormal(μ, PDMat(Σ))
 MvNormal(μ::AbstractVector{<:Real}, Σ::Diagonal{<:Real}) = MvNormal(μ, PDiagMat(diag(Σ)))
 MvNormal(μ::AbstractVector{<:Real}, Σ::UniformScaling{<:Real}) =
     MvNormal(μ, ScalMat(length(μ), Σ.λ))

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -37,7 +37,7 @@ f(\\mathbf{x}; \\boldsymbol{\\mu}, \\boldsymbol{\\Sigma}) = \\frac{1}{(2 \\pi)^{
 We realize that the mean vector and the covariance often have special forms in practice,
 which can be exploited to simplify the computation. For example, the mean vector is sometimes
 just a zero vector, while the covariance matrix can be a diagonal matrix or even in the form
-of ``\\sigma \\mathbf{I}``. To take advantage of such special cases, we introduce a parametric
+of ``\\sigma^2 \\mathbf{I}``. To take advantage of such special cases, we introduce a parametric
 type `MvNormal`, defined as below, which allows users to specify the special structure of
 the mean and covariance.
 

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -167,9 +167,9 @@ end
     @test typeof(convert(MvNormalCanon{Float64}, d)) == typeof(MvNormalCanon(mu, h, PDMat(J)))
     @test typeof(convert(MvNormalCanon{Float64}, d.μ, d.h, d.J)) == typeof(MvNormalCanon(mu, h, PDMat(J)))
 
-    @test typeof(MvNormal(mu, I)) == typeof(MvNormal(mu, 1))
-    @test typeof(MvNormal(mu, 3 * I)) == typeof(MvNormal(mu, 3))
-    @test typeof(MvNormal(mu, 0.1f0 * I)) == typeof(MvNormal(mu, 0.1))
+    @test MvNormal(mu, I) === MvNormal(mu, 1)
+    @test MvNormal(mu, 9 * I) === MvNormal(mu, 3)
+    @test MvNormal(mu, 0.25f0 * I) === MvNormal(mu, 0.5)
 end
 
 ##### MLE


### PR DESCRIPTION
There exist different issues about inconsistencies in the constructor of `MvNormal` (see, e.g., https://github.com/JuliaStats/Distributions.jl/issues/584 and https://github.com/JuliaStats/Distributions.jl/issues/826). It caught me by surprise (https://github.com/TuringLang/Turing.jl/issues/991) that actually
```julia
MvNormal(ones(3), 3 * I) != MvNormal(ones(3), Matrix(3 * I, 3, 3))
```
I would have assumed that `3 * I` is treated liked other matrices as a proper covariance matrix. IMO the current behaviour of
```julia
MvNormal(ones(3), 3 * I) == MvNormal(ones(3), 3)
```
is unintuitive (which, of course, is also due to the fact that vectors and scalars are treated as standard deviations - I assume to be more consistent with the constructor of `Normal`). This PR changes this behaviour and treats `UniformScaling` like any other matrix.

Additionally I tried to reduce the amount of redundant code.