### PR TITLE
Fix type of rand for Bernoulli

### DIFF
--- a/src/univariate/discrete/bernoulli.jl
+++ b/src/univariate/discrete/bernoulli.jl
@@ -104,7 +104,7 @@ cf(d::Bernoulli, t::Real) = failprob(d) + succprob(d) * cis(t)
 
 #### Sampling
 
-rand(rng::AbstractRNG, d::Bernoulli) = rand(rng) <= succprob(d)
+rand(rng::AbstractRNG, d::Bernoulli) = rand(rng) <= succprob(d) ? 1 : 0
 
 #### MLE fitting
 


### PR DESCRIPTION
Fixes the type of `rand(Bernoulli())` to 1/0 like in other functions. Currently it is inconsistent:

```julia
using Distributions

rand(Bernoulli()) # true/false
rand(Bernoulli(), 1) # 1/0
```