### PR TITLE
Added Cholesky for MvNormal.jl at line 206

### DIFF
--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -203,7 +203,7 @@ function MvNormal(μ::AbstractVector, Σ::AbstractPDMat)
 end
 
 # constructor with general covariance matrix
-MvNormal(μ::AbstractVector{<:Real}, Σ::AbstractMatrix{<:Real}) = MvNormal(μ, PDMat(Σ))
+MvNormal(μ::AbstractVector{<:Real}, Σ::AbstractMatrix{<:Real}) = MvNormal(μ, PDMat(Σ, cholesky(Σ)))
 MvNormal(μ::AbstractVector{<:Real}, Σ::Diagonal{<:Real}) = MvNormal(μ, PDiagMat(diag(Σ)))
 MvNormal(μ::AbstractVector{<:Real}, Σ::UniformScaling{<:Real}) =
     MvNormal(μ, ScalMat(length(μ), Σ.λ))

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -145,11 +145,13 @@ end
 end
 
 @testset "MvNormal constructor" begin
-    mu = [1., 2., 3.]
-    C = [4. -2. -1.; -2. 5. -1.; -1. -1. 6.]
+    mu = [1., 2., 3.] # Mean Vector
+    C = [4. -2. -1.; -2. 5. -1.; -1. -1. 6.] # Covariance Matrix
+    cholesky_of_C = cholesky(C) # Cholesky Decomposition of C
     J = inv(C)
     h = J \ mu
     @test typeof(MvNormal(mu, PDMat(Array{Float32}(C)))) == typeof(MvNormal(mu, PDMat(C)))
+    @test typeof(MvNormal(mu, PDMat(Array{Float64}(C), cholesky_of_C))) == typeof(MvNormal(mu, PDMat(C, cholesky(C))))
     @test typeof(MvNormal(mu, Array{Float32}(C))) == typeof(MvNormal(mu, PDMat(C)))
     @test typeof(MvNormal(mu, 2.0f0)) == typeof(MvNormal(mu, 2.0))
 
@@ -171,6 +173,8 @@ end
     @test MvNormal(mu, 9 * I) === MvNormal(mu, 3)
     @test MvNormal(mu, 0.25f0 * I) === MvNormal(mu, 0.5)
 end
+
+
 
 ##### MLE
 


### PR DESCRIPTION
For making proper GPU compatibility, I have added Cholesky decomposition in the constructor of MvNormal which was giving errors earlier when I tried to use it with CuArrays for GPU integration. After this change, the MvNormal can be defined in the GPU with both mu and sigma GPU defined.