### PR TITLE
Use native samplers for Poisson distribution

### DIFF
--- a/src/samplers/poisson.jl
+++ b/src/samplers/poisson.jl
@@ -102,7 +102,7 @@ function rand(rng::AbstractRNG, sampler::PoissonADSampler)
         c = 0.1069 / μ
 
         # Step H
-        if c * abs(U) <= py * exp(px + E) - fy * exp(fx + E)
+        if c*abs(U) <= py*exp(px + E) - fy*exp(fx + E)
             return K
         end
     end

--- a/src/samplers/poisson.jl
+++ b/src/samplers/poisson.jl
@@ -13,17 +13,20 @@ end
 #
 # Suitable for small μ
 #
-struct PoissonCountSampler <: Sampleable{Univariate,Discrete}
-    μ::Float64
+struct PoissonCountSampler{T<:Real} <: Sampleable{Univariate,Discrete}
+    μ::T
 end
+
+PoissonCountSampler(d::Poisson) = PoissonCountSampler(rate(d))
 
 function rand(rng::AbstractRNG, s::PoissonCountSampler)
     μ = s.μ
+    T = typeof(μ)
     n = 0
-    c = randexp(rng)
+    c = randexp(rng, T)
     while c < μ
         n += 1
-        c += randexp(rng)
+        c += randexp(rng, T)
     end
     return n
 end
@@ -36,72 +39,85 @@ end
 #
 #   For μ sufficiently large, (i.e. >= 10.0)
 #
-struct PoissonADSampler <: Sampleable{Univariate,Discrete}
-    μ::Float64
-    s::Float64
-    d::Float64
+struct PoissonADSampler{T<:Real} <: Sampleable{Univariate,Discrete}
+    μ::T
+    s::T
+    d::T
     L::Int
 end
 
-PoissonADSampler(μ::Float64) =
-    PoissonADSampler(μ,sqrt(μ),6.0*μ^2,floor(Int,μ-1.1484))
+PoissonADSampler(d::Poisson) = PoissonADSampler(rate(d))
 
-function rand(rng::AbstractRNG, s::PoissonADSampler)
+function PoissonADSampler(μ::Real)
+    s = sqrt(μ)
+    d = 6 * μ^2
+    L = floor(Int, μ - 1.1484)
+
+    PoissonADSampler(promote(μ, s, d)..., L)
+end
+
+function rand(rng::AbstractRNG, sampler::PoissonADSampler)
+    μ = sampler.μ
+    s = sampler.s
+    d = sampler.d
+    L = sampler.L
+    μType = typeof(μ)
+
     # Step N
-    G = s.μ + s.s*randn(rng)
+    G = μ + s * randn(rng, μType)
 
-    if G >= 0.0
-        K = floor(Int,G)
+    if G >= zero(G)
+        K = floor(Int, G)
         # Step I
-        if K >= s.L
+        if K >= L
             return K
         end
 
         # Step S
-        U = rand(rng)
-        if s.d*U >= (s.μ-K)^3
+        U = rand(rng, μType)
+        if d * U >= (μ - K)^3
             return K
         end
 
         # Step P
-        px,py,fx,fy = procf(s.μ,K,s.s)
+        px, py, fx, fy = procf(μ, K, s)
 
         # Step Q
-        if fy*(1-U) <= py*exp(px-fx)
+        if fy * (1 - U) <= py * exp(px - fx)
             return K
         end
     end
 
     while true
         # Step E
-        E = randexp(rng)
-        U = 2.0*rand(rng)-1.0
-        T = 1.8+copysign(E,U)
+        E = randexp(rng, μType)
+        U = 2 * rand(rng, μType) - one(μType)
+        T = 1.8 + copysign(E, U)
         if T <= -0.6744
             continue
         end
 
-        K = floor(Int,s.μ + s.s*T)
-        px,py,fx,fy = procf(s.μ,K,s.s)
-        c = 0.1069/s.μ
+        K = floor(Int, μ + s * T)
+        px, py, fx, fy = procf(μ, K, s)
+        c = 0.1069 / μ
 
         # Step H
-        if c*abs(U) <= py*exp(px+E)-fy*exp(fx+E)
+        if c * abs(U) <= py * exp(px + E) - fy * exp(fx + E)
             return K
         end
     end
 end
 
 # Procedure F
-function procf(μ::Float64, K::Int, s::Float64)
+function procf(μ, K::Int, s)
     # can be pre-computed, but does not seem to affect performance
     ω = 0.3989422804014327/s
     b1 = 0.041666666666666664/μ
     b2 = 0.3*b1*b1
     c3 = 0.14285714285714285*b1*b2
-    c2 = b2 - 15.0*c3
-    c1 = b1 - 6.0*b2 + 45.0*c3
-    c0 = 1.0 - b1 + 3.0*b2 - 15.0*c3
+    c2 = b2 - 15 * c3
+    c1 = b1 - 6 * b2 + 45 * c3
+    c0 = 1 - b1 + 3 * b2 - 15 * c3
 
     if K < 10
         px = -μ
@@ -116,7 +132,7 @@ function procf(μ::Float64, K::Int, s::Float64)
     end
     X = (K-μ+0.5)/s
     X2 = X^2
-    fx = -0.5*X2 # missing negation in pseudo-algorithm, but appears in fortran code.
+    fx = -X2 / 2 # missing negation in pseudo-algorithm, but appears in fortran code.
     fy = ω*(((c3*X2+c2)*X2+c1)*X2+c0)
     return px,py,fx,fy
 end

--- a/src/univariate/discrete/poisson.jl
+++ b/src/univariate/discrete/poisson.jl
@@ -141,14 +141,6 @@ fit_mle(::Type{<:Poisson}, ss::PoissonStats) = Poisson(ss.sx / ss.tw)
 
 ## samplers
 
-function rand(rng::AbstractRNG, d::Poisson)
-    if rate(d) < 6
-        return rand(rng, PoissonCountSampler(d))
-    else
-        return rand(rng, PoissonADSampler(d))
-    end
-end
-
 function sampler(d::Poisson)
     if rate(d) < 6
         return PoissonCountSampler(d)

--- a/src/univariate/discrete/poisson.jl
+++ b/src/univariate/discrete/poisson.jl
@@ -141,8 +141,10 @@ fit_mle(::Type{<:Poisson}, ss::PoissonStats) = Poisson(ss.sx / ss.tw)
 
 ## samplers
 
+const poissonsampler_threshold = 6
+
 function sampler(d::Poisson)
-    if rate(d) < 6
+    if rate(d) < poissonsampler_threshold
         return PoissonCountSampler(d)
     else
         return PoissonADSampler(d)


### PR DESCRIPTION
I noticed that `sampler` is not implemented for Poisson distributions although two native samplers `PoissonCountSampler` and `PoissonADSampler` exist. Moreover, currently R is used for sampling from Poisson distributions, [which is quite slow](https://github.com/JuliaDiffEq/PoissonRandom.jl/issues/6). For now I used the same cut-off value of 6 for both samplers, as chosen in [PoissonRandom.jl](https://github.com/JuliaDiffEq/PoissonRandom.jl).

I repeated the benchmarks
```julia
using Distributions, PoissonRandom, StatsFuns
using Plots

function n_count(rng, λ, n)
  tmp = 0
  for i in 1:n
    tmp += PoissonRandom.count_rand(rng,λ)
  end
  tmp
end

function n_pois(rng,λ,n)
  tmp = 0
  for i in 1:n
    tmp += pois_rand(rng,λ)
  end
  tmp
end

function n_ad(rng, λ, n)
  tmp = 0
  for i in 1:n
    tmp += PoissonRandom.ad_rand(rng, λ)
  end
  tmp
end

function n_dist(λ,n)
  tmp = 0
  for i in 1:n
    tmp += rand(Poisson(λ))
  end
  tmp
end

function n_rfunctions(λ, n)
  tmp = 0
  for i in 1:n
    tmp += convert(Int, StatsFuns.RFunctions.poisrand(λ))
  end
  tmp
end

function n_countsampler(rng, λ::Float64, n)
  tmp = 0
  for i in 1:n
    tmp += rand(rng, Distributions.PoissonCountSampler(λ))
  end
  tmp
end

function n_adsampler(rng, λ::Float64, n)
  tmp = 0
  for i in 1:n
    tmp += rand(rng, Distributions.PoissonADSampler(λ))
  end
  tmp
end

function time_λ!(rng, times, λ::Float64, n)
  times[1] = @elapsed n_count(rng, λ, n)
  times[2] = @elapsed n_ad(rng, λ, n)
  times[3] = @elapsed n_pois(rng, λ, n)
  times[4] = @elapsed n_dist(rng, λ, n)
  times[5] = @elapsed n_rfunctions(λ, n)
  times[6] = @elapsed n_countsampler(rng, λ, n)
  times[7] = @elapsed n_adsampler(rng, λ, n)

  nothing
end

function plot_benchmark(rng)
    times = Matrix{Float64}(undef, 7, 20)

    # Compile
    time_λ!(rng, view(times, :, 1), 5, 5_000_000)

    # Run with a bunch of λ
    for λ in 1:20
        time_λ!(rng, view(times, :, λ), float(λ), 5_000_000)
    end

    plot(times',
         labels = ["count_rand" "ad_rand" "pois_rand" "Distributions" "RFunctions" "PoissonCountSampler" "PoissonADSampler"],
         lw = 3)
end
```
from https://github.com/JuliaDiffEq/PoissonRandom.jl/issues/6 with this PR. I get
```julia
using Random
Random.seed!(1234)
plot_benchmark(Random.GLOBAL_RNG)
savefig("global_rng.png")
```
![global_rng](https://user-images.githubusercontent.com/26102/69832880-e2bd2c00-1230-11ea-9a7d-0bbcf7a1e3d4.png)
and
```julia
using RandomNumbers
plot_benchmark(Xorshifts.Xoroshiro128Plus(1234))
savefig("xoroshiro128plus.png")
```
![xoroshiro128plus](https://user-images.githubusercontent.com/26102/69832897-f7012900-1230-11ea-9f5f-33f5fe55eed6.png)

Using the native samplers leads to a significant speed-up and a performance which is on par with [PoissonRandom.jl](https://github.com/JuliaDiffEq/PoissonRandom.jl).