### PR TITLE
improved mixture

### DIFF
--- a/perf/mixtures.jl
+++ b/perf/mixtures.jl
@@ -1,0 +1,108 @@
+using BenchmarkTools: @btime
+import Random
+using Distributions: AbstractMixtureModel, MixtureModel, Normal, pdf, ncomponents, probs, component, components
+
+# v0.22.1
+function current_master(d::AbstractMixtureModel, x)
+    K = ncomponents(d)
+    p = probs(d)
+    @assert length(p) == K
+    v = 0.0
+    @inbounds for i in eachindex(p)
+        pi = p[i]
+        if pi > 0.0
+            c = component(d, i)
+            v += pdf(c, x) * pi
+        end
+    end
+    return v
+end
+
+# compute the overhead of having a mixture
+function evaluate_manual_pdf(distributions, priors, x)
+    return sum(pdf(d, x) * p for (d, p) in zip(distributions, priors))
+end
+
+function improved_version(d, x)
+   p = probs(d)
+   return sum(enumerate(p)) do (i, pi)
+       if pi > 0
+           @inbounds c = component(d, i)
+           pdf(c, x) * pi
+       end
+   end
+end
+
+function improved_no_inbound(d, x)
+   p = probs(d)
+   return sum(enumerate(p)) do (i, pi)
+       if pi > 0
+           c = component(d, i)
+           pdf(c, x) * pi
+       end
+   end
+end
+
+function improved_zipped(d, x)
+   ps = probs(d)
+   cs = components(d)
+   return sum(p * pdf(c, x) for (p, c) in zip(ps, cs))
+end
+
+function improved_indexed(d, x)
+   ps = probs(d)
+   cs = components(d)
+   return sum(ps[i] * pdf(cs[i], x) for i in eachindex(ps))
+end
+
+distributions = [
+    Normal(-1.0, 0.3),
+    Normal(0.0, 0.5),
+    Normal(3.0, 1.0),
+]
+
+priors = [0.25, 0.25, 0.5]
+
+gmm_normal = MixtureModel(distributions, priors)
+
+Random.seed!(42)
+for x in rand(5)
+    @info "sampling $x"
+    @info "evaluate_manual_pdf"
+    vman = @btime evaluate_manual_pdf($distributions, $priors, $x)
+    @info "current_master"
+    vmaster =  @btime current_master($gmm_normal, $x)
+    @info "improved_version"
+    v1 = @btime improved_version($gmm_normal, $x)
+    @info "improved_no_inbound"
+    v2 = @btime improved_no_inbound($gmm_normal, $x)
+    @info "improved_zipped"
+    v3 = @btime improved_zipped($gmm_normal, $x)
+    @info "improved_indexed"
+    v4 = @btime improved_indexed($gmm_normal, $x)
+    @assert vman ≈ vmaster ≈ v1 ≈ v2 ≈ v3 ≈ v4
+end
+
+large_normals = [Normal(rand(), rand()) for _ in 1:1000]
+large_probs = [rand() for _ in 1:1000]
+large_probs .= large_probs ./ sum(large_probs)
+
+gmm_large = MixtureModel(large_normals, large_probs)
+
+Random.seed!(42)
+for x in rand(5)
+    @info "sampling $x"
+    @info "evaluate_manual_pdf"
+    vman = @btime evaluate_manual_pdf($large_normals, $large_probs, $x)
+    @info "current_master"
+    vmaster = @btime current_master($gmm_large, $x)
+    @info "improved_version"
+    v1 = @btime improved_version($gmm_large, $x)
+    @info "improved_no_inbound"
+    v2 = @btime improved_no_inbound($gmm_large, $x)
+    @info "improved_zipped"
+    v3 = @btime improved_zipped($gmm_large, $x)
+    @info "improved_indexed"
+    v4 = @btime improved_indexed($gmm_large, $x)
+    @assert vman ≈ vmaster ≈ v1 ≈ v2 ≈ v3 ≈ v4
+end

--- a/perf/mixtures.jl
+++ b/perf/mixtures.jl
@@ -1,6 +1,6 @@
 using BenchmarkTools: @btime
 import Random
-using Distributions: AbstractMixtureModel, MixtureModel, Normal, pdf, ncomponents, probs, component, components
+using Distributions: AbstractMixtureModel, MixtureModel, LogNormal, Normal, pdf, ncomponents, probs, component, components, ContinuousUnivariateDistribution
 
 # v0.22.1
 function current_master(d::AbstractMixtureModel, x)
@@ -65,6 +65,8 @@ priors = [0.25, 0.25, 0.5]
 
 gmm_normal = MixtureModel(distributions, priors)
 
+@info "Small Gausian mixture"
+
 Random.seed!(42)
 for x in rand(5)
     @info "sampling $x"
@@ -89,6 +91,8 @@ large_probs .= large_probs ./ sum(large_probs)
 
 gmm_large = MixtureModel(large_normals, large_probs)
 
+@info "Large Gausian mixture"
+
 Random.seed!(42)
 for x in rand(5)
     @info "sampling $x"
@@ -104,5 +108,35 @@ for x in rand(5)
     v3 = @btime improved_zipped($gmm_large, $x)
     @info "improved_indexed"
     v4 = @btime improved_indexed($gmm_large, $x)
+    @assert vman ≈ vmaster ≈ v1 ≈ v2 ≈ v3 ≈ v4
+end
+
+large_het = append!(
+    ContinuousUnivariateDistribution[Normal(rand(), rand()) for _ in 1:1000],
+    ContinuousUnivariateDistribution[LogNormal(rand(), rand()) for _ in 1:1000],
+)
+
+large_het_probs = [rand() for _ in 1:2000]
+large_het_probs .= large_het_probs ./ sum(large_het_probs)
+
+gmm_het = MixtureModel(large_het, large_het_probs)
+
+@info "Heterogeneous distributions"
+
+Random.seed!(42)
+for x in rand(5)
+    @info "sampling $x"
+    @info "evaluate_manual_pdf"
+    vman = @btime evaluate_manual_pdf($large_het, $large_het_probs, $x)
+    @info "current_master"
+    vmaster = @btime current_master($gmm_het, $x)
+    @info "improved_version"
+    v1 = @btime improved_version($gmm_het, $x)
+    @info "improved_no_inbound"
+    v2 = @btime improved_no_inbound($gmm_het, $x)
+    @info "improved_zipped"
+    v3 = @btime improved_zipped($gmm_het, $x)
+    @info "improved_indexed"
+    v4 = @btime improved_indexed($gmm_het, $x)
     @assert vman ≈ vmaster ≈ v1 ≈ v2 ≈ v3 ≈ v4
 end

--- a/perf/mixtures.jl
+++ b/perf/mixtures.jl
@@ -1,6 +1,7 @@
 using BenchmarkTools: @btime
 import Random
 using Distributions: AbstractMixtureModel, MixtureModel, LogNormal, Normal, pdf, ncomponents, probs, component, components, ContinuousUnivariateDistribution
+using Test
 
 # v0.22.1
 function current_master(d::AbstractMixtureModel, x)
@@ -24,35 +25,71 @@ function evaluate_manual_pdf(distributions, priors, x)
 end
 
 function improved_version(d, x)
-   p = probs(d)
-   return sum(enumerate(p)) do (i, pi)
-       if pi > 0
-           @inbounds c = component(d, i)
-           pdf(c, x) * pi
-       end
-   end
+    p = probs(d)
+    return sum(enumerate(p)) do (i, pi)
+        if pi > 0
+            @inbounds c = component(d, i)
+            pdf(c, x) * pi
+        else
+            zero(eltype(p))
+        end
+    end
 end
 
 function improved_no_inbound(d, x)
-   p = probs(d)
-   return sum(enumerate(p)) do (i, pi)
-       if pi > 0
+    p = probs(d)
+    return sum(enumerate(p)) do (i, pi)
+        if pi > 0
            c = component(d, i)
            pdf(c, x) * pi
-       end
-   end
+        else
+            zero(eltype(p))
+        end
+    end
 end
 
-function improved_zipped(d, x)
-   ps = probs(d)
-   cs = components(d)
-   return sum(p * pdf(c, x) for (p, c) in zip(ps, cs))
+function ifelse_version(d, x)
+    ps = probs(d)
+    cs = components(d)
+    P = eltype(ps)
+    return sum(ifelse(ps[i] > 0, ps[i] * pdf(cs[i], x), zero(P)) for i in eachindex(ps))
 end
 
-function improved_indexed(d, x)
-   ps = probs(d)
-   cs = components(d)
-   return sum(ps[i] * pdf(cs[i], x) for i in eachindex(ps))
+function forloop(d, x)
+    ps = probs(d)
+    cs = components(d)
+    s = zero(eltype(ps))
+    @inbounds for i in eachindex(ps)
+        if ps[i] > 0
+            s += ps[i] * pdf(cs[i], x)
+        end
+    end
+    return s
+end
+
+function indexed_sum_comp(d, x)
+    ps = probs(d)
+    cs = components(d)
+    @inbounds sum(ps[i] * pdf(cs[i], x) for i in eachindex(ps) if ps[i] > 0)
+end
+
+function indexed_boolprod(d, x)
+    ps = probs(d)
+    cs = components(d)
+    @inbounds sum((ps[i] > 0) * (ps[i] * pdf(cs[i], x)) for i in eachindex(ps))
+end
+
+function indexed_boolprod_noinbound(d, x)
+    ps = probs(d)
+    cs = components(d)
+    return sum((ps[i] > 0) * (ps[i] * pdf(cs[i], x)) for i in eachindex(ps))
+end
+
+function sumcomp_cond(d, x)
+    ps = probs(d)
+    cs = components(d)
+    s = zero(eltype(ps))
+    @inbounds sum(ps[i] * pdf(cs[i], x) for i in eachindex(ps) if ps[i] > 0)
 end
 
 distributions = [
@@ -78,11 +115,20 @@ for x in rand(5)
     v1 = @btime improved_version($gmm_normal, $x)
     @info "improved_no_inbound"
     v2 = @btime improved_no_inbound($gmm_normal, $x)
-    @info "improved_zipped"
-    v3 = @btime improved_zipped($gmm_normal, $x)
-    @info "improved_indexed"
-    v4 = @btime improved_indexed($gmm_normal, $x)
-    @assert vman ≈ vmaster ≈ v1 ≈ v2 ≈ v3 ≈ v4
+    @info "ifelse_version"
+    v3 = @btime ifelse_version($gmm_normal, $x)
+    @info "forloop"
+    v4 = @btime forloop($gmm_normal, $x)
+    @info "indexed_sum_comp"
+    v5 = @btime indexed_sum_comp($gmm_normal, $x)
+    @info "indexed_boolprod"
+    v6 = @btime indexed_boolprod($gmm_normal, $x)
+    @info "indexed_boolprod_noinbound"
+    v6 = @btime indexed_boolprod_noinbound($gmm_normal, $x)
+    @info "sumcomp_cond"
+    v7 = @btime sumcomp_cond($gmm_normal, $x)
+    @assert vman ≈ vmaster ≈ v1 ≈ v2 ≈ v3 ≈ v4 ≈ v5 ≈ v6 ≈ v7
+    @info "==================="
 end
 
 large_normals = [Normal(rand(), rand()) for _ in 1:1000]
@@ -99,16 +145,25 @@ for x in rand(5)
     @info "evaluate_manual_pdf"
     vman = @btime evaluate_manual_pdf($large_normals, $large_probs, $x)
     @info "current_master"
-    vmaster = @btime current_master($gmm_large, $x)
+    vmaster =  @btime current_master($gmm_large, $x)
     @info "improved_version"
     v1 = @btime improved_version($gmm_large, $x)
     @info "improved_no_inbound"
     v2 = @btime improved_no_inbound($gmm_large, $x)
-    @info "improved_zipped"
-    v3 = @btime improved_zipped($gmm_large, $x)
-    @info "improved_indexed"
-    v4 = @btime improved_indexed($gmm_large, $x)
-    @assert vman ≈ vmaster ≈ v1 ≈ v2 ≈ v3 ≈ v4
+    @info "ifelse_version"
+    v3 = @btime ifelse_version($gmm_large, $x)
+    @info "forloop"
+    v4 = @btime forloop($gmm_large, $x)
+    @info "indexed_sum_comp"
+    v5 = @btime indexed_sum_comp($gmm_large, $x)
+    @info "indexed_boolprod"
+    v6 = @btime indexed_boolprod($gmm_large, $x)
+    @info "indexed_boolprod_noinbound"
+    v6 = @btime indexed_boolprod_noinbound($gmm_large, $x)
+    @info "sumcomp_cond"
+    v7 = @btime sumcomp_cond($gmm_large, $x)
+    @assert vman ≈ vmaster ≈ v1 ≈ v2 ≈ v3 ≈ v4 ≈ v5 ≈ v6 ≈ v7
+    @info "==================="
 end
 
 large_het = append!(
@@ -129,14 +184,61 @@ for x in rand(5)
     @info "evaluate_manual_pdf"
     vman = @btime evaluate_manual_pdf($large_het, $large_het_probs, $x)
     @info "current_master"
-    vmaster = @btime current_master($gmm_het, $x)
+    vmaster =  @btime current_master($gmm_het, $x)
     @info "improved_version"
     v1 = @btime improved_version($gmm_het, $x)
     @info "improved_no_inbound"
     v2 = @btime improved_no_inbound($gmm_het, $x)
-    @info "improved_zipped"
-    v3 = @btime improved_zipped($gmm_het, $x)
-    @info "improved_indexed"
-    v4 = @btime improved_indexed($gmm_het, $x)
-    @assert vman ≈ vmaster ≈ v1 ≈ v2 ≈ v3 ≈ v4
+    @info "ifelse_version"
+    v3 = @btime ifelse_version($gmm_het, $x)
+    @info "forloop"
+    v4 = @btime forloop($gmm_het, $x)
+    @info "indexed_sum_comp"
+    v5 = @btime indexed_sum_comp($gmm_het, $x)
+    @info "indexed_boolprod"
+    v6 = @btime indexed_boolprod($gmm_het, $x)
+    @info "indexed_boolprod_noinbound"
+    v6 = @btime indexed_boolprod_noinbound($gmm_het, $x)
+    @info "sumcomp_cond"
+    v7 = @btime sumcomp_cond($gmm_het, $x)
+    @assert vman ≈ vmaster ≈ v1 ≈ v2 ≈ v3 ≈ v4 ≈ v5 ≈ v6 ≈ v7
+    @info "==================="
+end
+
+
+@info "Test with one NaN"
+
+distributions = [
+    Normal(-1.0, 0.3),
+    Normal(0.0, 0.5),
+    Normal(3.0, 1.0),
+    Normal(NaN, 1.0),
+]
+
+priors = [0.25, 0.25, 0.5, 0.0]
+
+gmm_normal = MixtureModel(distributions, priors)
+
+Random.seed!(42)
+for x in rand(1)
+    @info "sampling $x"
+    @info "current_master"
+    vmaster =  @btime current_master($gmm_normal, $x)
+    @info "improved_version"
+    v1 = @btime improved_version($gmm_normal, $x)
+    @info "improved_no_inbound"
+    v2 = @btime improved_no_inbound($gmm_normal, $x)
+    @info "ifelse_version"
+    v3 = @btime ifelse_version($gmm_normal, $x)
+    @info "forloop"
+    v4 = @btime forloop($gmm_normal, $x)
+    @info "indexed_sum_comp"
+    v5 = @btime indexed_sum_comp($gmm_normal, $x)
+    @info "indexed_boolprod"
+    v6 = @btime indexed_boolprod($gmm_normal, $x)
+    @info "indexed_boolprod_noinbound"
+    v7 = @btime indexed_boolprod_noinbound($gmm_normal, $x)
+    @info "sumcomp_cond"
+    v8 = @btime sumcomp_cond($gmm_normal, $x)
+    @test vmaster ≈ v1 ≈ v2 ≈ v3 ≈ v4 ≈ v5 ≈ v6 ≈ v7 ≈ v8
 end

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -308,9 +308,9 @@ cdf(d::UnivariateMixture{Continuous}, x::Real) = _cdf(d, x)
 cdf(d::UnivariateMixture{Discrete}, x::Integer) = _cdf(d, x)
 
 function _mixpdf1(d::AbstractMixtureModel, x)
-   ps = probs(d)
-   cs = components(d)
-   return sum(ps[i] * pdf(cs[i], x) for i in eachindex(ps))
+    ps = probs(d)
+    cs = components(d)
+    @inbounds sum((ps[i] > 0) * ps[i] * pdf(cs[i], x) for i in eachindex(ps))
 end
 
 function _mixpdf!(r::AbstractArray, d::AbstractMixtureModel, x)

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -48,7 +48,7 @@ component_type(d::AbstractMixtureModel{VF,VS,C}) where {VF,VS,C} = C
 
 Get a list of components of the mixture model `d`.
 """
-components(d::AbstractMixtureModel)
+components(d::AbstractMixtureModel) = [component(d, k) for k in Base.OneTo(ncomponents(d))]
 
 """
     probs(d::AbstractMixtureModel)

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -305,22 +305,12 @@ function _cdf(d::UnivariateMixture, x::Real)
 end
 
 cdf(d::UnivariateMixture{Continuous}, x::Real) = _cdf(d, x)
-cdf(d::UnivariateMixture{Discrete}, x::Int) = _cdf(d, x)
-
+cdf(d::UnivariateMixture{Discrete}, x::Integer) = _cdf(d, x)
 
 function _mixpdf1(d::AbstractMixtureModel, x)
-    K = ncomponents(d)
-    p = probs(d)
-    @assert length(p) == K
-    v = 0.0
-    @inbounds for i in eachindex(p)
-        pi = p[i]
-        if pi > 0.0
-            c = component(d, i)
-            v += pdf(c, x) * pi
-        end
-    end
-    return v
+   ps = probs(d)
+   cs = components(d)
+   return sum(ps[i] * pdf(cs[i], x) for i in eachindex(ps))
 end
 
 function _mixpdf!(r::AbstractArray, d::AbstractMixtureModel, x)

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -279,7 +279,6 @@ end
 function insupport(d::AbstractMixtureModel, x::AbstractVector)
     K = ncomponents(d)
     p = probs(d)
-    @assert length(p) == K
     @inbounds for i in eachindex(p)
         pi = p[i]
         if pi > 0.0 && insupport(component(d, i), x)
@@ -292,7 +291,6 @@ end
 function _cdf(d::UnivariateMixture, x::Real)
     K = ncomponents(d)
     p = probs(d)
-    @assert length(p) == K
     r = 0.0
     @inbounds for i in eachindex(p)
         pi = p[i]
@@ -310,13 +308,12 @@ cdf(d::UnivariateMixture{Discrete}, x::Integer) = _cdf(d, x)
 function _mixpdf1(d::AbstractMixtureModel, x)
     ps = probs(d)
     cs = components(d)
-    @inbounds sum((ps[i] > 0) * ps[i] * pdf(cs[i], x) for i in eachindex(ps))
+    return sum((ps[i] > 0) * ps[i] * pdf(cs[i], x) for i in eachindex(ps))
 end
 
 function _mixpdf!(r::AbstractArray, d::AbstractMixtureModel, x)
     K = ncomponents(d)
     p = probs(d)
-    @assert length(p) == K
     fill!(r, 0.0)
     t = Array{eltype(p)}(undef, size(r))
     @inbounds for i in eachindex(p)
@@ -347,8 +344,6 @@ function _mixlogpdf1(d::AbstractMixtureModel, x)
 
     K = ncomponents(d)
     p = probs(d)
-    @assert length(p) == K
-
     lp = Vector{eltype(p)}(undef, K)
     m = -Inf   # m <- the maximum of log(p(cs[i], x)) + log(pri[i])
     @inbounds for i in eachindex(p)
@@ -374,7 +369,6 @@ end
 function _mixlogpdf!(r::AbstractArray, d::AbstractMixtureModel, x)
     K = ncomponents(d)
     p = probs(d)
-    @assert length(p) == K
     n = length(r)
     Lp = Matrix{eltype(p)}(undef, n, K)
     m = fill(-Inf, n)

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -308,7 +308,7 @@ cdf(d::UnivariateMixture{Discrete}, x::Integer) = _cdf(d, x)
 function _mixpdf1(d::AbstractMixtureModel, x)
     ps = probs(d)
     cs = components(d)
-    return sum((ps[i] > 0) * ps[i] * pdf(cs[i], x) for i in eachindex(ps))
+    return sum((ps[i] > 0) * (ps[i] * pdf(cs[i], x)) for i in eachindex(ps))
 end
 
 function _mixpdf!(r::AbstractArray, d::AbstractMixtureModel, x)

--- a/test/mixture.jl
+++ b/test/mixture.jl
@@ -208,7 +208,6 @@ end
             gmm_normal = MixtureModel(distributions, priors)
             for x in rand(10)
                 result = pdf(gmm_normal, x)
-                @info "$(@which pdf(gmm_normal, x))"
                 @test !isnan(result)
             end
         end

--- a/test/mixture.jl
+++ b/test/mixture.jl
@@ -196,6 +196,22 @@ end
             @test maximum(g_u) == Inf
             @test extrema(g_u) == (-Inf, Inf)
         end
+
+        @testset "Product 0 NaN in mixtures" begin
+            distributions = [
+                Normal(-1.0, 0.3),
+                Normal(0.0, 0.5),
+                Normal(3.0, 1.0),
+                Normal(NaN, 1.0),
+            ]
+            priors = [0.25, 0.25, 0.5, 0.0]
+            gmm_normal = MixtureModel(distributions, priors)
+            for x in rand(10)
+                result = pdf(gmm_normal, x)
+                @info "$(@which pdf(gmm_normal, x))"
+                @test !isnan(result)
+            end
+        end
     end
 
     @testset "Testing MultivariatevariateMixture" begin


### PR DESCRIPTION
The performance of mixture models is terrible at the moment, as proved in the added `perf/mixtures.jl` file.

Here are the result:
```julia
julia> include("mixtures.jl")
[ Info: sampling 0.5331830160438613
[ Info: evaluate_manual_pdf
  75.281 ns (3 allocations: 80 bytes)
[ Info: current_master
  470.505 ns (15 allocations: 272 bytes)
[ Info: improved_version
  553.541 ns (9 allocations: 192 bytes)
[ Info: improved_no_inbound
  584.072 ns (9 allocations: 192 bytes)
[ Info: improved_zipped
  377.395 ns (5 allocations: 112 bytes)
[ Info: improved_indexed
  263.629 ns (5 allocations: 112 bytes)
[ Info: sampling 0.4540291355871424
[ Info: evaluate_manual_pdf
  75.168 ns (3 allocations: 80 bytes)
[ Info: current_master
  470.010 ns (15 allocations: 272 bytes)
[ Info: improved_version
  569.508 ns (9 allocations: 192 bytes)
[ Info: improved_no_inbound
  599.706 ns (9 allocations: 192 bytes)
[ Info: improved_zipped
  371.519 ns (5 allocations: 112 bytes)
[ Info: improved_indexed
  267.948 ns (5 allocations: 112 bytes)
[ Info: sampling 0.017686826714964354
[ Info: evaluate_manual_pdf
  69.143 ns (3 allocations: 80 bytes)
[ Info: current_master
  464.056 ns (15 allocations: 272 bytes)
[ Info: improved_version
  560.951 ns (9 allocations: 192 bytes)
[ Info: improved_no_inbound
  577.039 ns (9 allocations: 192 bytes)
[ Info: improved_zipped
  358.352 ns (5 allocations: 112 bytes)
[ Info: improved_indexed
  264.006 ns (5 allocations: 112 bytes)
[ Info: sampling 0.17293302893695128
[ Info: evaluate_manual_pdf
  69.242 ns (3 allocations: 80 bytes)
[ Info: current_master
  464.408 ns (15 allocations: 272 bytes)
[ Info: improved_version
  564.859 ns (9 allocations: 192 bytes)
[ Info: improved_no_inbound
  584.464 ns (9 allocations: 192 bytes)
[ Info: improved_zipped
  365.293 ns (5 allocations: 112 bytes)
[ Info: improved_indexed
  263.831 ns (5 allocations: 112 bytes)
[ Info: sampling 0.9589258763297348
[ Info: evaluate_manual_pdf
  76.720 ns (3 allocations: 80 bytes)
[ Info: current_master
  455.234 ns (15 allocations: 272 bytes)
[ Info: improved_version
  583.144 ns (9 allocations: 192 bytes)
[ Info: improved_no_inbound
  586.072 ns (9 allocations: 192 bytes)
[ Info: improved_zipped
  371.335 ns (5 allocations: 112 bytes)
[ Info: improved_indexed
  268.012 ns (5 allocations: 112 bytes)
[ Info: sampling 0.5331830160438613
[ Info: evaluate_manual_pdf
  15.936 μs (3 allocations: 80 bytes)
[ Info: current_master
  129.241 μs (5980 allocations: 109.05 KiB)
[ Info: improved_version
  15.914 μs (9 allocations: 192 bytes)
[ Info: improved_no_inbound
  15.928 μs (9 allocations: 192 bytes)
[ Info: improved_zipped
  16.240 μs (5 allocations: 112 bytes)
[ Info: improved_indexed
  15.569 μs (5 allocations: 112 bytes)
[ Info: sampling 0.4540291355871424
[ Info: evaluate_manual_pdf
  15.991 μs (3 allocations: 80 bytes)
[ Info: current_master
  129.735 μs (5980 allocations: 109.05 KiB)
[ Info: improved_version
  15.903 μs (9 allocations: 192 bytes)
[ Info: improved_no_inbound
  15.809 μs (9 allocations: 192 bytes)
[ Info: improved_zipped
  16.216 μs (5 allocations: 112 bytes)
[ Info: improved_indexed
  15.667 μs (5 allocations: 112 bytes)
[ Info: sampling 0.017686826714964354
[ Info: evaluate_manual_pdf
  18.499 μs (3 allocations: 80 bytes)
[ Info: current_master
  133.670 μs (5980 allocations: 109.05 KiB)
[ Info: improved_version
  18.441 μs (9 allocations: 192 bytes)
[ Info: improved_no_inbound
  18.231 μs (9 allocations: 192 bytes)
[ Info: improved_zipped
  19.053 μs (5 allocations: 112 bytes)
[ Info: improved_indexed
  18.187 μs (5 allocations: 112 bytes)
[ Info: sampling 0.17293302893695128
[ Info: evaluate_manual_pdf
  16.944 μs (3 allocations: 80 bytes)
[ Info: current_master
  132.169 μs (5980 allocations: 109.05 KiB)
[ Info: improved_version
  16.825 μs (9 allocations: 192 bytes)
[ Info: improved_no_inbound
  16.680 μs (9 allocations: 192 bytes)
[ Info: improved_zipped
  17.417 μs (5 allocations: 112 bytes)
[ Info: improved_indexed
  16.610 μs (5 allocations: 112 bytes)
[ Info: sampling 0.9589258763297348
[ Info: evaluate_manual_pdf
  18.232 μs (3 allocations: 80 bytes)
[ Info: current_master
  133.976 μs (5980 allocations: 109.05 KiB)
[ Info: improved_version
  18.175 μs (9 allocations: 192 bytes)
[ Info: improved_no_inbound
  18.163 μs (9 allocations: 192 bytes)
[ Info: improved_zipped
  18.823 μs (5 allocations: 112 bytes)
[ Info: improved_indexed
  17.981 μs (5 allocations: 112 bytes)
```