### PR TITLE
use logmvbeta in MatrixBeta and MatrixFDist

### DIFF
--- a/src/matrix/matrixbeta.jl
+++ b/src/matrix/matrixbeta.jl
@@ -107,7 +107,7 @@ end
 
 function matrixbeta_logc0(p::Int, n1::Real, n2::Real)
     #  returns the natural log of the normalizing constant for the pdf
-    return logmvgamma(p, (n1 + n2)/2) - logmvgamma(p, n1/2) - logmvgamma(p, n2/2)
+    return -logmvbeta(p, n1 / 2, n2 / 2)
 end
 
 function logkernel(d::MatrixBeta, U::AbstractMatrix)

--- a/src/matrix/matrixfdist.jl
+++ b/src/matrix/matrixfdist.jl
@@ -121,7 +121,7 @@ end
 function matrixfdist_logc0(n1::Real, n2::Real, B::AbstractPDMat)
     #  returns the natural log of the normalizing constant for the pdf
     p = dim(B)
-    term1 = logmvgamma(p, (n1 + n2)/2) - logmvgamma(p, n1/2) - logmvgamma(p, n2/2)
+    term1 = -logmvbeta(p, n1 / 2, n2 / 2)
     term2 = (n2 / 2) * logdet(B)
     return term1 + term2
 end


### PR DESCRIPTION
JuliaStats/StatsFuns.jl#72 has been merged and released, so it can be used when computing the integrating constants of the Matrix-Beta and Matrix-F distributions.