### PR TITLE
Make new unwhiten_winv! conditional on PDSparseMat

### DIFF
--- a/src/multivariate/mvnormalcanon.jl
+++ b/src/multivariate/mvnormalcanon.jl
@@ -176,8 +176,10 @@ sqmahal!(r::AbstractVector, d::MvNormalCanon, x::AbstractMatrix) = quad!(r, d.J,
 unwhiten_winv!(J::AbstractPDMat, x::AbstractVecOrMat) = unwhiten!(inv(J), x)
 unwhiten_winv!(J::PDiagMat, x::AbstractVecOrMat) = whiten!(J, x)
 unwhiten_winv!(J::ScalMat, x::AbstractVecOrMat) = whiten!(J, x)
-unwhiten_winv!(J::PDSparseMat, x::AbstractVecOrMat) = x[:] = J.chol.U \ x
-
+if isdefined(PDMats, :PDSparseMat)
+    unwhiten_winv!(J::PDSparseMat, x::AbstractVecOrMat) = x[:] = J.chol.U \ x
+end
+    
 _rand!(rng::AbstractRNG, d::MvNormalCanon, x::AbstractVector) =
     add!(unwhiten_winv!(d.J, randn!(rng,x)), d.μ)
 _rand!(rng::AbstractRNG, d::MvNormalCanon, x::AbstractMatrix) =


### PR DESCRIPTION
The `PDSparseMat` struct is defined behind a `HAVE_CHOLMOD` flag which is false when people build Julia without GPL libraries, see https://github.com/JuliaStats/PDMats.jl/blob/d50e35a37d218f0e6ac552512bc4c79b102cc930/src/PDMats.jl#L51-L53. Hence, https://github.com/JuliaStats/Distributions.jl/pull/855 broke Distributions when Julia has been built without GPL libraries.

cc @ElOceanografo 