### PR TITLE
Truncate generic

### DIFF
--- a/docs/src/starting.md
+++ b/docs/src/starting.md
@@ -67,7 +67,7 @@ julia> Wishart(nu, S) # Continuous matrix-variate
 In addition, you can create truncated distributions from univariate distributions:
 
 ```julia
-julia> Truncated(Normal(mu, sigma), l, u)
+julia> truncated(Normal(mu, sigma), l, u)
 ```
 
 To find out which parameters are appropriate for a given distribution `D`, you can use `fieldnames(D)`:

--- a/docs/src/truncate.md
+++ b/docs/src/truncate.md
@@ -1,7 +1,7 @@
 # Truncated Distributions
 
 The package provides the `truncated` function which creates the most
-appropriate distribution to represente a truncated version of a given
+appropriate distribution to represent a truncated version of a given
 distribution.
 
 

--- a/docs/src/truncate.md
+++ b/docs/src/truncate.md
@@ -1,27 +1,25 @@
 # Truncated Distributions
 
-The package provides the `Truncated` type to represented truncated distributions, which is defined as below:
+The package provides the `truncated` function which creates the most
+appropriate distribution to represente a truncated version of a given
+distribution.
 
-```julia
-struct Truncated{D<:UnivariateDistribution,S<:ValueSupport} <: Distribution{Univariate,S}
-    untruncated::D      # the original distribution (untruncated)
-    lower::Float64      # lower bound
-    upper::Float64      # upper bound
-    lcdf::Float64       # cdf of lower bound
-    ucdf::Float64       # cdf of upper bound
 
-    tp::Float64         # the probability of the truncated part, i.e. ucdf - lcdf
-    logtp::Float64      # log(tp), i.e. log(ucdf - lcdf)
-end
+A truncated distribution can be constructed using the following signature:
+
+```@docs
+truncated
 ```
 
-A truncated distribution can be constructed using the constructor `Truncated` as follows:
+In the general case, this will create a `Truncated{typeof(d)}`
+structure, defined as follows:
 
 ```@docs
 Truncated
 ```
 
-Many functions, including those for the evaluation of pdf and sampling, are defined for all truncated univariate distributions:
+Many functions, including those for the evaluation of pdf and sampling,
+are defined for all truncated univariate distributions:
 
 - [`maximum(::UnivariateDistribution)`](@ref)
 - [`minimum(::UnivariateDistribution)`](@ref)
@@ -40,8 +38,9 @@ Many functions, including those for the evaluation of pdf and sampling, are defi
 - [`rand!(::UnivariateDistribution, ::AbstractArray)`](@ref)
 - [`median(::UnivariateDistribution)`](@ref)
 
-Functions to compute statistics, such as `mean`, `mode`, `var`, `std`, and `entropy`, are not available for generic truncated distributions. Generally, there are no easy ways to compute such quantities due to the complications incurred by truncation.
-However, these methods are supported for truncated normal distributions.
+Functions to compute statistics, such as `mean`, `mode`, `var`, `std`, and `entropy`, are not available for generic truncated distributions.
+Generally, there are no easy ways to compute such quantities due to the complications incurred by truncation.
+However, these methods are supported for truncated normal distributions `Truncated{<:Normal}`.
 
 ```@docs
 TruncatedNormal

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -145,9 +145,7 @@ export
     TDist,
     TriangularDist,
     Triweight,
-    truncate,
     Truncated,
-    TruncatedNormal,
     Uniform,
     UnivariateGMM,
     VonMises,
@@ -242,6 +240,7 @@ export
     suffstats,          # compute sufficient statistics
     succprob,           # the success probability
     support,            # the support of a distribution (or a distribution type)
+    truncated,          # truncate a distribution with a lower and upper bound
     var,                # variance of distribution
     varlogx,            # variance of log(x)
     expected_logdet,    # expected logarithm of random matrix determinant

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -145,6 +145,7 @@ export
     TDist,
     TriangularDist,
     Triweight,
+    truncate,
     Truncated,
     TruncatedNormal,
     Uniform,

--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -35,7 +35,8 @@ truncated(d::UnivariateDistribution, l::Integer, u::Integer) = truncated(d, floa
     Truncated(d, l, u):
 
 Create a generic wrapper for a truncated distribution.
-Prefer calling the generic `truncated(d, l, u)`.
+Prefer calling the function `truncated(d, l, u)`, which can choose the appropriate
+representation of the truncated distribution.
 
 # Arguments
 - `d::UnivariateDistribution`: The original distribution.

--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -1,5 +1,5 @@
 """
-    truncate(d, l, u):
+    truncated(d, l, u):
 
 Truncate a distribution between `l` and `u`.
 Builds the most appropriate distribution for the type of `d`,
@@ -16,11 +16,11 @@ should be implemented.
 
 Throws an error if `l >= u`.
 """
-function truncate(d::UnivariateDistribution, l::Real, u::Real)
-    return truncate(d, promote(l, u)...)
+function truncated(d::UnivariateDistribution, l::Real, u::Real)
+    return truncated(d, promote(l, u)...)
 end
 
-function truncate(d::UnivariateDistribution, l::T, u::T) where {T <: Real}
+function truncated(d::UnivariateDistribution, l::T, u::T) where {T <: Real}
     l < u || error("lower bound should be less than upper bound.")
     T2 = promote_type(T, eltype(d))
     lcdf = isinf(l) ? zero(T2) : T2(cdf(d, l))
@@ -29,7 +29,7 @@ function truncate(d::UnivariateDistribution, l::T, u::T) where {T <: Real}
     Truncated(d, promote(l, u, lcdf, ucdf, tp, log(tp))...)
 end
 
-truncate(d::UnivariateDistribution, l::Integer, u::Integer) = truncate(d, float(l), float(u))
+truncated(d::UnivariateDistribution, l::Integer, u::Integer) = truncated(d, float(l), float(u))
 
 """
     Truncated(d, l, u):
@@ -66,8 +66,9 @@ function Truncated(d::UnivariateDistribution, l::T, u::T) where {T <: Real}
     Truncated(d, promote(l, u, lcdf, ucdf, tp, log(tp))...)
 end
 
-@deprecate Truncated(d::UnivariateDistribution, l::Real, u::Real) truncate(d, l, u)
-@deprecate Truncated(d::UnivariateDistribution, l::Integer, u::Integer) truncate(d, l, u)
+Truncated(d::UnivariateDistribution, l::Integer, u::Integer) = Truncated(d, float(l), float(u))
+
+@deprecate Truncated(d::UnivariateDistribution, l::Real, u::Real) truncated(d, l, u)
 
 params(d::Truncated) = tuple(params(d.untruncated)..., d.lower, d.upper)
 partype(d::Truncated) = partype(d.untruncated)

--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -3,7 +3,7 @@
 
 Truncate a distribution between `l` and `u`.
 Builds the most appropriate distribution for the type of `d`,
-the fallback is constructing a `Truncated` distribution.
+the fallback is constructing a `Truncated` wrapper.
 
 To implement a specialized truncated form for a distribution `D`,
 the method `truncate(d::D, l::T, u::T) where {T <: Real}`
@@ -34,7 +34,7 @@ truncated(d::UnivariateDistribution, l::Integer, u::Integer) = truncated(d, floa
 """
     Truncated(d, l, u):
 
-Construct a truncated distribution.
+Create a generic wrapper for a truncated distribution.
 Prefer calling the generic `truncated(d, l, u)`.
 
 # Arguments

--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -80,7 +80,7 @@ isupperbounded(d::Truncated) = isupperbounded(d.untruncated) || isfinite(d.upper
 minimum(d::Truncated) = max(minimum(d.untruncated), d.lower)
 maximum(d::Truncated) = min(maximum(d.untruncated), d.upper)
 
-function insupport(d::Truncated{D,<: Union{Discrete,Continuous}}, x::Real) where {D<:UnivariateDistribution}
+function insupport(d::Truncated{D,<:Union{Discrete,Continuous}}, x::Real) where {D<:UnivariateDistribution}
     return d.lower <= x <= d.upper && insupport(d.untruncated, x)
 end
 

--- a/src/truncated/normal.jl
+++ b/src/truncated/normal.jl
@@ -6,8 +6,9 @@ The *truncated normal distribution* is a particularly important one in the famil
 We provide additional support for this type with `TruncatedNormal` which calls `Truncated(Normal(mu, sigma), l, u)`.
 Unlike the general case, truncated normal distributions support `mean`, `mode`, `modes`, `var`, `std`, and `entropy`.
 """
-TruncatedNormal(mu::Real, sigma::Real, a::Real, b::Real) =
-    Truncated(Normal(mu, sigma), a, b)
+TruncatedNormal
+
+@deprecate TruncatedNormal(mu::Real, sigma::Real, a::Real, b::Real) truncated(Normal(mu, sigma), a, b)
 
 ### statistics
 

--- a/src/truncated/uniform.jl
+++ b/src/truncated/uniform.jl
@@ -2,5 +2,6 @@
 ##### Shortcut for truncating uniform distributions.
 #####
 
-Truncated(d::Uniform, l::Real, u::Real) = Uniform(promote(max(l, d.a), min(u, d.b))...)
-Truncated(d::Uniform, l::Integer, u::Integer) = Uniform(max(l, d.a), min(u, d.b))
+truncated(d::Uniform, l::T, u::T) where {T <: Real} = Uniform(promote(max(l, d.a), min(u, d.b))...)
+
+truncated(d::Uniform, l::Integer, u::Integer) = truncated(d, float(l), float(u))

--- a/test/ref/continuous_test.ref.json
+++ b/test/ref/continuous_test.ref.json
@@ -4558,7 +4558,7 @@
   ]
 },
 {
-  "expr": "TruncatedNormal(0, 1, -2, 2)",
+  "expr": "truncated(Normal(0, 1), -2, 2)",
   "dtype": "TruncatedNormal",
   "minimum": -2,
   "maximum": 2,
@@ -4588,7 +4588,7 @@
   ]
 },
 {
-  "expr": "TruncatedNormal(3, 10, 7, 8)",
+  "expr": "truncated(Normal(3, 10), 7, 8)",
   "dtype": "TruncatedNormal",
   "minimum": 7,
   "maximum": 8,
@@ -4618,7 +4618,7 @@
   ]
 },
 {
-  "expr": "TruncatedNormal(27, 3, 0, Inf)",
+  "expr": "truncated(Normal(27, 3), 0, Inf)",
   "dtype": "TruncatedNormal",
   "minimum": 0,
   "maximum": "inf",
@@ -4648,7 +4648,7 @@
   ]
 },
 {
-  "expr": "TruncatedNormal(-5, 1, -Inf, -10)",
+  "expr": "truncated(Normal(-5, 1), -Inf, -10)",
   "dtype": "TruncatedNormal",
   "minimum": "-inf",
   "maximum": -10,
@@ -4678,7 +4678,7 @@
   ]
 },
 {
-  "expr": "TruncatedNormal(1.8, 1.2, -Inf, 0)",
+  "expr": "truncated(Normal(1.8, 1.2), -Inf, 0)",
   "dtype": "TruncatedNormal",
   "minimum": "-inf",
   "maximum": 0,

--- a/test/truncate.jl
+++ b/test/truncate.jl
@@ -38,11 +38,9 @@ function verify_and_test_drive(jsonfile, selected, n_tsamples::Int,lower::Int,up
 
         println("    testing Truncated($(ex),$lower,$upper)")
         d = Truncated(eval(Meta.parse(ex)),lower,upper)
-        if dtype != Uniform # Uniform is truncated to Uniform
-            if dtype != TruncatedNormal
-                @assert isa(dtype, Type) && dtype <: UnivariateDistribution
-                @test isa(d, dtypet)
-            end
+        if dtype != Uniform && dtype != TruncatedNormal # Uniform is truncated to Uniform
+            @assert isa(dtype, Type) && dtype <: UnivariateDistribution
+            @test isa(d, dtypet)
             # verification and testing
             verify_and_test(d, dct, n_tsamples)
         end
@@ -138,7 +136,7 @@ end
 
 ## automatic differentiation
 
-f = x -> logpdf(Truncated(Normal(x[1], x[2]), x[3], x[4]), mean(x))
+f = x -> logpdf(truncated(Normal(x[1], x[2]), x[3], x[4]), mean(x))
 at = [0.0, 1.0, 0.0, 1.0]
 @test isapprox(ForwardDiff.gradient(f, at), fdm(f, at), atol=1e-6)
 

--- a/test/truncated_exponential.jl
+++ b/test/truncated_exponential.jl
@@ -4,15 +4,15 @@ using Distributions, Random, Test
     d = Exponential(1.5)
     l = 1.2
     r = 2.7
-    @test mean(d) ≈ mean(Truncated(d, -3.0, Inf)) # non-binding truncation
-    @test mean(Truncated(d, l, Inf)) ≈ mean(d) + l
+    @test mean(d) ≈ mean(truncated(d, -3.0, Inf)) # non-binding truncation
+    @test mean(truncated(d, l, Inf)) ≈ mean(d) + l
     # test values below calculated using symbolic integration in Maxima
-    @test mean(Truncated(d, 0, r)) ≈ 0.9653092084094841
-    @test mean(Truncated(d, l, r)) ≈ 1.82703493969601
+    @test mean(truncated(d, 0, r)) ≈ 0.9653092084094841
+    @test mean(truncated(d, l, r)) ≈ 1.82703493969601
 
     # all the fun corner cases and numerical quirks
-    @test mean(Truncated(Exponential(1.0), -Inf, 0)) == 0                   # degenerate
-    @test mean(Truncated(Exponential(1.0), -Inf, 0+eps())) ≈ 0 atol = eps() # near-degenerate
-    @test mean(Truncated(Exponential(1.0), 1.0, 1.0+eps())) ≈ 1.0 # near-degenerate
-    @test mean(Truncated(Exponential(1e308), 1.0, 1.0+eps())) ≈ 1.0 # near-degenerate
+    @test mean(truncated(Exponential(1.0), -Inf, 0)) == 0                   # degenerate
+    @test mean(truncated(Exponential(1.0), -Inf, 0+eps())) ≈ 0 atol = eps() # near-degenerate
+    @test mean(truncated(Exponential(1.0), 1.0, 1.0+eps())) ≈ 1.0 # near-degenerate
+    @test mean(truncated(Exponential(1e308), 1.0, 1.0+eps())) ≈ 1.0 # near-degenerate
 end

--- a/test/truncated_uniform.jl
+++ b/test/truncated_uniform.jl
@@ -3,10 +3,10 @@ using Distributions, Test
 @testset "truncated uniform" begin
     # just test equivalence of truncation results
     u = Uniform(1, 2)
-    @test Truncated(u, -Inf, Inf) == u
-    @test Truncated(u, 0, Inf) == u
-    @test Truncated(u, -Inf, 2.1) == u
-    @test Truncated(u, 1.1, Inf) == Uniform(1.1, 2)
-    @test Truncated(u, 1.1, 2.1) == Uniform(1.1, 2)
-    @test Truncated(u, 1.1, 1.9) == Uniform(1.1, 1.9)
+    @test truncated(u, -Inf, Inf) == u
+    @test truncated(u, 0, Inf) == u
+    @test truncated(u, -Inf, 2.1) == u
+    @test truncated(u, 1.1, Inf) == Uniform(1.1, 2)
+    @test truncated(u, 1.1, 2.1) == Uniform(1.1, 2)
+    @test truncated(u, 1.1, 1.9) == Uniform(1.1, 1.9)
 end

--- a/test/truncnormal.jl
+++ b/test/truncnormal.jl
@@ -4,13 +4,13 @@ using Distributions, Random
 rng = MersenneTwister(123)
 
 @testset "Truncated normal, mean and variance" begin
-    d = Distributions.TruncatedNormal(0,1,100,115); @test mean(d) ≈ 100.00999800099926070518490239457545847490332879043
-    d = Distributions.TruncatedNormal(0,1,50,70); @test var(d) ≈ 0.00039904318680389954790992722653605933053648912703600
-    d = Distributions.TruncatedNormal(-2,3,50,70); @test mean(d) ≈ 50.171943499898757645751683644632860837133138152489
-    d = Distributions.TruncatedNormal(-2,3,50,70); @test var(d) ≈ 0.029373438107168350377591231295634273607812172191712
+    d = Distributions.truncated(Normal(0,1),100,115); @test mean(d) ≈ 100.00999800099926070518490239457545847490332879043
+    d = Distributions.truncated(Normal(0,1),50,70); @test var(d) ≈ 0.00039904318680389954790992722653605933053648912703600
+    d = Distributions.truncated(Normal(-2,3),50,70); @test mean(d) ≈ 50.171943499898757645751683644632860837133138152489
+    d = Distributions.truncated(Normal(-2,3),50,70); @test var(d) ≈ 0.029373438107168350377591231295634273607812172191712
 end
-@testset "Truncated normal $trunc" for trunc in [TruncatedNormal(0, 1, -2, 2),
-                                                 Truncated(Normal(0, 1), -2, 2)]
+@testset "Truncated normal $trunc" begin
+    trunc = truncated(Normal(0, 1), -2, 2)
     @testset "Truncated normal $trunc with $func" for func in
         [(r = rand, r! = rand!),
          (r = ((d, n) -> rand(rng, d, n)), r! = ((d, X) -> rand!(rng, d, X)))]

--- a/test/univariates.jl
+++ b/test/univariates.jl
@@ -23,10 +23,10 @@ function verify_and_test_drive(jsonfile, selected, n_tsamples::Int)
         println("    testing $(ex)")
         dtype = eval(dsym)
         d = eval(ex)
-        if dtype == TruncatedNormal
+        if dsym == :truncated
             @test isa(d, Truncated{Normal{Float64}})
         else
-            @test isa(dtype, Type) && dtype <: UnivariateDistribution
+            @test dtype isa Type && dtype <: UnivariateDistribution
             @test d isa dtype
         end
 

--- a/test/univariates.jl
+++ b/test/univariates.jl
@@ -64,7 +64,7 @@ function verify_and_test(D::Union{Type,Function}, d::UnivariateDistribution, dct
 
     # promotion constructor:
     float_pars = map(x -> isa(x, AbstractFloat), pars)
-    if length(pars) > 1 && sum(float_pars) > 1
+    if length(pars) > 1 && sum(float_pars) > 1 && !isa(D, typeof(truncated)) 
         mixed_pars = Any[pars...]
         first_float = findfirst(float_pars)
         mixed_pars[first_float] = Float32(mixed_pars[first_float])

--- a/test/univariates.jl
+++ b/test/univariates.jl
@@ -26,8 +26,8 @@ function verify_and_test_drive(jsonfile, selected, n_tsamples::Int)
         if dtype == TruncatedNormal
             @test isa(d, Truncated{Normal{Float64}})
         else
-            @assert isa(dtype, Type) && dtype <: UnivariateDistribution
-            @test isa(d, dtype)
+            @test isa(dtype, Type) && dtype <: UnivariateDistribution
+            @test d isa dtype
         end
 
         # verification and testing

--- a/test/univariates.jl
+++ b/test/univariates.jl
@@ -73,7 +73,7 @@ function verify_and_test(D::Union{Type,Function}, d::UnivariateDistribution, dct
     end
 
     # promote integer arguments to floats, where applicable
-    if sum(float_pars) >= 1 && !any(map(isinf, pars)) && !isa(d, Geometric) !isa(D, typeof(truncated))
+    if sum(float_pars) >= 1 && !any(map(isinf, pars)) && !isa(d, Geometric) && !isa(D, typeof(truncated))
         int_pars = map(x -> ceil(Int, x), pars)
         @test typeof(D(int_pars...)) == typeof(d)
     end

--- a/test/univariates.jl
+++ b/test/univariates.jl
@@ -73,7 +73,7 @@ function verify_and_test(D::Union{Type,Function}, d::UnivariateDistribution, dct
     end
 
     # promote integer arguments to floats, where applicable
-    if sum(float_pars) >= 1 && !any(map(isinf, pars)) && !isa(d, Geometric)
+    if sum(float_pars) >= 1 && !any(map(isinf, pars)) && !isa(d, Geometric) !isa(D, typeof(truncated))
         int_pars = map(x -> ceil(Int, x), pars)
         @test typeof(D(int_pars...)) == typeof(d)
     end


### PR DESCRIPTION
Just like https://github.com/JuliaStats/Distributions.jl/pull/975 but for `Truncated`
Sadly Base already exports `truncate` so we had to settle with `truncated(::D, lower, upper)`
