### PR TITLE
Removed Laplace from the list of fit.md

### DIFF
--- a/docs/src/fit.md
+++ b/docs/src/fit.md
@@ -72,9 +72,9 @@ fit_mle(Categorical, k, x, w)
 fit_mle(Categorical, x)        # equivalent to fit_mle(Categorical, max(x), x)
 fit_mle(Categorical, x, w)
 ```
-!!! note
+!!! warning
 
-    Laplace distribution currently does not support weighted fit_mle.
+     Laplace distribution currently does not support weighted fit_mle.
 ## Sufficient Statistics
 
 For many distributions, estimation can be based on (sum of) sufficient statistics computed from a dataset. To simplify implementation, for such distributions, we implement `suffstats` method instead of `fit_mle` directly:

--- a/docs/src/fit.md
+++ b/docs/src/fit.md
@@ -75,6 +75,7 @@ fit_mle(Categorical, x, w)
 !!! warning
 
      Laplace distribution currently does not support weighted `fit_mle`.
+     
 ## Sufficient Statistics
 
 For many distributions, estimation can be based on (sum of) sufficient statistics computed from a dataset. To simplify implementation, for such distributions, we implement `suffstats` method instead of `fit_mle` directly:

--- a/docs/src/fit.md
+++ b/docs/src/fit.md
@@ -74,7 +74,7 @@ fit_mle(Categorical, x, w)
 ```
 !!! warning
 
-     Laplace distribution currently does not support weighted fit_mle.
+     Laplace distribution currently does not support weighted `fit_mle`.
 ## Sufficient Statistics
 
 For many distributions, estimation can be based on (sum of) sufficient statistics computed from a dataset. To simplify implementation, for such distributions, we implement `suffstats` method instead of `fit_mle` directly:

--- a/docs/src/fit.md
+++ b/docs/src/fit.md
@@ -47,7 +47,6 @@ The `fit_mle` method has been implemented for the following distributions:
 - [`Normal`](@ref)
 - [`Gamma`](@ref)
 - [`Geometric`](@ref)
-- [`Laplace`](@ref)
 - [`Pareto`](@ref)
 - [`Poisson`](@ref)
 - [`Rayleigh`](@ref)

--- a/docs/src/fit.md
+++ b/docs/src/fit.md
@@ -47,6 +47,7 @@ The `fit_mle` method has been implemented for the following distributions:
 - [`Normal`](@ref)
 - [`Gamma`](@ref)
 - [`Geometric`](@ref)
+- [`Laplace`](@ref) 
 - [`Pareto`](@ref)
 - [`Poisson`](@ref)
 - [`Rayleigh`](@ref)
@@ -71,7 +72,9 @@ fit_mle(Categorical, k, x, w)
 fit_mle(Categorical, x)        # equivalent to fit_mle(Categorical, max(x), x)
 fit_mle(Categorical, x, w)
 ```
+!!! note
 
+    Laplace distribution currently does not support weighted fit_mle.
 ## Sufficient Statistics
 
 For many distributions, estimation can be based on (sum of) sufficient statistics computed from a dataset. To simplify implementation, for such distributions, we implement `suffstats` method instead of `fit_mle` directly:

--- a/docs/src/fit.md
+++ b/docs/src/fit.md
@@ -47,7 +47,7 @@ The `fit_mle` method has been implemented for the following distributions:
 - [`Normal`](@ref)
 - [`Gamma`](@ref)
 - [`Geometric`](@ref)
-- [`Laplace`](@ref) 
+- [`Laplace`](@ref)
 - [`Pareto`](@ref)
 - [`Poisson`](@ref)
 - [`Rayleigh`](@ref)


### PR DESCRIPTION
As requested in https://github.com/JuliaStats/Distributions.jl/issues/807#, I have removed the Laplace from the list of distribution from the list in fit.md .