### PR TITLE
Fix a type instability issue for logpdf(::Categorical)

### DIFF
--- a/src/univariate/discrete/categorical.jl
+++ b/src/univariate/discrete/categorical.jl
@@ -80,8 +80,6 @@ end
 
 pdf(d::Categorical{T}, x::Int) where {T<:Real} = insupport(d, x) ? probs(d)[x] : zero(T)
 
-logpdf(d::Categorical, x::Int) = insupport(d, x) ? log(probs(d)[x]) : -Inf
-
 function _pdf!(r::AbstractArray, d::Categorical{T}, rgn::UnitRange) where {T<:Real}
     vfirst = round(Int, first(rgn))
     vlast = round(Int, last(rgn))

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -341,7 +341,7 @@ Relying on this fallback is not recommended in general, as it is prone to overfl
 """
 logpdf(d::UnivariateDistribution, x::Real) = log(pdf(d, x))
 logpdf(d::DiscreteUnivariateDistribution, x::Integer) = log(pdf(d, x))
-logpdf(d::DiscreteUnivariateDistribution, x::Real) = isinteger(x) ? logpdf(d, round(Int, x)) : -Inf
+logpdf(d::DiscreteUnivariateDistribution, x::Real) = isinteger(x) ? logpdf(d, round(Int, x)) : partype(d)(-Inf)
 
 """
     cdf(d::UnivariateDistribution, x::Real)

--- a/test/categorical.jl
+++ b/test/categorical.jl
@@ -1,9 +1,11 @@
 using Distributions
 using Test
 
+@testset "Categorical" begin
 
-for p in Vector{Float64}[
+for p in Any[
     [0.5, 0.5],
+    [0.5f0, 0.5f0],
     [0.1, 0.3, 0.2, 0.4],
     [0.15, 0.25, 0.6] ]
 
@@ -22,7 +24,8 @@ for p in Vector{Float64}[
     for i = 1:k
         c += p[i]
         @test pdf(d, i) == p[i]
-        @test logpdf(d, i) == log(p[i])
+        @test @inferred(logpdf(d, i)) === log(p[i])
+        @test @inferred(logpdf(d, float(i))) === log(p[i])
         @test cdf(d, i)  ≈ c
         @test ccdf(d, i) ≈ 1.0 - c
     end
@@ -39,7 +42,10 @@ for p in Vector{Float64}[
     @test pdf.(d, support(d)) == p
     @test pdf.(d, 1:k) == p
 
-    test_distr(d, 10^6)
+    # The test utilities are currently only able to handle Float64s
+    if partype(d) === Float64
+        test_distr(d, 10^6)
+    end
 end
 
 d = Categorical(4)
@@ -54,3 +60,5 @@ p = ones(10^6) * 1.0e-6
 
 @test typeof(convert(Categorical{Float32,Vector{Float32}}, d)) == Categorical{Float32,Vector{Float32}}
 @test typeof(convert(Categorical{Float32,Vector{Float32}}, d.p)) == Categorical{Float32,Vector{Float32}}
+
+end


### PR DESCRIPTION
Found another literal `Inf` in the wild. There was also a redundant `logpdf` method for `Categorical`.