### PR TITLE
Fix `rand(::DiscreteNonParametric)` with values of zero probability

### DIFF
--- a/src/univariate/discrete/discretenonparametric.jl
+++ b/src/univariate/discrete/discretenonparametric.jl
@@ -74,12 +74,12 @@ function rand(rng::AbstractRNG, d::DiscreteNonParametric{T,P}) where {T,P}
     p = probs(d)
     n = length(p)
     draw = rand(rng, P)
-    cp = zero(P)
-    i = 0
-    while cp < draw && i < n
-        cp += p[i +=1]
+    cp = p[1]
+    i = 1
+    while cp <= draw && i < n
+        @inbounds cp += p[i +=1]
     end
-    x[max(i,1)]
+    return x[i]
 end
 
 rand(d::DiscreteNonParametric) = rand(GLOBAL_RNG, d)

--- a/test/discretenonparametric.jl
+++ b/test/discretenonparametric.jl
@@ -124,4 +124,10 @@ d = Categorical(p)
 rng = AllOneRNG()
 @test (rand(rng, d); true)
 
+# Sampling with values of zero probability; see issue #1105
+d = DiscreteNonParametric([0, 1, 2, 3, 4], [0.0f0, 0.1f0, 0.2f0, 0.3f0, 0.4f0])
+@test iszero(count(iszero(rand(d)) for _ in 1:100_000_000))
+
+d = DiscreteNonParametric([4, 3, 2, 1, 0], [0.4f0, 0.3f0, 0.2f0, 0.1f0, 0.0f0])
+@test iszero(count(iszero(rand(d)) for _ in 1:100_000_000))
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaStats/Distributions.jl/issues/1105.

The problem in the current implementation is the check `cp < draw`: if the probability of the first value is 0 and if `draw == 0.0`, the loop will stop immediately and the first element will be returned even though it has zero probability. When sampling with `Float32` the problem described in the issue linked above becomes apparent. Changing the comparison to `cp <= draw` fixes the problem.