### PR TITLE
Add varargs constructor for Categorical

### DIFF
--- a/src/univariate/discrete/categorical.jl
+++ b/src/univariate/discrete/categorical.jl
@@ -39,6 +39,8 @@ function Categorical(k::Integer; check_args=true)
     return Categorical{Float64,Vector{Float64}}(Base.OneTo(k), fill(1/k, k), check_args=check_args)
 end
 
+Categorical(probabilities::Real...; check_args=true) = Categorical([probabilities...]; check_args=check_args)
+
 ### Conversions
 
 convert(::Type{Categorical{P,Ps}}, x::AbstractVector{<:Real}) where {

--- a/test/categorical.jl
+++ b/test/categorical.jl
@@ -61,4 +61,8 @@ p = ones(10^6) * 1.0e-6
 @test typeof(convert(Categorical{Float32,Vector{Float32}}, d)) == Categorical{Float32,Vector{Float32}}
 @test typeof(convert(Categorical{Float32,Vector{Float32}}, d.p)) == Categorical{Float32,Vector{Float32}}
 
+@testset "test args... constructor" begin
+    @test Categorical(0.3, 0.7) == Categorical([0.3, 0.7])
+end
+
 end


### PR DESCRIPTION
This will make it easier to use the distribution in broadcasting. It made me wonder if we should deprecate the `Categorical(::Int)` constructor since it's tangentially ambiguous (although not ambiguous to the compiler.) Notice that I made this PR on top of the small fix in #1028.

I also wondered if we eventually should change the internal representation of `Categorical` to use a `Tuple` instead of `Vector` and then use the varargs constructor as the only allowed interface. It would both make the distribution much more efficient and, in my opinion, easier to use. The only issue would be if people often use `Categorical`s with a lot of outcomes. In any case, that is a PR for another day.