### PR TITLE
Micro improvements on MatrixNormal

### DIFF
--- a/src/matrix/matrixnormal.jl
+++ b/src/matrix/matrixnormal.jl
@@ -125,7 +125,7 @@ function _rand!(rng::AbstractRNG, d::MatrixNormal, Y::AbstractMatrix)
     X = randn(rng, n, p)
     A = cholesky(d.U).L
     B = cholesky(d.V).U
-    Y .= d.M + A * X * B
+    Y .= d.M .+ A * X * B
 end
 
 #  -----------------------------------------------------------------------------
@@ -154,7 +154,7 @@ end
 
 function _rand_params(::Type{MatrixNormal}, elty, n::Int, p::Int)
     M = randn(elty, n, p)
-    U = (X = 2rand(elty, n, n) .- 1; X * X')
-    V = (Y = 2rand(elty, p, p) .- 1; Y * Y')
+    U = (X = 2 .* rand(elty, n, n) .- 1; X * X')
+    V = (Y = 2 .* rand(elty, p, p) .- 1; Y * Y')
     return M, U, V
 end


### PR DESCRIPTION
I was just browsing the source code and saw a couple missed opportunities for broadcast fusion. I did some quick benchmarking and in both cases it saves a couple microseconds and allocations.  
```julia
julia> @btime _rand!($rng, $d, $X);
  22.679 μs (5 allocations: 32.63 KiB)

julia> @btime _rand2!($rng, $d, $X);
  22.065 μs (4 allocations: 24.69 KiB)
```
```julia
julia> @btime _rand_params(MatrixNormal, Float64, 100, 100);
  169.032 μs (25 allocations: 704.02 KiB)

julia> @btime _rand_params2(MatrixNormal, Float64, 100, 100);
  149.643 μs (25 allocations: 547.73 KiB)
```