### PR TITLE
fix distr_support macro for type parameters

### DIFF
--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -140,7 +140,7 @@ macro distr_support(D, lb, ub)
     D_has_constantbounds = (isa(ub, Number) || ub == :Inf) &&
                            (isa(lb, Number) || lb == :(-Inf))
 
-    paramdecl = D_has_constantbounds ? :(d::Union{$D, Type{$D}}) : :(d::$D)
+    paramdecl = D_has_constantbounds ? :(d::Union{$D, Type{<:$D}}) : :(d::$D)
 
     # overall
     esc(quote


### PR DESCRIPTION
This PR makes `minimum(Normal{Float64})` work where previously only `minimum(Normal)` would.