### PR TITLE
Implement quantile for MixtureModel{Univariate,Continuous}

### DIFF
--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -500,6 +500,21 @@ componentwise_logpdf(d::MultivariateMixture, x::AbstractVector) = componentwise_
 componentwise_logpdf(d::MultivariateMixture, x::AbstractMatrix) = componentwise_logpdf!(Matrix{eltype(x)}(undef, size(x,2), ncomponents(d)), d, x)
 
 
+function quantile(d::UnivariateMixture{Continuous}, p::Real)
+    ps = probs(d)
+    cs = [component(d,i) for i in eachindex(ps) if ps[i] > 0.0]
+    qs = quantile.(cs, p)
+    min_q, max_q = extrema(qs)
+
+    if iszero(p)
+        return(min_q)
+    elseif isone(p)
+        return(max_q)
+    end
+
+    quantile_bisect(d, p, min_q, max_q, 1.0e-12)
+end
+
 ## Sampling
 
 struct MixtureSampler{VF,VS,Sampler} <: Sampleable{VF,VS}

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -502,9 +502,7 @@ componentwise_logpdf(d::MultivariateMixture, x::AbstractMatrix) = componentwise_
 
 function quantile(d::UnivariateMixture{Continuous}, p::Real)
     ps = probs(d)
-    cs = [component(d,i) for i in eachindex(ps) if ps[i] > 0.0]
-    qs = quantile.(cs, p)
-    min_q, max_q = extrema(qs)
+    min_q, max_q = extrema(quantile(component(d, i), p) for (i, pi) in enumerate(ps) if pi > 0)
 
     if iszero(p)
         return(min_q)

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -512,7 +512,7 @@ function quantile(d::UnivariateMixture{Continuous}, p::Real)
         return(max_q)
     end
 
-    quantile_bisect(d, p, min_q, max_q, 1.0e-12)
+    quantile_bisect(d, p, min_q - 0.01*abs(min_q), max_q + 0.01*abs(max_q), 1.0e-12)
 end
 
 ## Sampling

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -500,9 +500,6 @@ componentwise_logpdf(d::MultivariateMixture, x::AbstractVector) = componentwise_
 componentwise_logpdf(d::MultivariateMixture, x::AbstractMatrix) = componentwise_logpdf!(Matrix{eltype(x)}(undef, size(x,2), ncomponents(d)), d, x)
 
 
-_default_tol(p::Real) = 1e-12
-_default_tol(p::AbstractFloat) = 10eps(eltype(p))
-
 function quantile(d::UnivariateMixture{Continuous}, p::Real)
     ps = probs(d)
     min_q, max_q = extrema(quantile(component(d, i), p) for (i, pi) in enumerate(ps) if pi > 0)
@@ -513,7 +510,7 @@ function quantile(d::UnivariateMixture{Continuous}, p::Real)
         return(max_q)
     end
 
-    tol =  _default_tol(p)
+    tol =  Base.rtoldefault(typeof(p)) * abs(p)
 
     if abs(cdf(d, min_q) - p) < tol
         return(min_q)

--- a/test/mixture.jl
+++ b/test/mixture.jl
@@ -72,7 +72,7 @@ function test_mixture(g::UnivariateMixture, n::Int, ns::Int,
     # quantile
     αs = [0.0; 0.49; 0.5; 0.51; 1.0]
     for α in αs
-        @test cdf(g, quantile(g, α)) ≈ α atol=1e-12
+        @test cdf(g, quantile(g, α)) ≈ α
     end
 
     # sampling

--- a/test/mixture.jl
+++ b/test/mixture.jl
@@ -178,6 +178,15 @@ end
          "rand(rng, ...)" => MersenneTwister(123))
 
     @testset "Testing UnivariateMixture" begin
+        g_u = MixtureModel([Normal(), Normal()])
+        @test isa(g_u, MixtureModel{Univariate, Continuous, <:Normal})
+        @test ncomponents(g_u) == 2
+        test_mixture(g_u, 1000, 10^6, rng)
+        test_params(g_u)
+        @test minimum(g_u) == -Inf
+        @test maximum(g_u) == Inf
+        @test extrema(g_u) == (-Inf, Inf)
+
         g_u = MixtureModel(Normal, [(0.0, 1.0), (2.0, 1.0), (-4.0, 1.5)], [0.2, 0.5, 0.3])
         @test isa(g_u, MixtureModel{Univariate, Continuous, Normal})
         @test ncomponents(g_u) == 3

--- a/test/mixture.jl
+++ b/test/mixture.jl
@@ -69,6 +69,12 @@ function test_mixture(g::UnivariateMixture, n::Int, ns::Int,
     @test componentwise_pdf(g, X)    ≈ P0
     @test componentwise_logpdf(g, X) ≈ LP0
 
+    # quantile
+    αs = [0.0; 0.49; 0.5; 0.51; 1.0]
+    for α in αs
+        @test cdf(g, quantile(g, α)) ≈ α atol=1e-12
+    end
+
     # sampling
     if (T <: AbstractFloat)
         if ismissing(rng)


### PR DESCRIPTION
This implements `quantile` for `MixtureModel{Univariate,Continuous}`. I am using the `quantile_bisect` function with starting range determined based on the component distributions.

Right now on master e.g., the following fails
```julia
julia> mix = MixtureModel([Normal(0.0, 1.0); Normal(0.0, 2.0 )], [0.4;0.6])
julia> median(mix)
ERROR: MethodError: no method matching iterate(::MixtureModel{Univariate,Continuous,Normal{Float64},Float64})
```
After this PR:
```julia
julia> median(mix)
0.0
```