### PR TITLE
Remove Wishart type constraint from MatrixBeta

### DIFF
--- a/src/matrix/matrixbeta.jl
+++ b/src/matrix/matrixbeta.jl
@@ -25,7 +25,7 @@ are independent, and we use ``\\mathcal{L}(\\cdot)`` to denote the lower Cholesk
 
 has ``\\mathbf{U}\\sim \\textrm{MB}_p(n_1/2, n_2/2)``.
 """
-struct MatrixBeta{T <: Real, TW <: Wishart} <: ContinuousMatrixDistribution
+struct MatrixBeta{T <: Real, TW} <: ContinuousMatrixDistribution
     W1::TW
     W2::TW
     logc0::T


### PR DESCRIPTION
This PR removes the Wishart type constraint from the MatrixBeta type. I understand the appeal of the type constraint but in DistributionsAD.jl we define our own version of Wishart that I want to use in MatrixBeta. The type constraint makes it impossible to do so. Defining an AbstractWishart is another option but maybe overkill.