### PR TITLE
Remove use of deprecated Random.RangeGenerator for reproducibility across Julia versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,8 +31,9 @@ FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 HypothesisTests = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Calculus", "Distributed", "FiniteDifferences", "ForwardDiff", "JSON", "StaticArrays", "HypothesisTests", "Test"]
+test = ["StableRNGs", "Calculus", "Distributed", "FiniteDifferences", "ForwardDiff", "JSON", "StaticArrays", "HypothesisTests", "Test"]

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -14,7 +14,7 @@ using LinearAlgebra, Printf
 import LinearAlgebra: dot, rank
 
 using Random
-import Random: GLOBAL_RNG, RangeGenerator, rand!, SamplerRangeInt
+import Random: GLOBAL_RNG, rand!, SamplerRangeInt
 
 import Statistics: mean, median, quantile, std, var, cov, cor
 import StatsBase: kurtosis, skewness, entropy, mode, modes,

--- a/src/samplers/aliastable.jl
+++ b/src/samplers/aliastable.jl
@@ -1,7 +1,6 @@
 struct AliasTable{N} <: Sampleable{Univariate,Discrete}
-    accept::NTuple{N,Float64}
-    alias::NTuple{N,Int}
-    sample_space::UnitRange{Int64}
+    accept::Vector{Float64}
+    alias::Vector{Int}
 end
 ncategories(s::AliasTable{N}) where N = N
 
@@ -11,11 +10,11 @@ function AliasTable(probs::AbstractVector{T}) where T<:Real
     accp = Vector{Float64}(undef, N)
     alias = Vector{Int}(undef, N)
     StatsBase.make_alias_table!(probs, 1.0, accp, alias)
-    AliasTable{N}(tuple(accp...), tuple(alias...), 1:N)
+    AliasTable{N}(accp, alias)
 end
 
-function rand(rng::AbstractRNG, s::AliasTable)
-    i = rand(rng, s.sample_space) % Int
+function rand(rng::AbstractRNG, s::AliasTable{N}) where N
+    i = rand(rng, 1:N) % Int
     u = rand(rng)
     @inbounds r = u < s.accept[i] ? i : s.alias[i]
     r

--- a/src/samplers/aliastable.jl
+++ b/src/samplers/aliastable.jl
@@ -1,20 +1,21 @@
-struct AliasTable{N} <: Sampleable{Univariate,Discrete}
+struct AliasTable <: Sampleable{Univariate,Discrete}
     accept::Vector{Float64}
     alias::Vector{Int}
+    n::Int
 end
-ncategories(s::AliasTable{N}) where N = N
+ncategories(s::AliasTable) = s.n
 
 function AliasTable(probs::AbstractVector)
-    N = length(probs)
-    N > 0 || throw(ArgumentError("The input probability vector is empty."))
-    accp = Vector{Float64}(undef, N)
-    alias = Vector{Int}(undef, N)
+    n = length(probs)
+    n > 0 || throw(ArgumentError("The input probability vector is empty."))
+    accp = Vector{Float64}(undef, n)
+    alias = Vector{Int}(undef, n)
     StatsBase.make_alias_table!(probs, 1.0, accp, alias)
-    AliasTable{N}(accp, alias)
+    AliasTable(accp, alias, n)
 end
 
-function rand(rng::AbstractRNG, s::AliasTable{N}) where N
-    i = rand(rng, 1:N) % Int
+function rand(rng::AbstractRNG, s::AliasTable)
+    i = rand(rng, 1:(s.n)) % Int
     u = rand(rng)
     @inbounds r = u < s.accept[i] ? i : s.alias[i]
     r

--- a/src/samplers/aliastable.jl
+++ b/src/samplers/aliastable.jl
@@ -14,7 +14,7 @@ function AliasTable(probs::AbstractVector)
 end
 
 function rand(rng::AbstractRNG, s::AliasTable)
-    i = rand(rng, 1:(s.n)) % Int
+    i = rand(rng, 1:length(s.alias)) % Int
     u = rand(rng)
     @inbounds r = u < s.accept[i] ? i : s.alias[i]
     r

--- a/src/samplers/aliastable.jl
+++ b/src/samplers/aliastable.jl
@@ -1,7 +1,6 @@
 struct AliasTable <: Sampleable{Univariate,Discrete}
     accept::Vector{Float64}
     alias::Vector{Int}
-    n::Int
 end
 ncategories(s::AliasTable) = s.n
 

--- a/src/samplers/aliastable.jl
+++ b/src/samplers/aliastable.jl
@@ -4,7 +4,7 @@ struct AliasTable{N} <: Sampleable{Univariate,Discrete}
 end
 ncategories(s::AliasTable{N}) where N = N
 
-function AliasTable(probs::AbstractVector{T}) where T<:Real
+function AliasTable(probs::AbstractVector)
     N = length(probs)
     N > 0 || throw(ArgumentError("The input probability vector is empty."))
     accp = Vector{Float64}(undef, N)

--- a/src/samplers/aliastable.jl
+++ b/src/samplers/aliastable.jl
@@ -15,7 +15,7 @@ function AliasTable(probs::AbstractVector{T}) where T<:Real
 end
 
 function rand(rng::AbstractRNG, s::AliasTable)
-    i = rand(rng, Random.Sampler(rng, s.sample_space)) % Int
+    i = rand(rng, s.sample_space) % Int
     u = rand(rng)
     @inbounds r = u < s.accept[i] ? i : s.alias[i]
     r

--- a/src/samplers/aliastable.jl
+++ b/src/samplers/aliastable.jl
@@ -10,7 +10,7 @@ function AliasTable(probs::AbstractVector)
     accp = Vector{Float64}(undef, n)
     alias = Vector{Int}(undef, n)
     StatsBase.make_alias_table!(probs, 1.0, accp, alias)
-    AliasTable(accp, alias, n)
+    AliasTable(accp, alias)
 end
 
 function rand(rng::AbstractRNG, s::AliasTable)

--- a/src/samplers/aliastable.jl
+++ b/src/samplers/aliastable.jl
@@ -1,21 +1,21 @@
-struct AliasTable{S} <: Sampleable{Univariate,Discrete}
-    accept::Vector{Float64}
-    alias::Vector{Int}
-    isampler::S
+struct AliasTable{N} <: Sampleable{Univariate,Discrete}
+    accept::NTuple{N,Float64}
+    alias::NTuple{N,Int}
+    sample_space::UnitRange{Int64}
 end
-ncategories(s::AliasTable) = length(s.accept)
+ncategories(s::AliasTable{N}) where N = N
 
 function AliasTable(probs::AbstractVector{T}) where T<:Real
-    n = length(probs)
-    n > 0 || throw(ArgumentError("The input probability vector is empty."))
-    accp = Vector{Float64}(undef, n)
-    alias = Vector{Int}(undef, n)
+    N = length(probs)
+    N > 0 || throw(ArgumentError("The input probability vector is empty."))
+    accp = Vector{Float64}(undef, N)
+    alias = Vector{Int}(undef, N)
     StatsBase.make_alias_table!(probs, 1.0, accp, alias)
-    AliasTable(accp, alias, Random.RangeGenerator(1:n))
+    AliasTable{N}(tuple(accp...), tuple(alias...), 1:N)
 end
 
 function rand(rng::AbstractRNG, s::AliasTable)
-    i = rand(rng, s.isampler) % Int
+    i = rand(rng, Random.Sampler(rng, s.sample_space)) % Int
     u = rand(rng)
     @inbounds r = u < s.accept[i] ? i : s.alias[i]
     r

--- a/src/samplers/aliastable.jl
+++ b/src/samplers/aliastable.jl
@@ -2,7 +2,7 @@ struct AliasTable <: Sampleable{Univariate,Discrete}
     accept::Vector{Float64}
     alias::Vector{Int}
 end
-ncategories(s::AliasTable) = s.n
+ncategories(s::AliasTable) = length(s.alias)
 
 function AliasTable(probs::AbstractVector)
     n = length(probs)

--- a/test/categorical.jl
+++ b/test/categorical.jl
@@ -1,5 +1,6 @@
 using Distributions
 using Test
+using StableRNGs
 
 @testset "Categorical" begin
 
@@ -64,6 +65,12 @@ p = ones(10^6) * 1.0e-6
 
 @testset "test args... constructor" begin
     @test Categorical(0.3, 0.7) == Categorical([0.3, 0.7])
+end
+
+@testset "reproducibility across julia versions" begin
+    d= Categorical([0.1, 0.2, 0.7])
+    rng = StableRNGs.StableRNG(600)
+    @test rand(rng, d, 10) == [2, 1, 3, 3, 2, 3, 3, 3, 3, 3]
 end
 
 end


### PR DESCRIPTION
This is needed to get reproducible sampling of `Distributions.Categorical` across Julia versions using `StableRNG` generators. 

Context: https://github.com/JuliaStats/StatsBase.jl/pull/576, https://github.com/rfourquet/StableRNGs.jl/issues/4#issuecomment-674497714

