### PR TITLE
Fix conversion error with DiscreteNonParametric

### DIFF
--- a/src/univariate/discrete/discretenonparametric.jl
+++ b/src/univariate/discrete/discretenonparametric.jl
@@ -40,7 +40,7 @@ Base.eltype(::Type{<:DiscreteNonParametric{T}}) where T = T
 
 # Conversion
 convert(::Type{DiscreteNonParametric{T,P,Ts,Ps}}, d::DiscreteNonParametric) where {T,P,Ts,Ps} =
-    DiscreteNonParametric{T,P,Ts,Ps}(Ts(support(d)), Ps(probs(d)), check_args=false)
+    DiscreteNonParametric{T,P,Ts,Ps}(convert(Ts, support(d)), convert(Ps, probs(d)), check_args=false)
 
 # Accessors
 params(d::DiscreteNonParametric) = (d.support, d.p)


### PR DESCRIPTION
```julia
julia> x = rand(2,3)
2×3 Array{Float64,2}:
 0.626575  0.277653  0.132907
 0.830829  0.489369  0.379038

julia> y = softmax(x;dims=1)
2×3 Array{Float64,2}:
 0.449113  0.447268  0.438776
 0.550887  0.552732  0.561224

julia> [Categorical(m;check_args=false) for m in eachcol(y)]
ERROR: MethodError: no method matching SubArray{Float64,1,Array{Float64,2},Tuple{Base.Slice{Base.OneTo{Int64}},Int64},true}(::SubArray{Float64,1,Array{Float64,2},Tuple{Base.Slice{Base.OneTo{Int64}},Int64},true})
Closest candidates are:
  SubArray{Float64,1,Array{Float64,2},Tuple{Base.Slice{Base.OneTo{Int64}},Int64},true}(::Any, ::Any, ::Any, ::Any) where {T, N, P, I, L} at subarray.jl:19
Stacktrace:
...
```