### PR TITLE
Faster, more accurate Poisson Binomial PMF

### DIFF
--- a/src/univariate/discrete/poissonbinomial.jl
+++ b/src/univariate/discrete/poissonbinomial.jl
@@ -135,6 +135,48 @@ function poissonbinomial_pdf(p::AbstractArray{T,1}) where {T <: Real}
   return S
 end
 
+# Computes the pdf of a poisson-binomial random variable using
+# fast fourier transform
+#
+#     Hong, Y. (2013).
+#     On computing the distribution function for the Poisson binomial
+#     distribution. Computational Statistics and Data Analysis, 59, 41–51.
+#
+function poissonbinomial_pdf_fft(p::AbstractArray{T}) where {T <: Real}
+    n = length(p)
+    ω = 2 * one(T) / (n + 1)
+
+    x = Vector{Complex{T}}(undef, n+1)
+    lmax = ceil(Int, n/2)
+    x[1] = one(T)/(n + 1)
+    for l=1:lmax
+        logz = zero(T)
+        argz = zero(T)
+        for j=1:n
+            zjl = 1 - p[j] + p[j] * cospi(ω*l) + im * p[j] * sinpi(ω * l)
+            logz += log(abs(zjl))
+            argz += atan(imag(zjl), real(zjl))
+        end
+        dl = exp(logz)
+        x[l + 1] = dl * cos(argz) / (n + 1) + dl * sin(argz) * im / (n + 1)
+        if n + 1 - l > l
+            x[n + 1 - l + 1] = conj(x[l + 1])
+        end
+    end
+    [max(0, real(xi)) for xi in _dft(x)]
+end
+
+# A simple implementation of a DFT to avoid introducing a dependency
+# on an external FFT package just for this one distribution
+function _dft(x::Vector{T}) where T
+    n = length(x)
+    y = zeros(complex(float(T)), n)
+    @inbounds for j = 0:n-1, k = 0:n-1
+        y[k+1] += x[j+1] * cis(-π * float(T)(2 * mod(j * k, n)) / n)
+    end
+    return y
+end
+
 #### Sampling
 
 sampler(d::PoissonBinomial) = PoissBinAliasSampler(d)

--- a/test/poissonbinomial.jl
+++ b/test/poissonbinomial.jl
@@ -1,6 +1,37 @@
 using Distributions
 using Test
 
+function naive_esf(x::AbstractVector{T}) where T <: Real
+    n = length(x)
+    S = zeros(T, n+1)
+    states = hcat(reverse.(digits.(0:2^n-1,base=2,pad=n))...)'
+
+    r_states = vec(mapslices(sum, states, dims=2))
+
+    for r in 0:n
+        idx = findall(r_states .== r)
+        S[r+1] = sum(mapslices(x->prod(x[x .!= 0]), states[idx, :] .* x', dims=2))
+    end
+    return S
+end
+
+function naive_pb(p::AbstractVector{T}) where T <: Real
+    x = p ./ (1 .- p)
+    naive_esf(x) * prod(1 ./ (1 .+ x))
+end
+
+# test PoissonBinomial PMF algorithms
+x = [3.5118, .6219, .2905, .8450, 1.8648]
+n = length(x)
+p = x ./ (1 .+ x)
+
+naive_sol = naive_pb(p)
+
+@test Distributions.poissonbinomial_pdf_fft(p) ≈ naive_sol
+@test Distributions.poissonbinomial_pdf(p) ≈ naive_sol
+
+@test Distributions.poissonbinomial_pdf_fft(p) ≈ Distributions.poissonbinomial_pdf(p)
+
 # Test the special base where PoissonBinomial distribution reduces
 # to Binomial distribution
 for (p, n) in [(0.8, 6), (0.5, 10), (0.04, 20)]

--- a/test/poissonbinomial.jl
+++ b/test/poissonbinomial.jl
@@ -108,6 +108,21 @@ for (n₁, n₂, n₃, p₁, p₂, p₃) in [(10, 10, 10, 0.1, 0.5, 0.9),
     end
 end
 
+# Test the _dft helper function
+@testset "_dft" begin
+    x = Distributions._dft(collect(1:8))
+    # Comparator computed from FFTW
+    fftw_fft = [36.0 + 0.0im,
+                -4.0 + 9.65685424949238im,
+                -4.0 + 4.0im,
+                -4.0 + 1.6568542494923806im,
+                -4.0 + 0.0im,
+                -4.0 - 1.6568542494923806im,
+                -4.0 - 4.0im,
+                -4.0 - 9.65685424949238im]
+    @test x ≈ fftw_fft
+end
+
 # Test autodiff using ForwardDiff
 f = x -> logpdf(PoissonBinomial(x), 0)
 at = [0.5, 0.5]


### PR DESCRIPTION
I have done a lot of research in evaluating poisson binomial pmf in last 3 years. The simplest and fastest continues to be the recursive formula. I've cited Thomas & Taub (1982) but it predates this article as well because it is related to evaluating the elementary symmetric function. The Hong (2013) article does a very bad job at evaluating and comparing their method 

```julia
julia> x = [3.5118, .6219, .2905, .8450, 1.8648]
julia> p = big.(x) ./ (1 .+ big.(x))
julia> @benchmark poisbin_sum_taub(p)
BenchmarkTools.Trial: 
  memory estimate:  10.20 KiB
  allocs estimate:  230
  --------------
  minimum time:     7.075 μs (0.00% GC)
  median time:      7.525 μs (0.00% GC)
  mean time:        9.559 μs (12.27% GC)
  maximum time:     2.087 ms (66.47% GC)
  --------------
  samples:          10000
  evals/sample:     4

julia> @benchmark Distributions.poissonbinomial_pdf_fft(p)
BenchmarkTools.Trial: 
  memory estimate:  188.90 KiB
  allocs estimate:  4155
  --------------
  minimum time:     515.800 μs (0.00% GC)
  median time:      523.201 μs (0.00% GC)
  mean time:        558.614 μs (3.83% GC)
  maximum time:     9.248 ms (62.80% GC)
  --------------
  samples:          8935
  evals/sample:     1

julia> sum(abs.(poisbin_sum_taub(p) .- naive_sol))
1.106509096121475717627626332421301195049237546693398552456162007115350824780186e-77
julia> sum(abs.(Distributions.poissonbinomial_pdf_fft(p) .- naive_sol))
3.197437330491599664330118659436447055371737441489833207203143282015769955768403e-17
```
One method which does truly scale better than the recursive algorithm is Biscarri (2018), but it is a lot more involved but I do have it implemented in julia in a separate package right now. In simulation study you can see that it has comparable error rate, but is faster than the recursive algorithm for long inputs (see figure below where DFT-CF is Hong (2013), Taub is recursive algorithm implemented in this PR, and DC-FFT is Biscarri (2018)).

![pmf_sim](https://user-images.githubusercontent.com/805168/96205404-1463e200-0f2c-11eb-8325-a7c3ac07aa51.png)
