### PR TITLE
relax qqbuild signature

### DIFF
--- a/src/qq.jl
+++ b/src/qq.jl
@@ -1,9 +1,9 @@
-struct QQPair
-    qx::Vector{Float64}
-    qy::Vector{Float64}
+struct QQPair{U<:AbstractVector, V<:AbstractVector}
+    qx::U
+    qy::V
 end
 
-function qqbuild(x::Vector, y::Vector)
+function qqbuild(x::AbstractVector, y::AbstractVector)
     n = min(length(x), length(y))
     grid = [0.0:(1 / (n - 1)):1.0;]
     qx = quantile(x, grid)
@@ -11,7 +11,7 @@ function qqbuild(x::Vector, y::Vector)
     return QQPair(qx, qy)
 end
 
-function qqbuild(x::Vector, d::UnivariateDistribution)
+function qqbuild(x::AbstractVector, d::UnivariateDistribution)
     n = length(x)
     grid = [(1 / (n - 1)):(1 / (n - 1)):(1.0 - (1 / (n - 1)));]
     qx = quantile(x, grid)
@@ -19,7 +19,7 @@ function qqbuild(x::Vector, d::UnivariateDistribution)
     return QQPair(qx, qd)
 end
 
-function qqbuild(d::UnivariateDistribution, x::Vector)
+function qqbuild(d::UnivariateDistribution, x::AbstractVector)
     n = length(x)
     grid = [(1 / (n - 1)):(1 / (n - 1)):(1.0 - (1 / (n - 1)));]
     qd = quantile.(Ref(d), grid)

--- a/test/qq.jl
+++ b/test/qq.jl
@@ -2,13 +2,19 @@ using Distributions
 using Test
 
 a = qqbuild(collect(1:10), collect(1:10))
-@test a.qx ≈ collect(1.0:10)
-@test a.qy ≈ collect(1.0:10)
+b = qqbuild(1:10, 1:10)
+c = qqbuild(view(collect(1:20), 1:10), view(collect(1:20), 1:10))
+@test a.qx ≈ b.qx ≈ c.qx ≈ collect(1.0:10)
+@test a.qy ≈ b.qy ≈ c.qy ≈ collect(1.0:10)
 
 a = qqbuild(collect(1:10), Uniform(1,10))
-@test a.qx ≈ collect(2.0:9)
-@test a.qy ≈ collect(2.0:9)
+b = qqbuild(1:10, Uniform(1,10))
+c = qqbuild(view(collect(1:20), 1:10), Uniform(1,10))
+@test a.qx ≈ b.qx ≈ c.qx ≈ collect(2.0:9)
+@test a.qy ≈ b.qy ≈ c.qy ≈ collect(2.0:9)
 
 a = qqbuild(Uniform(1,10), collect(1:10))
-@test a.qx ≈ collect(2.0:9)
-@test a.qy ≈ collect(2.0:9)
+b = qqbuild(Uniform(1,10), 1:10)
+c = qqbuild(Uniform(1,10), view(collect(1:20), 1:10))
+@test a.qx ≈ b.qx ≈ c.qx ≈ collect(2.0:9)
+@test a.qy ≈ b.qy ≈ c.qy ≈ collect(2.0:9)


### PR DESCRIPTION
Fixes #1196. I'm not completely sure whether the type parameter of `QQPair` should be widened to `AbstractVector` or `AbstractVector{<:Real}`. I chose the first option for simplicity.