### PR TITLE
Update show.jl

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -33,7 +33,7 @@ function _use_multline_show(d::Distribution, pnames)
     tlen = 0
     for (i, p) in enumerate(pnames)
         pv = getfield(d, p)
-        if !(isa(pv, Number) || isa(pv, NTuple) || isa(pv, AbstractVector))
+        if isa(pv, NTuple) || isa(pv, Array)
             multline = true
         else
             tlen += length(pv)


### PR DESCRIPTION
This changes the `show` method to match the criteria describing it: "if total number of values is greater than 8, or there are matrix-valued params, we use multi-line format". Tests passed locally but maybe there was another reason behind the `!isa(pv, Number)` condition that the tests don't capture?  

Why this PR, then? Because the current show method is not working great for `LocationScale`, and is even worse for composed `LocationScale`s:
```julia
julia> d = LocationScale(1,2,LocationScale(3,4,Normal()))
LocationScale{Float64,LocationScale{Float64,Normal{Float64}}}(
μ: 1.0
σ: 2.0
ρ: LocationScale{Float64,Normal{Float64}}(
μ: 3.0
σ: 4.0
ρ: Normal{Float64}(μ=0.0, σ=1.0)
)

)
```

PR https://github.com/JuliaStats/Distributions.jl/pull/1217 would improve things a bit because it specializes `LocationScale` on itself:
```julia
julia> 1 + 2 * (3 + 4 * Normal())
LocationScale{Float64,Normal{Float64}}(
μ: 7.0
σ: 8.0
ρ: Normal{Float64}(μ=0.0, σ=1.0)
)
```

but it would be even better combined with this PR:
```julia
julia> 1 + 2 * (3 + 4 * Normal())
LocationScale{Float64,Normal{Float64}}(μ=7.0, σ=8.0, ρ=Normal{Float64}(μ=0.0, σ=1.0))
```

and even better with adding a special
```julia
distrname(::LocationScale) = "LocationScale"
```

So that one would get the most readable output IMHO:
```julia
julia> 1 + 2 * (3 + 4 * Normal())
LocationScale(μ=7.0, σ=8.0, ρ=Normal{Float64}(μ=0.0, σ=1.0))
```