### PR TITLE
Revert "Return an Int from `invlogccdf` on Geometric"

### DIFF
--- a/src/univariate/discrete/geometric.jl
+++ b/src/univariate/discrete/geometric.jl
@@ -132,7 +132,7 @@ function invlogccdf(d::Geometric{T}, lp::Real) where T<:Real
     elseif lp == zero(d.p)
         return zero(T)
     end
-    max(ceil(Int, lp/log1p(-d.p)) - 1, zero(T))
+    max(ceil(lp/log1p(-d.p)) - 1, zero(T))
 end
 
 function mgf(d::Geometric, t::Real)


### PR DESCRIPTION
Really sorry @andreasnoack but I think my suggested solution here was the wrong one. This implementation breaks type stability of the method.

I'm actually not even sure Distributions does the wrong thing here, so I suggest simply reverting. I've handled the StatsPlots issue downstream.

This reverts commit 82120fcb8b51e0e3f5789b7ae78a9f9aa8ad2375.
