### PR TITLE
use _σ in cquantile(::Normal, ...)

### DIFF
--- a/src/univariate/continuous/normal.jl
+++ b/src/univariate/continuous/normal.jl
@@ -222,7 +222,7 @@ function cquantile(d::Normal, p::Real)
     q = xval(d, erfcinv(2*_p) * sqrt2)
     if isnan(_p)
         return oftype(q, _p)
-    elseif iszero(d.σ)
+    elseif iszero(_σ)
         # Quantile not uniquely defined at p=0 and p=1 when σ=0
         if iszero(_p)
             return oftype(q, Inf)


### PR DESCRIPTION
this is really minor thing, this `d.σ` was probably forgotten.

cf. analogous `quantile` above
https://github.com/JuliaStats/Distributions.jl/compare/master...kalmarek:patch-1#diff-b8d201d193aa5a9a28306a5ac259911618261cf3596f9cb557305e2f3fb73ac4L205