### PR TITLE
Add singular branch of the Wishart

### DIFF
--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -1,58 +1,68 @@
-# Wishart distribution
-#
-#   following the Wikipedia parameterization
-#
 """
     Wishart(ν, S)
 ```julia
-ν::Real           degrees of freedom (greater than p - 1)
+ν::Real           degrees of freedom in {1, 2, ..., p - 1} ∪ (p - 1, ∞)
 S::AbstractPDMat  p x p scale matrix
 ```
 The [Wishart distribution](http://en.wikipedia.org/wiki/Wishart_distribution)
-generalizes the gamma distribution to ``p\\times p`` real, positive definite
-matrices ``\\mathbf{H}``. If ``\\mathbf{H}\\sim \\textrm{W}_p(\\nu,\\mathbf{S})``,
-then its probability density function is
+generalizes the gamma distribution to ``p\\times p`` real, positive semidefinite
+matrices ``\\mathbf{H}``.
+
+If ``\\nu>p-1``, then ``\\mathbf{H}\\sim \\textrm{W}_p(\\nu, \\mathbf{S})``
+has rank ``p`` and its probability density function is
 
 ```math
 f(\\mathbf{H};\\nu,\\mathbf{S}) = \\frac{1}{2^{\\nu p/2} \\left|\\mathbf{S}\\right|^{\\nu/2} \\Gamma_p\\left(\\frac {\\nu}{2}\\right ) }{\\left|\\mathbf{H}\\right|}^{(\\nu-p-1)/2} e^{-(1/2)\\operatorname{tr}(\\mathbf{S}^{-1}\\mathbf{H})}.
 ```
 
-If ``\\nu`` is an integer, then a random matrix ``\\mathbf{H}`` given by
+If ``\\nu\\leq p-1``, then ``\\mathbf{H}`` has rank ``\\nu`` and
+a density is given [here](https://doi.org/10.1214/aos/1176325375).
+
+For integer ``\\nu``, a random matrix given by
 
 ```math
-\\mathbf{H} = \\mathbf{X}\\mathbf{X}^{\\rm{T}}, \\quad\\mathbf{X} \\sim \\textrm{MN}_{p,\\nu}(\\mathbf{0}, \\mathbf{S}, \\mathbf{I}_{\\nu})
+\\mathbf{H} = \\mathbf{X}\\mathbf{X}^{\\rm{T}},
+\\quad\\mathbf{X} \\sim \\textrm{MN}_{p,\\nu}(\\mathbf{0}, \\mathbf{S}, \\mathbf{I}_{\\nu})
 ```
 
-has ``\\mathbf{H}\\sim \\textrm{W}_p(\\nu, \\mathbf{S})``. For non-integer degrees of freedom,
-Wishart matrices can be generated via the [Bartlett decomposition](https://en.wikipedia.org/wiki/Wishart_distribution#Bartlett_decomposition).
+has ``\\mathbf{H}\\sim \\textrm{W}_p(\\nu, \\mathbf{S})``.
+For non-integer ``\\nu``, Wishart matrices can be generated via the
+[Bartlett decomposition](https://en.wikipedia.org/wiki/Wishart_distribution#Bartlett_decomposition).
 """
-struct Wishart{T<:Real, ST<:AbstractPDMat} <: ContinuousMatrixDistribution
-    df::T     # degree of freedom
-    S::ST     # the scale matrix
-    logc0::T  # the logarithm of normalizing constant in pdf
+struct Wishart{T<:Real, ST<:AbstractPDMat, R<:Integer} <: ContinuousMatrixDistribution
+    df::T          # degree of freedom
+    S::ST          # the scale matrix
+    logc0::T       # the logarithm of normalizing constant in pdf
+    rank::R        # rank of a sample
+    singular::Bool # singular of nonsingular wishart?
 end
 
 #  -----------------------------------------------------------------------------
 #  Constructors
 #  -----------------------------------------------------------------------------
 
-function Wishart(df::T, S::AbstractPDMat{T}) where T<:Real
+function Wishart(df::T, S::AbstractPDMat{T}, warn::Bool = true) where T<:Real
     p = dim(S)
-    df > p - 1 || throw(ArgumentError("df should be greater than dim - 1."))
-    logc0 = wishart_logc0(df, S)
+    rnk = p
+    singular = df <= p - 1
+    if singular
+        !isinteger(df) && throw(ArgumentError("singular df must be an integer. got $(df)."))
+        rnk = convert(Integer, df)
+        warn && @warn("got df <= dim - 1; returning a singular Wishart")
+    end
+    logc0 = wishart_logc0(df, S, rnk)
     R = Base.promote_eltype(T, logc0)
     prom_S = convert(AbstractArray{T}, S)
-    Wishart{R, typeof(prom_S)}(R(df), prom_S, R(logc0))
+    Wishart{R, typeof(prom_S), typeof(rnk)}(R(df), prom_S, R(logc0), rnk, singular)
 end
 
-function Wishart(df::Real, S::AbstractPDMat)
+function Wishart(df::Real, S::AbstractPDMat, warn::Bool = true)
     T = Base.promote_eltype(df, S)
-    Wishart(T(df), convert(AbstractArray{T}, S))
+    Wishart(T(df), convert(AbstractArray{T}, S), warn)
 end
 
-Wishart(df::Real, S::Matrix) = Wishart(df, PDMat(S))
-
-Wishart(df::Real, S::Cholesky) = Wishart(df, PDMat(S))
+Wishart(df::Real, S::Matrix, warn::Bool = true) = Wishart(df, PDMat(S), warn)
+Wishart(df::Real, S::Cholesky, warn::Bool = true) = Wishart(df, PDMat(S), warn)
 
 #  -----------------------------------------------------------------------------
 #  REPL display
@@ -66,27 +76,37 @@ show(io::IO, d::Wishart) = show_multline(io, d, [(:df, d.df), (:S, Matrix(d.S))]
 
 function convert(::Type{Wishart{T}}, d::Wishart) where T<:Real
     P = convert(AbstractArray{T}, d.S)
-    Wishart{T, typeof(P)}(T(d.df), P, T(d.logc0))
+    Wishart{T, typeof(P), typeof(d.rank)}(T(d.df), P, T(d.logc0), d.rank, d.singular)
 end
-function convert(::Type{Wishart{T}}, df, S::AbstractPDMat, logc0) where T<:Real
+function convert(::Type{Wishart{T}}, df, S::AbstractPDMat, logc0, rnk, singular) where T<:Real
     P = convert(AbstractArray{T}, S)
-    Wishart{T, typeof(P)}(T(df), P, T(logc0))
+    Wishart{T, typeof(P), typeof(rnk)}(T(df), P, T(logc0), rnk, singular)
 end
 
 #  -----------------------------------------------------------------------------
 #  Properties
 #  -----------------------------------------------------------------------------
 
-insupport(::Type{Wishart}, X::Matrix) = isposdef(X)
-insupport(d::Wishart, X::Matrix) = size(X) == size(d) && isposdef(X)
+insupport(::Type{Wishart}, X::AbstractMatrix) = ispossemdef(X)
+function insupport(d::Wishart, X::AbstractMatrix)
+    size(X) == size(d) || return false
+    if d.singular
+        return ispossemdef(X, rank(d))
+    else
+        return isposdef(X)
+    end
+end
 
 dim(d::Wishart) = dim(d.S)
 size(d::Wishart) = (p = dim(d); (p, p))
-rank(d::Wishart) = dim(d)
+rank(d::Wishart) = d.rank
 params(d::Wishart) = (d.df, d.S)
 @inline partype(d::Wishart{T}) where {T<:Real} = T
 
-mean(d::Wishart) = d.df * Matrix(d.S)
+function mean(d::Wishart)
+    d.singular && throw(ArgumentError("mean not defined for singular Wishart."))
+    d.df * Matrix(d.S)
+end
 
 function mode(d::Wishart)
     r = d.df - dim(d) - 1.0
@@ -95,6 +115,7 @@ function mode(d::Wishart)
 end
 
 function meanlogdet(d::Wishart)
+    d.singular && return 0
     p = dim(d)
     df = d.df
     v = logdet(d.S) + p * logtwo
@@ -105,6 +126,7 @@ function meanlogdet(d::Wishart)
 end
 
 function entropy(d::Wishart)
+    d.singular && throw(ArgumentError("entropy not defined for singular Wishart."))
     p = dim(d)
     df = d.df
     -d.logc0 - 0.5 * (df - p - 1) * meanlogdet(d) + 0.5 * df * p
@@ -112,11 +134,13 @@ end
 
 #  Gupta/Nagar (1999) Theorem 3.3.15.i
 function cov(d::Wishart, i::Integer, j::Integer, k::Integer, l::Integer)
+    d.singular && throw(ArgumentError("cov not defined for singular Wishart."))
     S = Matrix(d.S)
     d.df * (S[i, k] * S[j, l] + S[i, l] * S[j, k])
 end
 
 function var(d::Wishart, i::Integer, j::Integer)
+    d.singular && throw(ArgumentError("var not defined for singular Wishart."))
     S = Matrix(d.S)
     d.df * (S[i, i] * S[j, j] + S[i, j] ^ 2)
 end
@@ -125,13 +149,44 @@ end
 #  Evaluation
 #  -----------------------------------------------------------------------------
 
-function wishart_logc0(df::Real, S::AbstractPDMat)
-    h_df = df / 2
+function wishart_logc0(df::Real, S::AbstractPDMat, rnk::Integer)
     p = dim(S)
-    -h_df * (logdet(S) + p * typeof(df)(logtwo)) - logmvgamma(p, h_df)
+    if df <= p - 1
+        return singular_wishart_logc0(p, df, S, rnk)
+    else
+        return nonsingular_wishart_logc0(p, df, S)
+    end
 end
 
 function logkernel(d::Wishart, X::AbstractMatrix)
+    if d.singular
+        return singular_wishart_logkernel(d, X)
+    else
+        return nonsingular_wishart_logkernel(d, X)
+    end
+end
+
+#  Singular Wishart pdf: Theorem 6 in Uhlig (1994 AoS)
+function singular_wishart_logc0(p::Integer, df::Real, S::AbstractPDMat, rnk::Integer)
+    h_df = df / 2
+    -h_df * (logdet(S) + p * typeof(df)(logtwo)) - logmvgamma(rnk, h_df) + (rnk*(rnk - p) / 2)*typeof(df)(logπ)
+end
+
+function singular_wishart_logkernel(d::Wishart, X::AbstractMatrix)
+    df = d.df
+    p = dim(d)
+    r = rank(d)
+    L = eigvals(Hermitian(X), (p - r + 1):p)
+    0.5 * ((df - (p + 1)) * sum(log.(L)) - tr(d.S \ X))
+end
+
+#  Nonsingular Wishart pdf
+function nonsingular_wishart_logc0(p::Integer, df::Real, S::AbstractPDMat)
+    h_df = df / 2
+    -h_df * (logdet(S) + p * typeof(df)(logtwo)) - logmvgamma(p, h_df)
+end
+
+function nonsingular_wishart_logkernel(d::Wishart, X::AbstractMatrix)
     df = d.df
     p = dim(d)
     Xcf = cholesky(X)
@@ -143,7 +198,12 @@ end
 #  -----------------------------------------------------------------------------
 
 function _rand!(rng::AbstractRNG, d::Wishart, A::AbstractMatrix)
-    _wishart_genA!(rng, dim(d), d.df, A)
+    if d.singular
+        A .= zero(eltype(A))
+        A[:, 1:rank(d)] = randn(dim(d), rank(d))
+    else
+        _wishart_genA!(rng, dim(d), d.df, A)
+    end
     unwhiten!(d.S, A)
     A .= A * A'
 end

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -15,8 +15,9 @@ has rank ``p`` and its probability density function is
 f(\\mathbf{H};\\nu,\\mathbf{S}) = \\frac{1}{2^{\\nu p/2} \\left|\\mathbf{S}\\right|^{\\nu/2} \\Gamma_p\\left(\\frac {\\nu}{2}\\right ) }{\\left|\\mathbf{H}\\right|}^{(\\nu-p-1)/2} e^{-(1/2)\\operatorname{tr}(\\mathbf{S}^{-1}\\mathbf{H})}.
 ```
 
-If ``\\nu\\leq p-1``, then ``\\mathbf{H}`` has rank ``\\nu`` and
-a density is given [here](https://doi.org/10.1214/aos/1176325375).
+If ``\\nu\\leq p-1``, then ``\\mathbf{H}`` is rank ``\\nu`` and it has
+a density with respect to a suitably chosen volume element on the space of
+positive semidefinite matrices. See [here](https://doi.org/10.1214/aos/1176325375).
 
 For integer ``\\nu``, a random matrix given by
 

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -239,7 +239,7 @@ end
 
 function _rand_params(::Type{Wishart}, elty, n::Int, p::Int)
     n == p || throw(ArgumentError("dims must be equal for Wishart"))
-    ν = elty( n + 1 + abs(10randn()) )
+    ν = elty( n - 1 + abs(10randn()) )
     S = (X = 2rand(elty, n, n) .- 1; X * X')
     return ν, S
 end

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -116,7 +116,7 @@ function mode(d::Wishart)
 end
 
 function meanlogdet(d::Wishart)
-    d.singular && return 0
+    d.singular && return -Inf
     p = dim(d)
     df = d.df
     v = logdet(d.S) + p * logtwo

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -46,7 +46,8 @@ function Wishart(df::T, S::AbstractPDMat{T}, warn::Bool = true) where T<:Real
     rnk = p
     singular = df <= p - 1
     if singular
-        !isinteger(df) && throw(ArgumentError("singular df must be an integer. got $(df)."))
+        df > 0 || throw(ArgumentError("df must be positive. got $(df)."))
+        isinteger(df) || throw(ArgumentError("singular df must be an integer. got $(df)."))
         rnk = convert(Integer, df)
         warn && @warn("got df <= dim - 1; returning a singular Wishart")
     end

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -201,7 +201,7 @@ end
 function _rand!(rng::AbstractRNG, d::Wishart, A::AbstractMatrix)
     if d.singular
         A .= zero(eltype(A))
-        A[:, 1:rank(d)] = randn(dim(d), rank(d))
+        A[:, 1:rank(d)] = randn(rng, dim(d), rank(d))
     else
         _wishart_genA!(rng, dim(d), d.df, A)
     end

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -43,11 +43,11 @@ end
 #  -----------------------------------------------------------------------------
 
 function Wishart(df::T, S::AbstractPDMat{T}, warn::Bool = true) where T<:Real
+    df > 0 || throw(ArgumentError("df must be positive. got $(df)."))
     p = dim(S)
     rnk = p
     singular = df <= p - 1
     if singular
-        df > 0 || throw(ArgumentError("df must be positive. got $(df)."))
         isinteger(df) || throw(ArgumentError("singular df must be an integer. got $(df)."))
         rnk = convert(Integer, df)
         warn && @warn("got df <= dim - 1; returning a singular Wishart")

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -105,10 +105,7 @@ rank(d::Wishart) = d.rank
 params(d::Wishart) = (d.df, d.S)
 @inline partype(d::Wishart{T}) where {T<:Real} = T
 
-function mean(d::Wishart)
-    d.singular && throw(ArgumentError("mean not defined for singular Wishart."))
-    d.df * Matrix(d.S)
-end
+mean(d::Wishart) = d.df * Matrix(d.S)
 
 function mode(d::Wishart)
     r = d.df - dim(d) - 1.0

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -1,7 +1,7 @@
 """
     Wishart(ν, S)
 ```julia
-ν::Real           degrees of freedom in {1, 2, ..., p - 1} ∪ (p - 1, ∞)
+ν::Real           degrees of freedom (whole number or a real number greater than p - 1)
 S::AbstractPDMat  p x p scale matrix
 ```
 The [Wishart distribution](http://en.wikipedia.org/wiki/Wishart_distribution)

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -133,13 +133,11 @@ end
 
 #  Gupta/Nagar (1999) Theorem 3.3.15.i
 function cov(d::Wishart, i::Integer, j::Integer, k::Integer, l::Integer)
-    d.singular && throw(ArgumentError("cov not defined for singular Wishart."))
     S = Matrix(d.S)
     d.df * (S[i, k] * S[j, l] + S[i, l] * S[j, k])
 end
 
 function var(d::Wishart, i::Integer, j::Integer)
-    d.singular && throw(ArgumentError("var not defined for singular Wishart."))
     S = Matrix(d.S)
     d.df * (S[i, i] * S[j, j] + S[i, j] ^ 2)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -102,6 +102,7 @@ function _check_rank_range(k::Int, n::Int)
     nothing
 end
 
+#  return counts of the number of positive, zero, and negative eigenvalues
 function eigsigns(X::AbstractMatrix,
                   atol::Real=0.0,
                   rtol::Real=(minimum(size(X))*eps(real(float(one(eltype(X))))))*iszero(atol))
@@ -113,8 +114,8 @@ function eigsigns(eigs::Vector{<: Real}, atol::Real, rtol::Real)
     eigsigns(eigs, tol)
 end
 function eigsigns(eigs::Vector{<: Real}, tol::Real)
-    dp = sum(tol .< eigs)
-    dz = sum(-tol .< eigs .< tol)
-    dn = sum(eigs .< -tol)
+    dp = sum(tol .< eigs)         #  number of positive eigenvalues
+    dz = sum(-tol .< eigs .< tol) #  number of numerically zero eigenvalues
+    dn = sum(eigs .< -tol)        #  number of negative eigenvalues
     return dp, dz, dn
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -114,8 +114,8 @@ function eigsigns(eigs::Vector{<: Real}, atol::Real, rtol::Real)
     eigsigns(eigs, tol)
 end
 function eigsigns(eigs::Vector{<: Real}, tol::Real)
-    dp = sum(tol .< eigs)         #  number of positive eigenvalues
-    dz = sum(-tol .< eigs .< tol) #  number of numerically zero eigenvalues
-    dn = sum(eigs .< -tol)        #  number of negative eigenvalues
+    dp = count(x -> tol < x, eigs)        #  number of positive eigenvalues
+    dz = count(x -> -tol < x < tol, eigs) #  number of numerically zero eigenvalues
+    dn = count(x -> x < -tol, eigs)       #  number of negative eigenvalues
     return dp, dz, dn
 end

--- a/test/matrixvariates.jl
+++ b/test/matrixvariates.jl
@@ -331,17 +331,25 @@ function test_special(dist::Type{Wishart})
         @test pvalue(kstest) >= α
     end
     @testset "H ~ W(ν, I) ⟹ H[i, i] ~ χ²(ν)" begin
-        ν = n + 1
-        ρ = Chisq(ν)
-        d = Wishart(ν, ScalMat(n, 1))
+        κ = n + 1
+        ρ = Chisq(κ)
+        g = Wishart(κ, ScalMat(n, 1))
         mymats = zeros(n, n, M)
         for m in 1:M
-            mymats[:, :, m] = rand(d)
+            mymats[:, :, m] = rand(g)
         end
         for i in 1:n
             kstest = ExactOneSampleKSTest(mymats[i, i, :], ρ)
             @test pvalue(kstest) >= α / n
         end
+    end
+    @testset "Check Singular Branch" begin
+        X = H[1]
+        test_draw(Wishart(n - 1, Σ, false))
+        test_draw(Wishart(n - 2, Σ, false))
+        @test Distributions.singular_wishart_logkernel(d, X) ≈ Distributions.nonsingular_wishart_logkernel(d, X)
+        @test Distributions.singular_wishart_logc0(n, ν, d.S, rank(d)) ≈ Distributions.nonsingular_wishart_logc0(n, ν, d.S)
+        @test logpdf(d, X) ≈ Distributions.singular_wishart_logkernel(d, X) + Distributions.singular_wishart_logc0(n, ν, d.S, rank(d))
     end
     nothing
 end

--- a/test/matrixvariates.jl
+++ b/test/matrixvariates.jl
@@ -344,8 +344,14 @@ function test_special(dist::Type{Wishart})
     end
     @testset "Check Singular Branch" begin
         X = H[1]
-        test_draw(Wishart(n - 1, Σ, false))
-        test_draw(Wishart(n - 2, Σ, false))
+        rank1 = Wishart(n - 2, Σ, false)
+        rank2 = Wishart(n - 1, Σ, false)
+        test_draw(rank1)
+        test_draw(rank2)
+        test_draws(rank1, rand(rank1, 10^6))
+        test_draws(rank2, rand(rank2, 10^6))
+        test_cov(rank1)
+        test_cov(rank2)
         @test Distributions.singular_wishart_logkernel(d, X) ≈ Distributions.nonsingular_wishart_logkernel(d, X)
         @test Distributions.singular_wishart_logc0(n, ν, d.S, rank(d)) ≈ Distributions.nonsingular_wishart_logc0(n, ν, d.S)
         @test logpdf(d, X) ≈ Distributions.singular_wishart_logkernel(d, X) + Distributions.singular_wishart_logc0(n, ν, d.S, rank(d))

--- a/test/matrixvariates.jl
+++ b/test/matrixvariates.jl
@@ -28,7 +28,6 @@ import Distributions: _univariate, _multivariate, _rand_params
 
 function test_draw(d::MatrixDistribution, X::AbstractMatrix)
     @test size(d) == size(X)
-    @test size(d) == size(mean(d))
     @test size(d, 1) == size(X, 1)
     @test size(d, 2) == size(X, 2)
     @test length(d) == length(X)


### PR DESCRIPTION
This PR adds the [singular branch](https://en.wikipedia.org/wiki/Wishart_distribution#The_range_of_the_shape_parameter) of the Wishart distribution. That is, for integer `df < p`, the Wishart is a distribution over rank-`df` positive semidefinite `p x p` matrices, defined in the [usual way](https://en.wikipedia.org/wiki/Wishart_distribution#Definition).

In this case the Wishart does not have a Lebesgue density, but it does have a density with respect to an appropriate dominating measure on rank-`df` positive semidefinite matrices, which is given in Theorem 6 [here](https://projecteuclid.org/euclid.aos/1176325375). The usual density in the full rank case is a special case of this "generalized" density.

I am currently implementing this by extending the behavior of `Wishart` instead of defining a separate distribution. I prefer this because it's what Matlab [does](https://stats.stackexchange.com/questions/24288/how-to-sample-from-a-wishart-distribution), and because I think that a hard distinction between singular/nonsingular Wishart is ultimately artificial and could cause headache for the user. For example, there are certain time series models where the degrees of freedom of a Wishart are time-varying, and may or may not be singular from period to period. A user implementing this might prefer that we supply one Wishart that covers both cases instead of supplying two and forcing them to manually switch between them.

Let me know what you think!