### PR TITLE
define var for multivariate mixture models

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.23.4"
+version = "0.23.5"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -227,6 +227,10 @@ function var(d::UnivariateMixture)
     return v
 end
 
+function var(d::MultivariateMixture)
+    return diag(cov(d))
+end
+
 function cov(d::MultivariateMixture)
     K = ncomponents(d)
     p = probs(d)

--- a/test/mixture.jl
+++ b/test/mixture.jl
@@ -146,6 +146,7 @@ function test_mixture(g::MultivariateMixture, n::Int, ns::Int,
     @test size(Xs) == (length(g), ns)
     @test isapprox(vec(mean(Xs, dims=2)), mean(g), atol=0.1)
     @test isapprox(cov(Xs, dims=2)      , cov(g) , atol=0.1)
+    @test isapprox(var(Xs, dims=2)      , var(g) , atol=0.1)
 end
 
 function test_params(g::AbstractMixtureModel)


### PR DESCRIPTION
Closes #1060 

Adds a method to `var` function which takes a multivariate mixture model as the argument, expanding the current which only accepts univariate mixture models.

Implementation is based on the `cov` function so should be robust. 