### PR TITLE
Fix gradlogpdf for LogitNormal

### DIFF
--- a/src/univariate/continuous/logitnormal.jl
+++ b/src/univariate/continuous/logitnormal.jl
@@ -136,10 +136,12 @@ cquantile(d::LogitNormal, q::Real) = logistic(norminvccdf(d.μ, d.σ, q))
 invlogcdf(d::LogitNormal, lq::Real) = logistic(norminvlogcdf(d.μ, d.σ, lq))
 invlogccdf(d::LogitNormal, lq::Real) = logistic(norminvlogccdf(d.μ, d.σ, lq))
 
-function gradlogpdf(d::LogitNormal{T}, x::Real) where T<:Real
-    #TODO check
-    (μ, σ) = params(d)
-    0 < x < 1 ? (μ - logit(x)) / (σ^2 * x * (1-x)) - 1/(x-1) - 1/x : zero(T)
+function gradlogpdf(d::LogitNormal, x::Real)
+    μ, σ = params(d)
+    _insupport = insupport(d, x)
+    _x = _insupport ? x : zero(x)
+    z = (μ - logit(_x) + σ^2 * (2 * _x - 1)) / (σ^2 * _x * (1 - _x))
+    return _insupport ? z : oftype(z, NaN)
 end
 
 # mgf(d::LogitNormal)

--- a/src/univariate/continuous/logitnormal.jl
+++ b/src/univariate/continuous/logitnormal.jl
@@ -139,7 +139,7 @@ invlogccdf(d::LogitNormal, lq::Real) = logistic(norminvlogccdf(d.μ, d.σ, lq))
 function gradlogpdf(d::LogitNormal{T}, x::Real) where T<:Real
     #TODO check
     (μ, σ) = params(d)
-    0 < x < 1 ? - ((log(x) - μ) / ((σ^2) + 1) * x * (1-x)) : zero(T)
+    0 < x < 1 ? (μ - logit(x)) / (σ^2 * x * (1-x)) - 1/(x-1) - 1/x : zero(T)
 end
 
 # mgf(d::LogitNormal)


### PR DESCRIPTION
This PR fixes `gradlogpdf` for `LogitNormal`. Comparison with ForwardDiff:

```julia
using ForwardDiff, Distributions, Plots
plot(x -> gradlogpdf(LogitNormal(), x), xlims=(-0.1,1.1), lab="gradlogpdf", lw=10, ylims=(-500,500))
plot!(x -> ForwardDiff.derivative(y -> logpdf(LogitNormal(), y), x), xlims=(-0.1,1.1), lab="AD(logpdf)", lw=4)
```

produces

<img width="712" alt="Screen Shot 2020-11-13 at 12 16 38 pm" src="https://user-images.githubusercontent.com/4486578/99015912-16ac7100-25aa-11eb-9ac3-ffa22f14f483.png">

And for non-standard parameters:

```julia
μ, σ = 1.0, 2.0
plot(x -> gradlogpdf(LogitNormal(μ, σ), x), xlims=(-0.1,1.1), lab="gradlogpdf", lw=10, ylims=(-50,50))
plot!(x -> ForwardDiff.derivative(y -> logpdf(LogitNormal(μ, σ), y), x), xlims=(-0.1,1.1), lab="AD(logpdf)", lw=4)
```

produces

<img width="712" alt="Screen Shot 2020-11-13 at 12 19 03 pm" src="https://user-images.githubusercontent.com/4486578/99016076-6be88280-25aa-11eb-9793-fe238f292b0c.png">
