### PR TITLE
Use `log1mexp` in the computations of `logdiffcdf`

### DIFF
--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -398,14 +398,17 @@ logcdf(d::DiscreteUnivariateDistribution, x::Integer) = log(cdf(d, x))
 logcdf(d::DiscreteUnivariateDistribution, x::Real) = logcdf(d, floor(Int,x))
 
 """
-    logdiffcdf(d::UnivariateDistribution, x::T, y::T) where {T <: Real}
+    logdiffcdf(d::UnivariateDistribution, x::Real, y::Real)
 
 The natural logarithm of the difference between the cumulative density function at `x` and `y`, i.e. `log(cdf(x) - cdf(y))`.
 """
-function logdiffcdf(d::UnivariateDistribution, x::T, y::T) where {T <: Real}
-    x <= y && throw(ArgumentError("requires x > y."))
-    u, v = logcdf(d, x), logcdf(d, y)
-    return u + log1p(-exp(v - u))
+function logdiffcdf(d::UnivariateDistribution, x::Real, y::Real)
+    # Promote to ensure that we don't compute logcdf in low precision and then promote
+    _x, _y = promote(x, y)
+    _x <= _y && throw(ArgumentError("requires x > y."))
+    u = logcdf(d, _x)
+    v = logcdf(d, _y)
+    return u + log1mexp(v - u)
 end
 
 """

--- a/test/lognormal.jl
+++ b/test/lognormal.jl
@@ -11,8 +11,9 @@ isnan_type(::Type{T}, v) where {T} = isnan(v) && v isa T
     @test logpdf(LogNormal(), Inf) === -Inf
     @test iszero(logcdf(LogNormal(0, 0), 1))
     @test iszero(logcdf(LogNormal(), Inf))
-    @test logdiffcdf(LogNormal(), Float32(exp(5)), Float32(exp(3))) ≈ -6.6079385945968929 rtol=1e-12
-    @test logdiffcdf(LogNormal(), Float64(exp(5)), Float64(exp(3))) ≈ -6.6079385945968929 rtol=1e-12
+    @test logdiffcdf(LogNormal(), Float32(exp(5)), Float32(exp(3))) ≈ -6.607938594596893 rtol=1e-12
+    @test logdiffcdf(LogNormal(), Float32(exp(5)), Float64(exp(3))) ≈ -6.60793859457367 rtol=1e-12
+    @test logdiffcdf(LogNormal(), Float64(exp(5)), Float64(exp(3))) ≈ -6.607938594596893 rtol=1e-12
     let d = LogNormal(Float64(0), Float64(1)), x = Float64(exp(-60)), y = Float64(exp(-60.001))
         float_res = logdiffcdf(d, x, y)
         big_float_res = log(cdf(d, BigFloat(x, 100)) - cdf(d, BigFloat(y, 100)))

--- a/test/normal.jl
+++ b/test/normal.jl
@@ -9,15 +9,15 @@ isnan_type(::Type{T}, v) where {T} = isnan(v) && v isa T
     @test -Inf === logpdf(Normal(), Inf)
     @test iszero(logcdf(Normal(0, 0), 0))
     @test iszero(logcdf(Normal(), Inf))
-    @test logdiffcdf(Normal(), Float32(5), Float32(3)) ≈ -6.6079385945968929 rtol=1e-12
-    @test logdiffcdf(Normal(), Float64(5), Float64(3)) ≈ -6.6079385945968929 rtol=1e-12
+    @test logdiffcdf(Normal(), Float32(5), Float32(3)) ≈ -6.607938594596893 rtol=1e-12
+    @test logdiffcdf(Normal(), Float32(5), Float64(3)) ≈ -6.607938594596893 rtol=1e-12
+    @test logdiffcdf(Normal(), Float64(5), Float64(3)) ≈ -6.607938594596893 rtol=1e-12
     let d = Normal(Float64(0), Float64(1)), x = Float64(-60), y = Float64(-60.001)
         float_res = logdiffcdf(d, x, y)
         big_float_res = log(cdf(d, BigFloat(x, 100)) - cdf(d, BigFloat(y, 100)))
         @test float_res ≈ big_float_res
     end
     @test_throws ArgumentError logdiffcdf(Normal(), 1.0, 2.0)
-    @test_throws MethodError logdiffcdf(Normal(), Float32(2), Float64(1))
     @test -Inf === logccdf(Normal(0, 0), 0)
     @test iszero(logccdf(Normal(eps(), 0), 0))
     @test -Inf === quantile(Normal(), 0)


### PR DESCRIPTION
This PR loosens the type annotations of `logdiffcdf` and uses `log1mexp` in its computations.