### PR TITLE
When implementing a Sampler you need to implement 2 arg rand

### DIFF
--- a/docs/src/extends.md
+++ b/docs/src/extends.md
@@ -18,12 +18,12 @@ Unlike a full fledged distributions, a sampler, in general, only provides limite
 To implement a univariate sampler, one can define a sub type (say `Spl`) of `Sampleable{Univariate,S}` (where `S` can be `Discrete` or `Continuous`), and provide a `rand` method, as
 
 ```julia
-function rand(s::Spl)
+function rand(rng::AbstractRNG, s::Spl)
     # ... generate a single sample from s
 end
 ```
 
-The package already implements a vectorized version of `rand!` and `rand` that repeatedly calls the he scalar version to generate multiple samples.
+The package already implements a vectorized version of `rand!` and `rand` that repeatedly calls the he scalar version to generate multiple samples; as wells as a one arg version that uses the default random number generator.
 
 ### Multivariate Sampler
 

--- a/docs/src/extends.md
+++ b/docs/src/extends.md
@@ -23,7 +23,7 @@ function rand(rng::AbstractRNG, s::Spl)
 end
 ```
 
-The package already implements a vectorized version of `rand!` and `rand` that repeatedly calls the he scalar version to generate multiple samples; as wells as a one arg version that uses the default random number generator.
+The package already implements a vectorized version of `rand!` and `rand` that repeatedly calls the scalar version to generate multiple samples; as wells as a one arg version that uses the default random number generator.
 
 ### Multivariate Sampler
 


### PR DESCRIPTION
I was implementing a distirbution today, [PERT-Beta](https://en.wikipedia.org/wiki/PERT_distribution).
and I gut up to implementing my sampler, and i found it was erroring.
Then i looked at all the existing distributions and realized that they were implementing the two arg version of rand.
