### PR TITLE
Support all possible outputs of `rand` in `loglikelihood`

### DIFF
--- a/docs/src/extends.md
+++ b/docs/src/extends.md
@@ -145,7 +145,8 @@ Following methods need to be implemented for each multivariate distribution type
 
 Note that if there exists faster methods for batch evaluation, one should override `_logpdf!` and `_pdf!`.
 
-Furthermore, the generic `loglikelihood` function delegates to `_loglikelihood`, which repeatedly calls `_logpdf`. If there is a better way to compute log-likelihood, one should override `_loglikelihood`.
+Furthermore, the generic `loglikelihood` function repeatedly calls `_logpdf`. If there is
+a better way to compute the log-likelihood, one should override `loglikelihood`.
 
 It is also recommended that one also implements the following statistics functions:
 

--- a/docs/src/multivariate.md
+++ b/docs/src/multivariate.md
@@ -33,7 +33,7 @@ entropy(::MultivariateDistribution, ::Real)
 insupport(::MultivariateDistribution, ::AbstractArray)
 pdf(::MultivariateDistribution, ::AbstractArray)
 logpdf(::MultivariateDistribution, ::AbstractArray)
-loglikelihood(::MultivariateDistribution, ::AbstractMatrix)
+loglikelihood(::MultivariateDistribution, ::AbstractArray)
 ```
 **Note:** For multivariate distributions, the pdf value is usually very small or large, and therefore direct evaluating the pdf may cause numerical problems. It is generally advisable to perform probability computation in log-scale.
 

--- a/docs/src/univariate.md
+++ b/docs/src/univariate.md
@@ -71,7 +71,7 @@ cf(::UnivariateDistribution, ::Any)
 insupport(::UnivariateDistribution, x::Any)
 pdf(::UnivariateDistribution, ::Real)
 logpdf(::UnivariateDistribution, ::Real)
-loglikelihood(::UnivariateDistribution, ::AbstractArray)
+loglikelihood(::UnivariateDistribution, ::Union{Real,AbstractArray})
 cdf(::UnivariateDistribution, ::Real)
 logcdf(::UnivariateDistribution, ::Real)
 logdiffcdf(::UnivariateDistribution, ::T, ::T) where {T <: Real}

--- a/src/multivariates.jl
+++ b/src/multivariates.jl
@@ -250,13 +250,19 @@ Generally, one does not need to implement `pdf` (or `_pdf`) as fallback methods 
 _logpdf(d::MultivariateDistribution, x::AbstractArray)
 
 """
-    loglikelihood(d::MultivariateDistribution, x::AbstractMatrix)
+    loglikelihood(d::MultivariateDistribution, x::AbstractArray)
 
-The log-likelihood of distribution `d` w.r.t. all columns contained in matrix `x`.
+The log-likelihood of distribution `d` with respect to all samples contained in array `x`.
+
+Here, `x` can be a vector of length `dim(d)`, a matrix with `dim(d)` rows, or an array of
+vectors of length `dim(d)`.
 """
-function loglikelihood(d::MultivariateDistribution, X::AbstractMatrix)
+function loglikelihood(d::MultivariateDistribution, X::AbstractVecOrMat{<:Real})
     size(X, 1) == length(d) || throw(DimensionMismatch("Inconsistent array dimensions."))
     return sum(i -> _logpdf(d, view(X, :, i)), 1:size(X, 2))
+end
+function loglikelihood(d::MultivariateDistribution, X::AbstractArray{<:AbstractVector})
+    return sum(x -> _logpdf(d, x), X)
 end
 
 ##### Specific distributions #####

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -522,11 +522,14 @@ end
 
 ## loglikelihood
 """
-    loglikelihood(d::UnivariateDistribution, X::AbstractArray)
+    loglikelihood(d::UnivariateDistribution, x::Union{Real,AbstractArray})
 
-The log-likelihood of distribution `d` w.r.t. all samples contained in array `x`.
+The log-likelihood of distribution `d` with respect to all samples contained in `x`.
+
+Here `x` can be a single scalar sample or an array of samples.
 """
 loglikelihood(d::UnivariateDistribution, X::AbstractArray) = sum(x -> logpdf(d, x), X)
+loglikelihood(d::UnivariateDistribution, x::Real) = logpdf(d, x)
 
 ### macros to use StatsFuns for method implementation
 

--- a/test/locationscale.jl
+++ b/test/locationscale.jl
@@ -44,6 +44,7 @@ function test_location_scale_normal(μ::Real, σ::Real, μD::Real, σD::Real,
     @test pdf.(d,2:4) ≈ pdf.(dref,2:4)
     @test logpdf(d,0.4) ≈ logpdf(dref,0.4)
     @test loglikelihood(d,[0.1,0.2,0.3]) ≈ loglikelihood(dref,[0.1,0.2,0.3])
+    @test loglikelihood(d, 0.4) ≈ loglikelihood(dref, 0.4)
     @test cdf(d,μ-0.4) ≈ cdf(dref,μ-0.4)
     @test logcdf(d,μ-0.4) ≈ logcdf(dref,μ-0.4)
     @test ccdf(d,μ-0.4) ≈ ccdf(dref,μ-0.4) atol=1e-100

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -83,6 +83,8 @@ function test_mvnormal(g::AbstractMvNormal, n_tsamples::Int=10^6,
 
     # log likelihood
     @test loglikelihood(g, X) ≈ sum([Distributions._logpdf(g, X[:,i]) for i in 1:size(X, 2)])
+    @test loglikelihood(g, X[:, 1]) ≈ logpdf(g, X[:, 1])
+    @test loglikelihood(g, [X[:, i] for i in axes(X, 2)]) ≈ loglikelihood(g, X)
 end
 
 ###### General Testing


### PR DESCRIPTION
This PR generalizes `loglikelihood` and adds supports for all possible sample types, i.e., `Real` and `AbstractArray` for univariate distributions and `AbstractVecOrMat` and `AbstractArray{<:AbstractVector}` for multivariate distributions.

Additionally, I updated the documentation and added some tests.