### PR TITLE
Fix typestability of (log)pdf, (log)cdf, (log)ccdf, and gradlogpdf for LogNormal

### DIFF
--- a/src/univariate/continuous/lognormal.jl
+++ b/src/univariate/continuous/lognormal.jl
@@ -33,7 +33,7 @@ struct LogNormal{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function LogNormal(μ::T, σ::T; check_args=true) where {T <: Real}
-    check_args && @check_args(LogNormal, σ > zero(σ))
+    check_args && @check_args(LogNormal, σ ≥ zero(σ))
     return LogNormal{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/lognormal.jl
+++ b/src/univariate/continuous/lognormal.jl
@@ -92,29 +92,57 @@ end
 
 #### Evalution
 
-pdf(d::LogNormal, x::Real) = normpdf(d.μ, d.σ, log(x)) / x
-function logpdf(d::LogNormal{T}, x::Real) where T<:Real
-    if !insupport(d, x)
-        return -T(Inf)
+function pdf(d::LogNormal, x::Real)
+    if x ≤ zero(x)
+        logx = log(zero(x))
+        x = one(x)
     else
-        lx = log(x)
-        return normlogpdf(d.μ, d.σ, lx) - lx
+        logx = log(x)
     end
+    return pdf(Normal(d.μ, d.σ), logx) / x
 end
 
-cdf(d::LogNormal{T}, x::Real) where {T<:Real} = x > 0 ? cdf(Normal(params(d)...), log(x)) : zero(T)
-ccdf(d::LogNormal{T}, x::Real) where {T<:Real} = x > 0 ? ccdf(Normal(params(d)...), log(x)) : one(T)
-logcdf(d::LogNormal{T}, x::Real) where {T<:Real} = x > 0 ? logcdf(Normal(params(d)...), log(x)) : -T(Inf)
-logccdf(d::LogNormal{T}, x::Real) where {T<:Real} = x > 0 ? logccdf(Normal(params(d)...), log(x)) : zero(T)
+function logpdf(d::LogNormal, x::Real)
+    if x ≤ zero(x)
+        logx = log(zero(x))
+        b = zero(logx)
+    else
+        logx = log(x)
+        b = logx
+    end
+    return logpdf(Normal(d.μ, d.σ), logx) - b
+end
+
+function cdf(d::LogNormal, x::Real)
+    logx = x ≤ zero(x) ? log(zero(x)) : log(x)
+    return cdf(Normal(d.μ, d.σ), logx)
+end
+
+function ccdf(d::LogNormal, x::Real)
+    logx = x ≤ zero(x) ? log(zero(x)) : log(x)
+    return ccdf(Normal(d.μ, d.σ), logx)
+    end
+
+function logcdf(d::LogNormal, x::Real)
+    logx = x ≤ zero(x) ? log(zero(x)) : log(x)
+    return logcdf(Normal(d.μ, d.σ), logx)
+end
+
+function logccdf(d::LogNormal, x::Real)
+    logx = x ≤ zero(x) ? log(zero(x)) : log(x)
+    return logccdf(Normal(d.μ, d.σ), logx)
+end
 
 quantile(d::LogNormal, q::Real) = exp(quantile(Normal(params(d)...), q))
 cquantile(d::LogNormal, q::Real) = exp(cquantile(Normal(params(d)...), q))
 invlogcdf(d::LogNormal, lq::Real) = exp(invlogcdf(Normal(params(d)...), lq))
 invlogccdf(d::LogNormal, lq::Real) = exp(invlogccdf(Normal(params(d)...), lq))
 
-function gradlogpdf(d::LogNormal{T}, x::Real) where T<:Real
-    (μ, σ) = params(d)
-    x > 0 ? - ((log(x) - μ) / (σ^2) + 1) / x : zero(T)
+function gradlogpdf(d::LogNormal, x::Real)
+    outofsupport = x ≤ zero(x)
+    y = outofsupport ? one(x) : x
+    z = (gradlogpdf(Normal(d.μ, d.σ), log(y)) - 1) / y
+    return outofsupport ? zero(z) : z
 end
 
 # mgf(d::LogNormal)

--- a/test/lognormal.jl
+++ b/test/lognormal.jl
@@ -1,0 +1,308 @@
+using Distributions
+using ForwardDiff
+using Test
+
+isnan_type(::Type{T}, v) where {T} = isnan(v) && v isa T
+
+@testset "LogNormal" begin
+    @test isa(convert(LogNormal{Float64}, Float16(0), Float16(1)),
+              LogNormal{Float64})
+    @test logpdf(LogNormal(0, 0), 1) === Inf
+    @test logpdf(LogNormal(), Inf) === -Inf
+    @test iszero(logcdf(LogNormal(0, 0), 1))
+    @test iszero(logcdf(LogNormal(), Inf))
+    @test logdiffcdf(LogNormal(), Float32(exp(5)), Float32(exp(3))) ≈ -6.6079385945968929 rtol=1e-12
+    @test logdiffcdf(LogNormal(), Float64(exp(5)), Float64(exp(3))) ≈ -6.6079385945968929 rtol=1e-12
+    let d = LogNormal(Float64(0), Float64(1)), x = Float64(exp(-60)), y = Float64(exp(-60.001))
+        float_res = logdiffcdf(d, x, y)
+        big_float_res = log(cdf(d, BigFloat(x, 100)) - cdf(d, BigFloat(y, 100)))
+        @test float_res ≈ big_float_res
+    end
+
+    @test logccdf(LogNormal(0, 0), 1) === -Inf
+    @test iszero(logccdf(LogNormal(eps(), 0), 1))
+
+    @test iszero(quantile(LogNormal(), 0))
+    @test isone(quantile(LogNormal(), 0.5))
+    @test quantile(LogNormal(), 1) === Inf
+
+    @test iszero(quantile(LogNormal(0, 0), 0))
+    @test isone(quantile(LogNormal(0, 0), 0.75))
+    @test quantile(LogNormal(0, 0), 1) === Inf
+
+    @test iszero(quantile(LogNormal(0.25, 0), 0))
+    @test quantile(LogNormal(0.25, 0), 0.95) == exp(0.25)
+    @test quantile(LogNormal(0.25, 0), 1) === Inf
+
+    @test cquantile(LogNormal(), 0) === Inf
+    @test isone(cquantile(LogNormal(), 0.5))
+    @test iszero(cquantile(LogNormal(), 1))
+
+    @test cquantile(LogNormal(0, 0), 0) === Inf
+    @test isone(cquantile(LogNormal(0, 0), 0.75))
+    @test iszero(cquantile(LogNormal(0, 0), 1))
+
+    @test cquantile(LogNormal(0.25, 0), 0) === Inf
+    @test cquantile(LogNormal(0.25, 0), 0.95) == exp(0.25)
+    @test iszero(cquantile(LogNormal(0.25, 0), 1))
+
+    @test iszero(invlogcdf(LogNormal(), -Inf))
+    @test isnan_type(Float64, invlogcdf(LogNormal(), NaN))
+
+    @test invlogccdf(LogNormal(), -Inf) === Inf
+    @test isnan_type(Float64, invlogccdf(LogNormal(), NaN))
+
+    # test for #996 being fixed
+    let d = LogNormal(0, 1), x = exp(1), ∂x = exp(2)
+        @inferred cdf(d, ForwardDiff.Dual(x, ∂x)) ≈ ForwardDiff.Dual(cdf(d, x), ∂x * pdf(d, x))
+    end
+end
+
+
+@testset "LogNormal type inference" begin
+    # pdf
+    @test @inferred(pdf(LogNormal(0.0, 0.0), 1.0)) === Inf
+    @test @inferred(pdf(LogNormal(0.0, 0.0), 0.5)) === 0.0
+    @test @inferred(pdf(LogNormal(0.0, 0.0), 0.0)) === 0.0
+    @test @inferred(pdf(LogNormal(0.0, 0.0), -0.5)) === 0.0
+
+    @test @inferred(pdf(LogNormal(0.0, 0.0), 1.0f0)) === Inf
+    @test @inferred(pdf(LogNormal(0.0f0, 0.0f0), 1.0)) === Inf
+    @test @inferred(pdf(LogNormal(0.0f0, 0.0f0), 1.0f0)) === Inf32
+
+    @test isnan_type(Float64, @inferred(pdf(LogNormal(0.0, 0.0), NaN)))
+    @test isnan_type(Float64, @inferred(pdf(LogNormal(NaN, 0.0), 1.0f0)))
+    @test isnan_type(Float64, @inferred(pdf(LogNormal(NaN, 0.0), 0.0f0)))
+    @test isnan_type(Float64, @inferred(pdf(LogNormal(NaN, 0.0), -1.0f0)))
+
+    @test isnan_type(Float32, @inferred(pdf(LogNormal(NaN32, 0.0f0), 1.0f0)))
+    @test isnan_type(Float32, @inferred(pdf(LogNormal(NaN32, 0.0f0), 0.0f0)))
+    @test isnan_type(Float32, @inferred(pdf(LogNormal(NaN32, 0.0f0), -1.0f0)))
+
+    @test @inferred(pdf(LogNormal(0 // 1, 0 // 1), 1 // 1)) === Inf
+    @test @inferred(pdf(LogNormal(0 // 1, 0 // 1), 0 // 1)) === 0.0
+    @test @inferred(pdf(LogNormal(0 // 1, 0 // 1), -1 // 1)) === 0.0
+    @test isnan_type(Float64, @inferred(pdf(LogNormal(0 // 1, 0 // 1), NaN)))
+
+    @test @inferred(pdf(LogNormal(0.0, 0.0), BigInt(1))) == big(Inf)
+    @test @inferred(pdf(LogNormal(0.0, 0.0), BigInt(0))) == big(0.0)
+    @test @inferred(pdf(LogNormal(0.0, 0.0), BigInt(-1))) == big(0.0)
+    @test @inferred(pdf(LogNormal(0.0, 0.0), BigFloat(1))) == big(Inf)
+    @test @inferred(pdf(LogNormal(0.0, 0.0), BigFloat(0))) == big(0.0)
+    @test @inferred(pdf(LogNormal(0.0, 0.0), BigFloat(-1))) == big(0.0)
+    @test isnan_type(BigFloat, @inferred(pdf(LogNormal(0.0, 0.0), BigFloat(NaN))))
+
+    # logpdf
+    @test @inferred(logpdf(LogNormal(0.0, 0.0), 1.0)) === Inf
+    @test @inferred(logpdf(LogNormal(0.0, 0.0), 0.5)) === -Inf
+    @test @inferred(logpdf(LogNormal(0.0, 0.0), 0.0)) === -Inf
+    @test @inferred(logpdf(LogNormal(0.0, 0.0), -0.5)) === -Inf
+
+    @test @inferred(logpdf(LogNormal(0.0, 0.0), 1.0f0)) === Inf
+    @test @inferred(logpdf(LogNormal(0.0f0, 0.0f0), 1.0)) === Inf
+    @test @inferred(logpdf(LogNormal(0.0f0, 0.0f0), 1.0f0)) === Inf32
+
+    @test isnan_type(Float64, @inferred(logpdf(LogNormal(0.0, 0.0), NaN)))
+    @test isnan_type(Float64, @inferred(logpdf(LogNormal(NaN, 0.0), 1.0f0)))
+    @test isnan_type(Float64, @inferred(logpdf(LogNormal(NaN, 0.0), 0.0f0)))
+    @test isnan_type(Float64, @inferred(logpdf(LogNormal(NaN, 0.0), -1.0f0)))
+
+    @test isnan_type(Float32, @inferred(logpdf(LogNormal(NaN32, 0.0f0), 1.0f0)))
+    @test isnan_type(Float32, @inferred(logpdf(LogNormal(NaN32, 0.0f0), 0.0f0)))
+    @test isnan_type(Float32, @inferred(logpdf(LogNormal(NaN32, 0.0f0), -1.0f0)))
+
+    @test @inferred(logpdf(LogNormal(0 // 1, 0 // 1), 1 // 1)) === Inf
+    @test @inferred(logpdf(LogNormal(0 // 1, 0 // 1), 0 // 1)) === -Inf
+    @test @inferred(logpdf(LogNormal(0 // 1, 0 // 1), -1 // 1)) === -Inf
+    @test isnan_type(Float64, @inferred(logpdf(LogNormal(0 // 1, 0 // 1), NaN)))
+
+    @test @inferred(logpdf(LogNormal(0.0, 0.0), BigInt(1))) == big(Inf)
+    @test @inferred(logpdf(LogNormal(0.0, 0.0), BigInt(0))) == big(-Inf)
+    @test @inferred(logpdf(LogNormal(0.0, 0.0), BigInt(-1))) == big(-Inf)
+    @test @inferred(logpdf(LogNormal(0.0, 0.0), BigFloat(1))) == big(Inf)
+    @test @inferred(logpdf(LogNormal(0.0, 0.0), BigFloat(0))) == big(-Inf)
+    @test @inferred(logpdf(LogNormal(0.0, 0.0), BigFloat(-1))) == big(-Inf)
+    @test isnan_type(BigFloat, @inferred(logpdf(LogNormal(0.0, 0.0), BigFloat(NaN))))
+
+    # cdf
+    @test @inferred(cdf(LogNormal(0.0, 0.0), 1.0)) === 1.0
+    @test @inferred(cdf(LogNormal(0.0, 0.0), 0.5)) === 0.0
+    @test @inferred(cdf(LogNormal(0.0, 0.0), 0.0)) === 0.0
+    @test @inferred(cdf(LogNormal(0.0, 0.0), -0.5)) === 0.0
+
+    @test @inferred(cdf(LogNormal(0.0, 0.0), 1.0f0)) === 1.0
+    @test @inferred(cdf(LogNormal(0.0f0, 0.0f0), 1.0)) === 1.0
+    @test @inferred(cdf(LogNormal(0.0f0, 0.0f0), 1.0f0)) === 1.0f0
+
+    @test isnan_type(Float64, @inferred(cdf(LogNormal(0.0, 0.0), NaN)))
+    @test isnan_type(Float64, @inferred(cdf(LogNormal(NaN, 0.0), 1.0f0)))
+    @test isnan_type(Float64, @inferred(cdf(LogNormal(NaN, 0.0), 0.0f0)))
+    @test isnan_type(Float64, @inferred(cdf(LogNormal(NaN, 0.0), -1.0f0)))
+
+    @test isnan_type(Float32, @inferred(cdf(LogNormal(NaN32, 0.0f0), 1.0f0)))
+    @test isnan_type(Float32, @inferred(cdf(LogNormal(NaN32, 0.0f0), 0.0f0)))
+    @test isnan_type(Float32, @inferred(cdf(LogNormal(NaN32, 0.0f0), -1.0f0)))
+
+    @test @inferred(cdf(LogNormal(0 // 1, 0 // 1), 1 // 1)) === 1.0
+    @test @inferred(cdf(LogNormal(0 // 1, 0 // 1), 0 // 1)) === 0.0
+    @test @inferred(cdf(LogNormal(0 // 1, 0 // 1), -1 // 1)) === 0.0
+    @test isnan_type(Float64, @inferred(cdf(LogNormal(0 // 1, 0 // 1), NaN)))
+
+    @test @inferred(cdf(LogNormal(0.0, 0.0), BigInt(1))) == big(1.0)
+    @test @inferred(cdf(LogNormal(0.0, 0.0), BigInt(0))) == big(0.0)
+    @test @inferred(cdf(LogNormal(0.0, 0.0), BigInt(-1))) == big(0.0)
+    @test @inferred(cdf(LogNormal(0.0, 0.0), BigFloat(1))) == big(1.0)
+    @test @inferred(cdf(LogNormal(0.0, 0.0), BigFloat(0))) == big(0.0)
+    @test @inferred(cdf(LogNormal(0.0, 0.0), BigFloat(-1))) == big(0.0)
+    @test isnan_type(BigFloat, @inferred(cdf(LogNormal(0.0, 0.0), BigFloat(NaN))))
+
+    # logcdf
+    @test @inferred(logcdf(LogNormal(0.0, 0.0), 1.0)) === -0.0
+    @test @inferred(logcdf(LogNormal(0.0, 0.0), 0.5)) === -Inf
+    @test @inferred(logcdf(LogNormal(0.0, 0.0), 0.0)) === -Inf
+    @test @inferred(logcdf(LogNormal(0.0, 0.0), -0.5)) === -Inf
+
+    @test @inferred(logcdf(LogNormal(0.0, 0.0), 1.0f0)) === -0.0
+    @test @inferred(logcdf(LogNormal(0.0f0, 0.0f0), 1.0)) === -0.0
+    @test @inferred(logcdf(LogNormal(0.0f0, 0.0f0), 1.0f0)) === -0.0f0
+
+    @test isnan_type(Float64, @inferred(logcdf(LogNormal(0.0, 0.0), NaN)))
+    @test isnan_type(Float64, @inferred(logcdf(LogNormal(NaN, 0.0), 1.0f0)))
+    @test isnan_type(Float64, @inferred(logcdf(LogNormal(NaN, 0.0), 0.0f0)))
+    @test isnan_type(Float64, @inferred(logcdf(LogNormal(NaN, 0.0), -1.0f0)))
+
+    @test isnan_type(Float32, @inferred(logcdf(LogNormal(NaN32, 0.0f0), 1.0f0)))
+    @test isnan_type(Float32, @inferred(logcdf(LogNormal(NaN32, 0.0f0), 0.0f0)))
+    @test isnan_type(Float32, @inferred(logcdf(LogNormal(NaN32, 0.0f0), -1.0f0)))
+
+    @test @inferred(logcdf(LogNormal(0 // 1, 0 // 1), 1 // 1)) === -0.0
+    @test @inferred(logcdf(LogNormal(0 // 1, 0 // 1), 0 // 1)) === -Inf
+    @test @inferred(logcdf(LogNormal(0 // 1, 0 // 1), -1 // 1)) === -Inf
+    @test isnan_type(Float64, @inferred(logcdf(LogNormal(0 // 1, 0 // 1), NaN)))
+
+    @test @inferred(logcdf(LogNormal(0.0, 0.0), BigInt(1))) == big(0.0)
+    @test @inferred(logcdf(LogNormal(0.0, 0.0), BigInt(0))) == big(-Inf)
+    @test @inferred(logcdf(LogNormal(0.0, 0.0), BigInt(-1))) == big(-Inf)
+    @test @inferred(logcdf(LogNormal(0.0, 0.0), BigFloat(1))) == big(0.0)
+    @test @inferred(logcdf(LogNormal(0.0, 0.0), BigFloat(0))) == big(-Inf)
+    @test @inferred(logcdf(LogNormal(0.0, 0.0), BigFloat(-1))) == big(-Inf)
+    @test isnan_type(BigFloat, @inferred(logcdf(LogNormal(0.0, 0.0), BigFloat(NaN))))
+
+    # ccdf
+    @test @inferred(ccdf(LogNormal(0.0, 0.0), 1.0)) === 0.0
+    @test @inferred(ccdf(LogNormal(0.0, 0.0), 0.5)) === 1.0
+    @test @inferred(ccdf(LogNormal(0.0, 0.0), 0.0)) === 1.0
+    @test @inferred(ccdf(LogNormal(0.0, 0.0), -0.5)) === 1.0
+
+    @test @inferred(ccdf(LogNormal(0.0, 0.0), 1.0f0)) === 0.0
+    @test @inferred(ccdf(LogNormal(0.0f0, 0.0f0), 1.0)) === 0.0
+    @test @inferred(ccdf(LogNormal(0.0f0, 0.0f0), 1.0f0)) === 0.0f0
+
+    @test isnan_type(Float64, @inferred(ccdf(LogNormal(0.0, 0.0), NaN)))
+    @test isnan_type(Float64, @inferred(ccdf(LogNormal(NaN, 0.0), 1.0f0)))
+    @test isnan_type(Float64, @inferred(ccdf(LogNormal(NaN, 0.0), 0.0f0)))
+    @test isnan_type(Float64, @inferred(ccdf(LogNormal(NaN, 0.0), -1.0f0)))
+
+    @test isnan_type(Float32, @inferred(ccdf(LogNormal(NaN32, 0.0f0), 1.0f0)))
+    @test isnan_type(Float32, @inferred(ccdf(LogNormal(NaN32, 0.0f0), 0.0f0)))
+    @test isnan_type(Float32, @inferred(ccdf(LogNormal(NaN32, 0.0f0), -1.0f0)))
+
+    @test @inferred(ccdf(LogNormal(0 // 1, 0 // 1), 1 // 1)) === 0.0
+    @test @inferred(ccdf(LogNormal(0 // 1, 0 // 1), 0 // 1)) === 1.0
+    @test @inferred(ccdf(LogNormal(0 // 1, 0 // 1), -1 // 1)) === 1.0
+    @test isnan_type(Float64, @inferred(ccdf(LogNormal(0 // 1, 0 // 1), NaN)))
+
+    @test @inferred(ccdf(LogNormal(0.0, 0.0), BigInt(1))) == big(0.0)
+    @test @inferred(ccdf(LogNormal(0.0, 0.0), BigInt(0))) == big(1.0)
+    @test @inferred(ccdf(LogNormal(0.0, 0.0), BigInt(-1))) == big(1.0)
+    @test @inferred(ccdf(LogNormal(0.0, 0.0), BigFloat(1))) == big(0.0)
+    @test @inferred(ccdf(LogNormal(0.0, 0.0), BigFloat(0))) == big(1.0)
+    @test @inferred(ccdf(LogNormal(0.0, 0.0), BigFloat(-1))) == big(1.0)
+    @test isnan_type(BigFloat, @inferred(ccdf(LogNormal(0.0, 0.0), BigFloat(NaN))))
+
+    # logccdf
+    @test @inferred(logccdf(LogNormal(0.0, 0.0), 1.0)) === -Inf
+    @test @inferred(logccdf(LogNormal(0.0, 0.0), 0.5)) === -0.0
+    @test @inferred(logccdf(LogNormal(0.0, 0.0), 0.0)) === -0.0
+    @test @inferred(logccdf(LogNormal(0.0, 0.0), -0.5)) === -0.0
+
+    @test @inferred(logccdf(LogNormal(0.0, 0.0), 1.0f0)) === -Inf
+    @test @inferred(logccdf(LogNormal(0.0f0, 0.0f0), 1.0)) === -Inf
+    @test @inferred(logccdf(LogNormal(0.0f0, 0.0f0), 1.0f0)) === -Inf32
+
+    @test isnan_type(Float64, @inferred(logccdf(LogNormal(0.0, 0.0), NaN)))
+    @test isnan_type(Float64, @inferred(logccdf(LogNormal(NaN, 0.0), 1.0f0)))
+    @test isnan_type(Float64, @inferred(logccdf(LogNormal(NaN, 0.0), 0.0f0)))
+    @test isnan_type(Float64, @inferred(logccdf(LogNormal(NaN, 0.0), -1.0f0)))
+
+    @test isnan_type(Float32, @inferred(logccdf(LogNormal(NaN32, 0.0f0), 1.0f0)))
+    @test isnan_type(Float32, @inferred(logccdf(LogNormal(NaN32, 0.0f0), 0.0f0)))
+    @test isnan_type(Float32, @inferred(logccdf(LogNormal(NaN32, 0.0f0), -1.0f0)))
+
+    @test @inferred(logccdf(LogNormal(0 // 1, 0 // 1), 1 // 1)) === -Inf
+    @test @inferred(logccdf(LogNormal(0 // 1, 0 // 1), 0 // 1)) === -0.0
+    @test @inferred(logccdf(LogNormal(0 // 1, 0 // 1), -1 // 1)) === -0.0
+    @test isnan_type(Float64, @inferred(logccdf(LogNormal(0 // 1, 0 // 1), NaN)))
+
+    @test @inferred(logccdf(LogNormal(0.0, 0.0), BigInt(1))) == big(-Inf)
+    @test @inferred(logccdf(LogNormal(0.0, 0.0), BigInt(0))) == big(0.0)
+    @test @inferred(logccdf(LogNormal(0.0, 0.0), BigInt(-1))) == big(0.0)
+    @test @inferred(logccdf(LogNormal(0.0, 0.0), BigFloat(1))) == big(-Inf)
+    @test @inferred(logccdf(LogNormal(0.0, 0.0), BigFloat(0))) == big(0.0)
+    @test @inferred(logccdf(LogNormal(0.0, 0.0), BigFloat(-1))) == big(0.0)
+    @test isnan_type(BigFloat, @inferred(logccdf(LogNormal(0.0, 0.0), BigFloat(NaN))))
+
+    # quantile
+    @test @inferred(quantile(LogNormal(1.0, 0.0), 0.0f0)) === 0.0
+    @test @inferred(quantile(LogNormal(1.0, 0.0f0), 1.0)) === Inf
+    @test @inferred(quantile(LogNormal(1.0f0, 0.0), 0.5)) ===  exp(1)
+    @test isnan_type(Float64, @inferred(quantile(LogNormal(1.0f0, 0.0), NaN)))
+    @test @inferred(quantile(LogNormal(1.0f0, 0.0f0), 0.0f0)) === 0.0f0
+    @test @inferred(quantile(LogNormal(1.0f0, 0.0f0), 1.0f0)) === Inf32
+    @test @inferred(quantile(LogNormal(1.0f0, 0.0f0), 0.5f0)) === exp(1.0f0)
+    @test isnan_type(Float32, @inferred(quantile(LogNormal(1.0f0, 0.0f0), NaN32)))
+    @test @inferred(quantile(LogNormal(1//1, 0//1), 1//2)) === exp(1)
+
+    # cquantile
+    @test @inferred(cquantile(LogNormal(1.0, 0.0), 0.0f0)) === Inf
+    @test @inferred(cquantile(LogNormal(1.0, 0.0f0), 1.0)) === 0.0
+    @test @inferred(cquantile(LogNormal(1.0f0, 0.0), 0.5)) === exp(1)
+    @test isnan_type(Float64, @inferred(cquantile(LogNormal(1.0f0, 0.0), NaN)))
+    @test @inferred(cquantile(LogNormal(1.0f0, 0.0f0), 0.0f0)) === Inf32
+    @test @inferred(cquantile(LogNormal(1.0f0, 0.0f0), 1.0f0)) === 0.0f0
+    @test @inferred(cquantile(LogNormal(1.0f0, 0.0f0), 0.5f0)) === exp(1.0f0)
+    @test isnan_type(Float32, @inferred(cquantile(LogNormal(1.0f0, 0.0f0), NaN32)))
+    @test @inferred(cquantile(LogNormal(1//1, 0//1), 1//2)) === exp(1)
+
+    # gradlogpdf
+    @test @inferred(gradlogpdf(LogNormal(0.0, 1.0), 1.0)) === -1.0
+    @test @inferred(gradlogpdf(LogNormal(0.0, 1.0), exp(-1))) === 0.0
+    @test @inferred(gradlogpdf(LogNormal(0.0, 1.0), 0.0)) === 0.0
+    @test @inferred(gradlogpdf(LogNormal(0.0, 1.0), -0.5)) === 0.0
+
+    @test @inferred(gradlogpdf(LogNormal(0.0, 1.0), 1.0f0)) === -1.0
+    @test @inferred(gradlogpdf(LogNormal(0.0f0, 1.0f0), 1.0)) === -1.0
+    @test @inferred(gradlogpdf(LogNormal(0.0f0, 1.0f0), 1.0f0)) === -1.0f0
+
+    @test isnan_type(Float64, @inferred(logccdf(LogNormal(0.0, 1.0), NaN)))
+    @test isnan_type(Float64, @inferred(logccdf(LogNormal(NaN, 1.0), 1.0f0)))
+    @test isnan_type(Float64, @inferred(logccdf(LogNormal(NaN, 1.0), 0.0f0)))
+    @test isnan_type(Float64, @inferred(logccdf(LogNormal(NaN, 1.0), -1.0f0)))
+
+    @test isnan_type(Float32, @inferred(logccdf(LogNormal(NaN32, 1.0f0), 1.0f0)))
+    @test isnan_type(Float32, @inferred(logccdf(LogNormal(NaN32, 1.0f0), 0.0f0)))
+    @test isnan_type(Float32, @inferred(logccdf(LogNormal(NaN32, 1.0f0), -1.0f0)))
+
+    @test @inferred(gradlogpdf(LogNormal(0 // 1, 1 // 1), 1 // 1)) === -1.0
+    @test @inferred(gradlogpdf(LogNormal(0 // 1, 1 // 1), 0 // 1)) === 0.0
+    @test @inferred(gradlogpdf(LogNormal(0 // 1, 1 // 1), -1 // 1)) === 0.0
+    @test isnan_type(Float64, @inferred(gradlogpdf(LogNormal(0 // 1, 1 // 1), NaN)))
+
+    @test @inferred(gradlogpdf(LogNormal(0.0, 1.0), BigInt(1))) == big(-1.0)
+    @test @inferred(gradlogpdf(LogNormal(0.0, 1.0), BigInt(0))) == big(0.0)
+    @test @inferred(gradlogpdf(LogNormal(0.0, 1.0), BigInt(-1))) == big(0.0)
+    @test @inferred(gradlogpdf(LogNormal(0.0, 1.0), BigFloat(1))) == big(-1.0)
+    @test @inferred(gradlogpdf(LogNormal(0.0, 1.0), BigFloat(0))) == big(0.0)
+    @test @inferred(gradlogpdf(LogNormal(0.0, 1.0), BigFloat(-1))) == big(0.0)
+    @test isnan_type(BigFloat, @inferred(gradlogpdf(LogNormal(0.0, 1.0), BigFloat(NaN))))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ const tests = [
     "truncnormal",
     "truncated_exponential",
     "normal",
+    "lognormal",
     "mvnormal",
     "mvlognormal",
     "types",


### PR DESCRIPTION
I noticed some type-instabilities in the current implementation of (log)pdf for `LogNormal`, and tried to fix them.

I adapted the type inference tests for `Normal` distributions. In these tests degenerate normal distributions (with zero variance) are used quite often, hence to simplify the transfer of the tests and for consistency I also allowed the use of degenerate log normal distributions.

This PR fixes https://github.com/JuliaStats/Distributions.jl/issues/456.