### PR TITLE
Revert update of `show`

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -26,14 +26,15 @@ function _use_multline_show(d::Distribution, pnames)
     # decide whether to use one-line or multi-line format
     #
     # Criteria: if total number of values is greater than 8, or
-    # there are matrix-valued params, we use multi-line format
+    # there are params that are neither numbers, tuples, or vectors,
+    # we use multi-line format
     #
     namevals = _NameVal[]
     multline = false
     tlen = 0
     for (i, p) in enumerate(pnames)
         pv = getfield(d, p)
-        if isa(pv, NTuple) || isa(pv, Array)
+        if !(isa(pv, Number) || isa(pv, NTuple) || isa(pv, AbstractVector))
             multline = true
         else
             tlen += length(pv)


### PR DESCRIPTION
This PR reverts https://github.com/JuliaStats/Distributions.jl/pull/1220 which leads to errors for all distributions with fields that are neither of type `NTuple` nor `Array` and do not implement `length` (see https://github.com/JuliaStats/Distributions.jl/pull/1220#discussion_r547174197).

For instance, this leads to errors for `AbstractGPs.FiniteGP` which has a field of type `AbstractGPs.GP` that does not implement `length`.

It would be great if a version with this bugfix could be released soon.