### PR TITLE
Add `loglikelihood` for `MatrixDistribution`

### DIFF
--- a/src/matrixvariates.jl
+++ b/src/matrixvariates.jl
@@ -214,6 +214,23 @@ Evaluate logarithm of pdf value for a given sample `x`. This function need not p
 """
 _logpdf(d::MatrixDistribution, x::AbstractArray)
 
+"""
+    loglikelihood(d::MatrixDistribution, x::AbstractArray)
+
+The log-likelihood of distribution `d` with respect to all samples contained in array `x`.
+
+Here, `x` can be a matrix of size `size(d)`, a three-dimensional array with `size(d, 1)`
+rows and `size(d, 2)` columns, or an array of matrices of size `size(d)`.
+"""
+loglikelihood(d::MatrixDistribution, X::AbstractMatrix{<:Real}) = logpdf(d, X)
+function loglikelihood(d::MatrixDistribution, X::AbstractArray{<:Real,3})
+    (size(X, 1), size(X, 2)) == size(d) || throw(DimensionMismatch("Inconsistent array dimensions."))
+    return sum(i -> _logpdf(d, view(X, :, :, i)), axes(X, 3))
+end
+function loglikelihood(d::MatrixDistribution, X::AbstractArray{<:AbstractMatrix{<:Real}})
+    return sum(x -> logpdf(d, x), X)
+end
+
 #  for testing
 is_univariate(d::MatrixDistribution) = size(d) == (1, 1)
 check_univariate(d::MatrixDistribution) = is_univariate(d) || throw(ArgumentError("not 1 x 1"))

--- a/src/multivariates.jl
+++ b/src/multivariates.jl
@@ -257,12 +257,13 @@ The log-likelihood of distribution `d` with respect to all samples contained in 
 Here, `x` can be a vector of length `dim(d)`, a matrix with `dim(d)` rows, or an array of
 vectors of length `dim(d)`.
 """
-function loglikelihood(d::MultivariateDistribution, X::AbstractVecOrMat{<:Real})
+loglikelihood(d::MultivariateDistribution, X::AbstractVector{<:Real}) = logpdf(d, X)
+function loglikelihood(d::MultivariateDistribution, X::AbstractMatrix{<:Real})
     size(X, 1) == length(d) || throw(DimensionMismatch("Inconsistent array dimensions."))
     return sum(i -> _logpdf(d, view(X, :, i)), 1:size(X, 2))
 end
 function loglikelihood(d::MultivariateDistribution, X::AbstractArray{<:AbstractVector})
-    return sum(x -> _logpdf(d, x), X)
+    return sum(x -> logpdf(d, x), X)
 end
 
 ##### Specific distributions #####

--- a/test/matrixvariates.jl
+++ b/test/matrixvariates.jl
@@ -35,6 +35,14 @@ function test_draw(d::MatrixDistribution, X::AbstractMatrix)
     @test insupport(d, X)
     @test logpdf(d, X) ≈ log(pdf(d, X))
     @test logpdf(d, [X, X]) ≈ log.(pdf(d, [X, X]))
+    @test loglikelihood(d, X) ≈ logpdf(d, X)
+    @test loglikelihood(d, [X, X]) ≈ 2 * logpdf(d, X)
+    if d isa MatrixFDist
+        # Broken since `pdadd` is not defined for SubArray
+        @test_broken loglikelihood(d, cat(X, X; dims=3)) ≈ 2 * logpdf(d, X)
+    else
+        @test loglikelihood(d, cat(X, X; dims=3)) ≈ 2 * logpdf(d, X)
+    end
     nothing
 end
 


### PR DESCRIPTION
This PR adds `loglikelihood` implementations for `MatrixDistribution`, consistent with the existing behaviour for uni- and multivariate distributions (see https://github.com/JuliaStats/Distributions.jl/pull/1144). It also simplifies the implementation of `loglikelihood` for `MultivariateDistribution` and ensures that `_logpdf` is only called if the dimension was checked before.