### PR TITLE
improve pdmat usage in the matrix-variates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 
 [compat]
 FillArrays = "0.8"
-PDMats = "0.9"
+PDMats = ">=0.9.12"
 QuadGK = "2"
 SpecialFunctions = "0.8, 0.9, 0.10"
 StatsBase = "0.32"

--- a/src/matrix/inversewishart.jl
+++ b/src/matrix/inversewishart.jl
@@ -1,8 +1,8 @@
 """
     InverseWishart(ν, Ψ)
 ```julia
-ν::Real   degrees of freedom (greater than p - 1)
-Ψ::PDMat  p x p scale matrix
+ν::Real           degrees of freedom (greater than p - 1)
+Ψ::AbstractPDMat  p x p scale matrix
 ```
 The [inverse Wishart distribution](http://en.wikipedia.org/wiki/Inverse-Wishart_distribution)
 generalizes the inverse gamma distribution to ``p\\times p`` real, positive definite

--- a/src/matrix/matrixfdist.jl
+++ b/src/matrix/matrixfdist.jl
@@ -1,9 +1,9 @@
 """
     MatrixFDist(n1, n2, B)
 ```julia
-n1::Real  degrees of freedom (greater than p - 1)
-n2::Real  degrees of freedom (greater than p - 1)
-B::PDMat  p x p scale
+n1::Real          degrees of freedom (greater than p - 1)
+n2::Real          degrees of freedom (greater than p - 1)
+B::AbstractPDMat  p x p scale
 ```
 The [matrix *F*-Distribution](https://projecteuclid.org/euclid.ba/1515747744)
 (sometimes called the matrix beta type II distribution) generalizes the
@@ -56,7 +56,7 @@ MatrixFDist(n1::Real, n2::Real, B::Union{AbstractMatrix, LinearAlgebra.Cholesky}
 #  REPL display
 #  -----------------------------------------------------------------------------
 
- show(io::IO, d::MatrixFDist) = show_multline(io, d, [(:n1, d.W.df), (:n2, d.n2), (:B, d.W.S.mat)])
+ show(io::IO, d::MatrixFDist) = show_multline(io, d, [(:n1, d.W.df), (:n2, d.n2), (:B, Matrix(d.W.S))])
 
 #  -----------------------------------------------------------------------------
 #  Conversion
@@ -90,7 +90,7 @@ function mean(d::MatrixFDist)
     p = dim(d)
     n1, n2, B = params(d)
     n2 > p + 1 || throw(ArgumentError("mean only defined for df2 > dim + 1"))
-    return (n1 / (n2 - p - 1)) * B.mat
+    return (n1 / (n2 - p - 1)) * Matrix(B)
 end
 
 @inline partype(d::MatrixFDist{T}) where {T <: Real} = T

--- a/src/matrix/matrixnormal.jl
+++ b/src/matrix/matrixnormal.jl
@@ -2,8 +2,8 @@
     MatrixNormal(M, U, V)
 ```julia
 M::AbstractMatrix  n x p mean
-U::PDMat           n x n row covariance
-V::PDMat           p x p column covariance
+U::AbstractPDMat   n x n row covariance
+V::AbstractPDMat   p x p column covariance
 ```
 The [matrix normal distribution](https://en.wikipedia.org/wiki/Matrix_normal_distribution) generalizes the multivariate normal distribution to ``n\\times p`` real matrices ``\\mathbf{X}``.
 If ``\\mathbf{X}\\sim MN_{n,p}(\\mathbf{M}, \\mathbf{U}, \\mathbf{V})``, then its
@@ -15,10 +15,10 @@ f(\\mathbf{X};\\mathbf{M}, \\mathbf{U}, \\mathbf{V}) = \\frac{\\exp\\left( -\\fr
 
 ``\\mathbf{X}\\sim MN_{n,p}(\\mathbf{M},\\mathbf{U},\\mathbf{V})`` if and only if ``\\text{vec}(\\mathbf{X})\\sim N(\\text{vec}(\\mathbf{M}),\\mathbf{V}\\otimes\\mathbf{U})``.
 """
-struct MatrixNormal{T <: Real, TM <: AbstractMatrix, ST <: AbstractPDMat} <: ContinuousMatrixDistribution
+struct MatrixNormal{T <: Real, TM <: AbstractMatrix, TU <: AbstractPDMat, TV <: AbstractPDMat} <: ContinuousMatrixDistribution
     M::TM
-    U::ST
-    V::ST
+    U::TU
+    V::TV
     logc0::T
 end
 
@@ -35,7 +35,7 @@ function MatrixNormal(M::AbstractMatrix{T}, U::AbstractPDMat{T}, V::AbstractPDMa
     prom_M = convert(AbstractArray{R}, M)
     prom_U = convert(AbstractArray{R}, U)
     prom_V = convert(AbstractArray{R}, V)
-    MatrixNormal{R, typeof(prom_M), typeof(prom_U)}(prom_M, prom_U, prom_V, R(logc0))
+    MatrixNormal{R, typeof(prom_M), typeof(prom_U), typeof(prom_V)}(prom_M, prom_U, prom_V, R(logc0))
 end
 
 function MatrixNormal(M::AbstractMatrix, U::AbstractPDMat, V::AbstractPDMat)
@@ -63,14 +63,14 @@ function convert(::Type{MatrixNormal{T}}, d::MatrixNormal) where T <: Real
     MM = convert(AbstractArray{T}, d.M)
     UU = convert(AbstractArray{T}, d.U)
     VV = convert(AbstractArray{T}, d.V)
-    MatrixNormal{T, typeof(MM), typeof(UU)}(MM, UU, VV, T(d.logc0))
+    MatrixNormal{T, typeof(MM), typeof(UU), typeof(VV)}(MM, UU, VV, T(d.logc0))
 end
 
 function convert(::Type{MatrixNormal{T}}, M::AbstractMatrix, U::AbstractPDMat, V::AbstractPDMat, logc0) where T <: Real
     MM = convert(AbstractArray{T}, M)
     UU = convert(AbstractArray{T}, U)
     VV = convert(AbstractArray{T}, V)
-    MatrixNormal{T, typeof(MM), typeof(UU)}(MM, UU, VV, T(logc0))
+    MatrixNormal{T, typeof(MM), typeof(UU), typeof(VV)}(MM, UU, VV, T(logc0))
 end
 
 #  -----------------------------------------------------------------------------
@@ -87,7 +87,7 @@ mean(d::MatrixNormal) = d.M
 
 mode(d::MatrixNormal) = d.M
 
-cov(d::MatrixNormal, ::Val{true}=Val(true)) = kron(Matrix(d.V), Matrix(d.U))
+cov(d::MatrixNormal, ::Val{true}=Val(true)) = Matrix(kron(d.V, d.U))
 
 cov(d::MatrixNormal, ::Val{false}) = ((n, p) = size(d); reshape(cov(d), n, p, n, p))
 
@@ -109,7 +109,8 @@ end
 
 function logkernel(d::MatrixNormal, X::AbstractMatrix)
     A  = X - d.M
-    -0.5 * tr( (d.V \ A') * (d.U \ A) )
+    At = Matrix(A')
+    -0.5 * tr( (d.V \ At) * (d.U \ A) )
 end
 
 _logpdf(d::MatrixNormal, X::AbstractMatrix) = logkernel(d, X) + d.logc0
@@ -118,14 +119,18 @@ _logpdf(d::MatrixNormal, X::AbstractMatrix) = logkernel(d, X) + d.logc0
 #  Sampling
 #  -----------------------------------------------------------------------------
 
-function _rand!(rng::AbstractRNG, d::MatrixNormal, A::AbstractMatrix)
+#  https://en.wikipedia.org/wiki/Matrix_normal_distribution#Drawing_values_from_the_distribution
+
+function _rand!(rng::AbstractRNG, d::MatrixNormal, Y::AbstractMatrix)
     n, p = size(d)
     X = randn(rng, n, p)
-    A .= d.M + d.U.chol.L * X * d.V.chol.U
+    A = cholesky(d.U).L
+    B = cholesky(d.V).U
+    Y .= d.M + A * X * B
 end
 
 #  -----------------------------------------------------------------------------
 #  Transformation
 #  -----------------------------------------------------------------------------
 
-vec(d::MatrixNormal) = MvNormal(vec(d.M), cov(d))
+vec(d::MatrixNormal) = MvNormal(vec(d.M), kron(d.V, d.U))

--- a/src/matrix/matrixnormal.jl
+++ b/src/matrix/matrixnormal.jl
@@ -109,8 +109,7 @@ end
 
 function logkernel(d::MatrixNormal, X::AbstractMatrix)
     A  = X - d.M
-    At = Matrix(A')
-    -0.5 * tr( (d.V \ At) * (d.U \ A) )
+    -0.5 * tr( (d.V \ A') * (d.U \ A) )
 end
 
 _logpdf(d::MatrixNormal, X::AbstractMatrix) = logkernel(d, X) + d.logc0

--- a/src/matrix/matrixtdist.jl
+++ b/src/matrix/matrixtdist.jl
@@ -3,8 +3,8 @@
 ```julia
 ν::Real            positive degrees of freedom
 M::AbstractMatrix  n x p location
-Σ::PDMat           n x n scale
-Ω::PDMat           p x p scale
+Σ::AbstractPDMat   n x n scale
+Ω::AbstractPDMat   p x p scale
 ```
 The [matrix *t*-Distribution](https://en.wikipedia.org/wiki/Matrix_t-distribution)
 generalizes the multivariate *t*-Distribution to ``n\\times p`` real
@@ -35,11 +35,11 @@ is given by
 then the marginal distribution of ``\\mathbf{X}`` is
 ``MT_{n,p}(\\nu,\\mathbf{M},\\boldsymbol{\\Sigma},\\boldsymbol{\\Omega})``.
 """
-struct MatrixTDist{T <: Real, TM <: AbstractMatrix, ST <: AbstractPDMat} <: ContinuousMatrixDistribution
+struct MatrixTDist{T <: Real, TM <: AbstractMatrix, TΣ <: AbstractPDMat, TΩ <: AbstractPDMat} <: ContinuousMatrixDistribution
     ν::T
     M::TM
-    Σ::ST
-    Ω::ST
+    Σ::TΣ
+    Ω::TΩ
     logc0::T
 end
 
@@ -57,7 +57,7 @@ function MatrixTDist(ν::T, M::AbstractMatrix{T}, Σ::AbstractPDMat{T}, Ω::Abst
     prom_M = convert(AbstractArray{R}, M)
     prom_Σ = convert(AbstractArray{R}, Σ)
     prom_Ω = convert(AbstractArray{R}, Ω)
-    MatrixTDist{R, typeof(prom_M), typeof(prom_Σ)}(R(ν), prom_M, prom_Σ, prom_Ω, R(logc0))
+    MatrixTDist{R, typeof(prom_M), typeof(prom_Σ), typeof(prom_Ω)}(R(ν), prom_M, prom_Σ, prom_Ω, R(logc0))
 end
 
 function MatrixTDist(ν::Real, M::AbstractMatrix, Σ::AbstractPDMat, Ω::AbstractPDMat)
@@ -83,14 +83,14 @@ function convert(::Type{MatrixTDist{T}}, d::MatrixTDist) where T <: Real
     MM = convert(AbstractArray{T}, d.M)
     ΣΣ = convert(AbstractArray{T}, d.Σ)
     ΩΩ = convert(AbstractArray{T}, d.Ω)
-    MatrixTDist{T, typeof(MM), typeof(ΣΣ)}(T(d.ν), MM, ΣΣ, ΩΩ, T(d.logc0))
+    MatrixTDist{T, typeof(MM), typeof(ΣΣ), typeof(ΩΩ)}(T(d.ν), MM, ΣΣ, ΩΩ, T(d.logc0))
 end
 
 function convert(::Type{MatrixTDist{T}}, ν, M::AbstractMatrix, Σ::AbstractPDMat, Ω::AbstractPDMat, logc0) where T <: Real
     MM = convert(AbstractArray{T}, M)
     ΣΣ = convert(AbstractArray{T}, Σ)
     ΩΩ = convert(AbstractArray{T}, Ω)
-    MatrixTDist{T, typeof(MM), typeof(ΣΣ)}(T(ν), MM, ΣΣ, ΩΩ, T(logc0))
+    MatrixTDist{T, typeof(MM), typeof(ΣΣ), typeof(ΩΩ)}(T(ν), MM, ΣΣ, ΩΩ, T(logc0))
 end
 
 #  -----------------------------------------------------------------------------
@@ -111,7 +111,7 @@ end
 
 mode(d::MatrixTDist) = d.M
 
-cov(d::MatrixTDist, ::Val{true}=Val(true)) = d.ν <= 2 ? throw(ArgumentError("cov only defined for df > 2")) : kron(Matrix(d.Ω), Matrix(d.Σ)) ./ (d.ν - 2)
+cov(d::MatrixTDist, ::Val{true}=Val(true)) = d.ν <= 2 ? throw(ArgumentError("cov only defined for df > 2")) : Matrix(kron(d.Ω, d.Σ)) ./ (d.ν - 2)
 
 cov(d::MatrixTDist, ::Val{false}) = ((n, p) = size(d); reshape(cov(d), n, p, n, p))
 
@@ -140,7 +140,8 @@ end
 function logkernel(d::MatrixTDist, X::AbstractMatrix)
     n, p = size(d)
     A = X - d.M
-    (-(d.ν + n + p - 1) / 2) * logdet( I + (d.Σ \ A) * (d.Ω \ A') )
+    At = Matrix(A')
+    (-(d.ν + n + p - 1) / 2) * logdet( I + (d.Σ \ A) * (d.Ω \ At) )
 end
 
 _logpdf(d::MatrixTDist, X::AbstractMatrix) = logkernel(d, X) + d.logc0
@@ -168,5 +169,5 @@ function MvTDist(MT::MatrixTDist)
     n, p = size(MT)
     all([n, p] .> 1) && error("Row or col dim of `MatrixTDist` must be 1 to coerce to `MvTDist`")
     ν, M, Σ, Ω = params(MT)
-    MvTDist(ν, vec(M), (1 / ν) * kron(Σ.mat, Ω.mat))
+    MvTDist(ν, vec(M), (1 / ν) * kron(Σ, Ω))
 end

--- a/src/matrix/matrixtdist.jl
+++ b/src/matrix/matrixtdist.jl
@@ -140,8 +140,7 @@ end
 function logkernel(d::MatrixTDist, X::AbstractMatrix)
     n, p = size(d)
     A = X - d.M
-    At = Matrix(A')
-    (-(d.ν + n + p - 1) / 2) * logdet( I + (d.Σ \ A) * (d.Ω \ At) )
+    (-(d.ν + n + p - 1) / 2) * logdet( I + (d.Σ \ A) * (d.Ω \ A') )
 end
 
 _logpdf(d::MatrixTDist, X::AbstractMatrix) = logkernel(d, X) + d.logc0

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -5,8 +5,8 @@
 """
     Wishart(ν, S)
 ```julia
-ν::Real   degrees of freedom (greater than p - 1)
-S::PDMat  p x p scale matrix
+ν::Real           degrees of freedom (greater than p - 1)
+S::AbstractPDMat  p x p scale matrix
 ```
 The [Wishart distribution](http://en.wikipedia.org/wiki/Wishart_distribution)
 generalizes the gamma distribution to ``p\\times p`` real, positive definite

--- a/test/matrixnormal.jl
+++ b/test/matrixnormal.jl
@@ -158,3 +158,32 @@ end
     @test partype(Del1) == elty
     @test partype(Del2) == elty
 end
+
+@testset "PDMat mixing and matching" begin
+    n = 3
+    p = 4
+
+    M = randn(n, p)
+
+    u = rand()
+    U_scale = ScalMat(n, u)
+    U_dense = Matrix(U_scale)
+    U_pd    = PDMat(U_dense)
+    U_pdiag = PDiagMat(u*ones(n))
+
+    v = rand(p)
+    V_pdiag = PDiagMat(v)
+    V_dense = Matrix(V_pdiag)
+    V_pd    = PDMat(V_dense)
+
+    UV = kron(V_dense, U_dense)
+    baseeval = logpdf(MatrixNormal(M, U_dense, V_dense), M)
+
+    for U in [U_scale, U_dense, U_pd, U_pdiag]
+        for V in [V_pdiag, V_dense, V_pd]
+            d = MatrixNormal(M, U, V)
+            @test cov(d) ≈ UV
+            @test logpdf(d, M) ≈ baseeval
+        end
+    end
+end


### PR DESCRIPTION
The matrix-variates commit many small sins that make them incapable of handling `AbstractPDMat` subtypes other than `PDMat`. This PR fixes that:

  - Allow the two posdef matrices in `MatrixNormal` and `MatrixTDist` to be different types;
  - Don't implicitly assume a `PDMat` by hard-coding direct access to fields like `.mat` and `.chol.L`;
  - Use the new `kron` methods in `PDMats.jl`;
  - ~~Temporary workaround for the fact that not all `AbstractPDMat` subtypes have `\` defined such that `S \ M'` will work (not everyone's `\` plays nice with `Adjoint`)~~.

(Shout-out to @willtebbutt, who [nailed](https://github.com/JuliaStats/Distributions.jl/pull/917#discussion_r297628281) this issue from the start, but I completely misunderstood what he was asking at the time.)
