### PR TITLE
Stop testing PoissonADSampler for μ=5.0

### DIFF
--- a/src/multivariate/dirichlet.jl
+++ b/src/multivariate/dirichlet.jl
@@ -266,22 +266,12 @@ function dirichlet_mle_init(P::AbstractMatrix{Float64})
     K = size(P, 1)
     n = size(P, 2)
 
-    μ = Vector{Float64}(undef, K)  # E[p]
-    γ = Vector{Float64}(undef, K)  # E[p^2]
-
-    for i = 1:n
-        for k = 1:K
-            @inbounds pk = P[k, i]
-            @inbounds μ[k] += pk
-            @inbounds γ[k] += pk * pk
-        end
-    end
+    μ = vec(sum(P, dims=2))       # E[p]
+    γ = vec(sum(abs2, P, dims=2)) # E[p^2]
 
     c = 1.0 / n
-    for k = 1:K
-        μ[k] *= c
-        γ[k] *= c
-    end
+    μ .*= c
+    γ .*= c
 
     _dirichlet_mle_init2(μ, γ)
 end
@@ -290,14 +280,14 @@ function dirichlet_mle_init(P::AbstractMatrix{Float64}, w::AbstractArray{Float64
     K = size(P, 1)
     n = size(P, 2)
 
-    μ = Vector{Float64}(undef, K)  # E[p]
-    γ = Vector{Float64}(undef, K)  # E[p^2]
-    tw = 0.
+    μ = zeros(K)  # E[p]
+    γ = zeros(K)  # E[p^2]
+    tw = 0.0
 
-    for i = 1:n
+    for i in 1:n
         @inbounds wi = w[i]
         tw += wi
-        for k = 1:K
+        for k in 1:K
             pk = P[k, i]
             @inbounds μ[k] += pk * wi
             @inbounds γ[k] += pk * pk * wi
@@ -305,10 +295,8 @@ function dirichlet_mle_init(P::AbstractMatrix{Float64}, w::AbstractArray{Float64
     end
 
     c = 1.0 / tw
-    for k = 1:K
-        μ[k] *= c
-        γ[k] *= c
-    end
+    μ .*= c
+    γ .*= c
 
     _dirichlet_mle_init2(μ, γ)
 end
@@ -327,7 +315,7 @@ function fit_dirichlet!(elogp::Vector{Float64}, α::Vector{Float64};
     α0 = sum(α)
 
     if debug
-        objv = dot(α - 1.0, elogp) + loggamma(α0) - sum(loggamma(α))
+        objv = dot(α .- 1.0, elogp) + loggamma(α0) - sum(loggamma, α)
     end
 
     t = 0
@@ -371,7 +359,7 @@ function fit_dirichlet!(elogp::Vector{Float64}, α::Vector{Float64};
 
         if debug
             prev_objv = objv
-            objv = dot(α - 1.0, elogp) + loggamma(α0) - sum(loggamma(α))
+            objv = dot(α .- 1.0, elogp) + loggamma(α0) - sum(loggamma, α)
             @printf("Iter %4d: objv = %.4e  ch = %.3e  gnorm = %.3e\n",
                 t, objv, objv - prev_objv, gnorm)
         end
@@ -381,26 +369,32 @@ function fit_dirichlet!(elogp::Vector{Float64}, α::Vector{Float64};
         converged = gnorm < tol
     end
 
+    if !converged
+        throw(ErrorException("No convergence after $maxiter (maxiter) iterations."))
+    end
+
     Dirichlet(α)
 end
 
 
 function fit_mle(::Type{T}, P::AbstractMatrix{Float64};
-    init::Vector{Float64}=Float64[], maxiter::Int=25, tol::Float64=1.0e-12) where {T<:Dirichlet}
+    init::Vector{Float64}=Float64[], maxiter::Int=25, tol::Float64=1.0e-12,
+    debug::Bool=false) where {T<:Dirichlet}
 
     α = isempty(init) ? dirichlet_mle_init(P) : init
     elogp = mean_logp(suffstats(T, P))
-    fit_dirichlet!(elogp, α; maxiter=maxiter, tol=tol)
+    fit_dirichlet!(elogp, α; maxiter=maxiter, tol=tol, debug=debug)
 end
 
 function fit_mle(::Type{<:Dirichlet}, P::AbstractMatrix{Float64},
                  w::AbstractArray{Float64};
-    init::Vector{Float64}=Float64[], maxiter::Int=25, tol::Float64=1.0e-12)
+    init::Vector{Float64}=Float64[], maxiter::Int=25, tol::Float64=1.0e-12,
+    debug::Bool=false)
 
     n = size(P, 2)
     length(w) == n || throw(DimensionMismatch("Inconsistent argument dimensions."))
 
     α = isempty(init) ? dirichlet_mle_init(P, w) : init
     elogp = mean_logp(suffstats(Dirichlet, P, w))
-    fit_dirichlet!(elogp, α; maxiter=maxiter, tol=tol)
+    fit_dirichlet!(elogp, α; maxiter=maxiter, tol=tol, debug=debug)
 end

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -63,7 +63,7 @@ end
 
 for (S, paramlst) in [
     (PoissonCountSampler, [0.2, 0.5, 1.0, 2.0, 5.0, 10.0, 15.0, 20.0, 30.0]),
-    (PoissonADSampler, [5.0, 10.0, 15.0, 20.0, 30.0])]
+    (PoissonADSampler, [10.0, 15.0, 20.0, 30.0])]
     local S
 
     println("    testing $S")


### PR DESCRIPTION
since it's not accurate for too small values.

Initialize arrays in fit_mle for Dirichlet.

Add debug keyword to fit_mle for Dirichlet and fix debug branches
in `fit_dirichlet!`

The initialization bug was the one that caused the test failure in https://github.com/JuliaStats/Distributions.jl/pull/1164 on 32 bit. It's a bit surprising that we haven't hit it more frequently since the initial values were often completely off because of the this, e.g.
```julia
julia> Distributions.dirichlet_mle_init(x)
3-element Array{Float64,1}:
 -0.0
 -0.0
 -0.0
julia> Distributions.dirichlet_mle_init(x)
3-element Array{Float64,1}:
  5.158988734525853e104
  8.769340308733536e104
 -0.16535356495305348
julia> Distributions.dirichlet_mle_init(x)
3-element Array{Float64,1}:
 5.040668036024078e103
 8.579050171199378e103
 3.165512062017993e197
julia> Distributions.dirichlet_mle_init(x)
3-element Array{Float64,1}:
 -1.9279331031482295e199
 -1.9280754428163168e199
  0.9840394381466419
```
It looks like the bug has been there fore seven years so I don't think we have many users of `fit_mle` for `Dirichlet`.