### PR TITLE
Remove pre-allocation of outputs for `logpdf` and `pdf` + deprecate implementations for multiple samples

### DIFF
--- a/docs/src/extends.md
+++ b/docs/src/extends.md
@@ -140,12 +140,10 @@ Following methods need to be implemented for each multivariate distribution type
 - [`sampler(d::Distribution)`](@ref)
 - [`eltype(d::Distribution)`](@ref)
 - [`Distributions._rand!(::AbstractRNG, d::MultivariateDistribution, x::AbstractArray)`](@ref)
-- [`Distributions._logpdf(d::MultivariateDistribution, x::AbstractArray)`](@ref)
+- [`Distributions._logpdf(d::MultivariateDistribution, x::AbstractVector)`](@ref)
 
-Note that if there exists faster methods for batch evaluation, one should override `_logpdf!` and `_pdf!`.
-
-Furthermore, the generic `loglikelihood` function repeatedly calls `_logpdf`. If there is
-a better way to compute the log-likelihood, one should override `loglikelihood`.
+The generic `loglikelihood` function repeatedly calls `_logpdf`. If there is a better way
+to compute the log-likelihood, one should override `loglikelihood`.
 
 It is also recommended that one also implements the following statistics functions:
 
@@ -163,4 +161,4 @@ Following methods need to be implemented for each matrix-variate distribution ty
 - [`size(d::MatrixDistribution)`](@ref)
 - [`rand(d::MatrixDistribution)`](@ref)
 - [`sampler(d::MatrixDistribution)`](@ref)
-- [`Distributions._logpdf(d::MatrixDistribution, x::AbstractArray)`](@ref)
+- [`Distributions._logpdf(d::MatrixDistribution, x::AbstractMatrix)`](@ref)

--- a/docs/src/matrix.md
+++ b/docs/src/matrix.md
@@ -23,8 +23,8 @@ Distributions.rank(::MatrixDistribution)
 mean(::MatrixDistribution)
 var(::MatrixDistribution)
 cov(::MatrixDistribution)
-pdf{T<:Real}(d::MatrixDistribution, x::AbstractMatrix{T})
-logpdf{T<:Real}(d::MatrixDistribution, x::AbstractMatrix{T})
+pdf(d::MatrixDistribution, x::AbstractMatrix)
+logpdf(d::MatrixDistribution, x::AbstractMatrix)
 Distributions._rand!(::AbstractRNG, ::MatrixDistribution, A::AbstractMatrix)
 vec(d::MatrixDistribution)
 ```
@@ -45,5 +45,5 @@ LKJ
 ## Internal Methods (for creating your own matrix-variate distributions)
 
 ```@docs
-Distributions._logpdf(d::MatrixDistribution, x::AbstractArray)
+Distributions._logpdf(d::MatrixDistribution, x::AbstractMatrix)
 ```

--- a/docs/src/multivariate.md
+++ b/docs/src/multivariate.md
@@ -31,8 +31,8 @@ entropy(::MultivariateDistribution, ::Real)
 
 ```@docs
 insupport(::MultivariateDistribution, ::AbstractArray)
-pdf(::MultivariateDistribution, ::AbstractArray)
-logpdf(::MultivariateDistribution, ::AbstractArray)
+pdf(::MultivariateDistribution, ::AbstractVector)
+logpdf(::MultivariateDistribution, ::AbstractVector)
 loglikelihood(::MultivariateDistribution, ::AbstractArray)
 ```
 **Note:** For multivariate distributions, the pdf value is usually very small or large, and therefore direct evaluating the pdf may cause numerical problems. It is generally advisable to perform probability computation in log-scale.
@@ -69,7 +69,7 @@ In addition to the methods listed in the common interface above, we also provide
 ```@docs
 invcov(::Distributions.AbstractMvNormal)
 logdetcov(::Distributions.AbstractMvNormal)
-sqmahal(::Distributions.AbstractMvNormal, ::AbstractArray)
+sqmahal(::Distributions.AbstractMvNormal, ::AbstractVector)
 rand(::AbstractRNG, ::Distributions.AbstractMvNormal)
 ```
 
@@ -97,7 +97,7 @@ params{D<:Distributions.AbstractMvLogNormal}(::Type{D},m::AbstractVector,S::Abst
 ## Internal Methods (for creating you own multivariate distribution)
 
 ```@docs
-Distributions._logpdf(d::MultivariateDistribution, x::AbstractArray)
+Distributions._logpdf(d::MultivariateDistribution, x::AbstractVector)
 ```
 
 ## Product distributions

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -209,7 +209,6 @@ export
 
     invscale,           # Inverse scale parameter
     sqmahal,            # squared Mahalanobis distance to Gaussian center
-    sqmahal!,           # inplace evaluation of sqmahal
     location,           # get the location parameter
     location!,          # provide storage for the location parameter (used in multivariate distribution mvlognormal)
     mean,               # mean of distribution

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -50,9 +50,9 @@ for fun in (:pdf, :logpdf)
     # `eachcol` requires Julia 1.1
     @static if VERSION < v"1.1"
         @eval begin
-            @deprecate ($_fun!)(r::AbstractArray, d::MultivariateDistribution, X::AbstractMatrix) r .= ($fun).(Ref(d), (view(x, :, i) for i in axes(x, 2))) false
-            @deprecate ($fun!)(r::AbstractArray, d::MultivariateDistribution, X::AbstractMatrix) r .= ($fun).(Ref(d), (view(x, :, i) for i in axes(x, 2)))
-            @deprecate ($fun)(d::MultivariateDistribution, X::AbstractMatrix) ($fun).(Ref(d), (view(x, :, i) for i in axes(x, 2)))
+            @deprecate ($_fun!)(r::AbstractArray, d::MultivariateDistribution, X::AbstractMatrix) r .= ($fun).(Ref(d), (view(X, :, i) for i in axes(X, 2))) false
+            @deprecate ($fun!)(r::AbstractArray, d::MultivariateDistribution, X::AbstractMatrix) r .= ($fun).(Ref(d), (view(X, :, i) for i in axes(X, 2)))
+            @deprecate ($fun)(d::MultivariateDistribution, X::AbstractMatrix) ($fun).(Ref(d), (view(X, :, i) for i in axes(X, 2)))
         end
     else
         @eval begin

--- a/src/matrixvariates.jl
+++ b/src/matrixvariates.jl
@@ -197,14 +197,12 @@ function pdf!(r::AbstractArray, d::MatrixDistribution, X::AbstractArray{M}) wher
     _pdf!(r, d, X)
 end
 
-function logpdf(d::MatrixDistribution, X::AbstractArray{M}) where M<:Matrix
-    T = promote_type(partype(d), eltype(M))
-    _logpdf!(Array{T}(undef, size(X)), d, X)
+function logpdf(d::MatrixDistribution, X::AbstractArray{<:AbstractMatrix{<:Real}})
+    map(Base.Fix1(logpdf, d), X)
 end
 
-function pdf(d::MatrixDistribution, X::AbstractArray{M}) where M<:Matrix
-    T = promote_type(partype(d), eltype(M))
-    _pdf!(Array{T}(undef, size(X)), d, X)
+function pdf(d::MatrixDistribution, X::AbstractArray{<:AbstractMatrix{<:Real}})
+    map(Base.Fix1(pdf, d), X)
 end
 
 """

--- a/src/matrixvariates.jl
+++ b/src/matrixvariates.jl
@@ -145,72 +145,53 @@ end
 
 # pdf & logpdf
 
+"""
+    _logpdf(d::MatrixDistribution, X::AbstractMatrix)
+
+Return the logarithm of the probability density of distribution `d` evaluated at `X`.
+
+This function does not need to perform dimension checking. Its default implementation is
+`logkernel(d, X) + d.logc0`.
+"""
 _logpdf(d::MatrixDistribution, X::AbstractMatrix) = logkernel(d, X) + d.logc0
 
-_pdf(d::MatrixDistribution, x::AbstractMatrix{T}) where {T<:Real} = exp(_logpdf(d, x))
+"""
+    _pdf(d::MultivariateDistribution, X::AbstractMatrix)
+
+Return the probability density of distribution `d` evaluated at `X`.
+
+This function does not need to perform dimension checking. It does not need to be
+implemented and falls back to `exp(_logpdf(d, X))`.
+
+See also: [`_logpdf`](@ref)
+"""
+_pdf(d::MatrixDistribution, X::AbstractMatrix) = exp(_logpdf(d, X))
 
 """
-    logpdf(d::MatrixDistribution, AbstractMatrix)
+    logpdf(d::MatrixDistribution, X::AbstractMatrix)
 
-Compute the logarithm of the probability density at the input matrix `x`.
+Compute the logarithm of the probability density at the input matrix `X`.
+
+The default implementation performs dimension checking and falls back to [`_logpdf`](@ref).
 """
-function logpdf(d::MatrixDistribution, x::AbstractMatrix{T}) where T<:Real
+function logpdf(d::MatrixDistribution, x::AbstractMatrix)
     size(x) == size(d) ||
         throw(DimensionMismatch("Inconsistent array dimensions."))
     _logpdf(d, x)
 end
 
 """
-    pdf(d::MatrixDistribution, x::AbstractArray)
+    pdf(d::MatrixDistribution, X::AbstractMatrix)
 
-Compute the probability density at the input matrix `x`.
+Compute the probability density at the input matrix `X`.
+
+The default implementation performs dimension checking and falls back to [`_pdf`](@ref).
 """
-function pdf(d::MatrixDistribution, x::AbstractMatrix{T}) where T<:Real
+function pdf(d::MatrixDistribution, x::AbstractMatrix)
     size(x) == size(d) ||
         throw(DimensionMismatch("Inconsistent array dimensions."))
     _pdf(d, x)
 end
-
-function _logpdf!(r::AbstractArray, d::MatrixDistribution, X::AbstractArray{M}) where M<:Matrix
-    for i = 1:length(X)
-        r[i] = logpdf(d, X[i])
-    end
-    return r
-end
-
-function _pdf!(r::AbstractArray, d::MatrixDistribution, X::AbstractArray{M}) where M<:Matrix
-    for i = 1:length(X)
-        r[i] = pdf(d, X[i])
-    end
-    return r
-end
-
-function logpdf!(r::AbstractArray, d::MatrixDistribution, X::AbstractArray{M}) where M<:Matrix
-    length(X) == length(r) ||
-        throw(DimensionMismatch("Inconsistent array dimensions."))
-    _logpdf!(r, d, X)
-end
-
-function pdf!(r::AbstractArray, d::MatrixDistribution, X::AbstractArray{M}) where M<:Matrix
-    length(X) == length(r) ||
-        throw(DimensionMismatch("Inconsistent array dimensions."))
-    _pdf!(r, d, X)
-end
-
-function logpdf(d::MatrixDistribution, X::AbstractArray{<:AbstractMatrix{<:Real}})
-    map(Base.Fix1(logpdf, d), X)
-end
-
-function pdf(d::MatrixDistribution, X::AbstractArray{<:AbstractMatrix{<:Real}})
-    map(Base.Fix1(pdf, d), X)
-end
-
-"""
-    _logpdf(d::MatrixDistribution, x::AbstractArray)
-
-Evaluate logarithm of pdf value for a given sample `x`. This function need not perform dimension checking.
-"""
-_logpdf(d::MatrixDistribution, x::AbstractArray)
 
 """
     loglikelihood(d::MatrixDistribution, x::AbstractArray)

--- a/src/multivariate/mvnormalcanon.jl
+++ b/src/multivariate/mvnormalcanon.jl
@@ -167,9 +167,7 @@ logdetcov(d::MvNormalCanon) = -logdet(d.J)
 
 ### Evaluation
 
-sqmahal(d::MvNormalCanon, x::AbstractVector) = quad(d.J, broadcast(-, x, d.μ))
-sqmahal!(r::AbstractVector, d::MvNormalCanon, x::AbstractMatrix) = quad!(r, d.J, broadcast(-, x, d.μ))
-
+sqmahal(d::MvNormalCanon, x::AbstractVector) = quad(d.J, x .- d.μ)
 
 # Sampling (for GenericMvNormal)
 

--- a/src/multivariate/mvtdist.jl
+++ b/src/multivariate/mvtdist.jl
@@ -115,13 +115,6 @@ insupport(d::AbstractMvTDist, x::AbstractVector{T}) where {T<:Real} =
 
 sqmahal(d::GenericMvTDist, x::AbstractVector{<:Real}) = invquad(d.Σ, x - d.μ)
 
-function sqmahal!(r::AbstractArray, d::GenericMvTDist, x::AbstractMatrix{<:Real})
-    invquad!(r, d.Σ, x .- d.μ)
-end
-
-sqmahal(d::AbstractMvTDist, x::AbstractMatrix{T}) where {T<:Real} = sqmahal!(Vector{T}(undef, size(x, 2)), d, x)
-
-
 function mvtdist_consts(d::AbstractMvTDist)
     hdf = 0.5 * d.df
     hdim = 0.5 * d.dim
@@ -130,21 +123,10 @@ function mvtdist_consts(d::AbstractMvTDist)
     return (shdfhdim, v)
 end
 
-function _logpdf(d::AbstractMvTDist, x::AbstractVector{T}) where T<:Real
+function _logpdf(d::AbstractMvTDist, x::AbstractVector)
     shdfhdim, v = mvtdist_consts(d)
     v - shdfhdim * log1p(sqmahal(d, x) / d.df)
 end
-
-function _logpdf!(r::AbstractArray, d::AbstractMvTDist, x::AbstractMatrix)
-    sqmahal!(r, d, x)
-    shdfhdim, v = mvtdist_consts(d)
-    for i = 1:size(x, 2)
-        r[i] = v - shdfhdim * log1p(r[i] / d.df)
-    end
-    return r
-end
-
-_pdf!(r::AbstractArray, d::AbstractMvTDist, x::AbstractMatrix{T}) where {T<:Real} = exp!(_logpdf!(r, d, x))
 
 function gradlogpdf(d::GenericMvTDist, x::AbstractVector{<:Real})
     z = x - d.μ

--- a/src/multivariates.jl
+++ b/src/multivariates.jl
@@ -230,15 +230,13 @@ end
 function logpdf(d::MultivariateDistribution, X::AbstractMatrix)
     size(X, 1) == length(d) ||
         throw(DimensionMismatch("Inconsistent array dimensions."))
-    T = promote_type(partype(d), eltype(X))
-    _logpdf!(Vector{T}(undef, size(X,2)), d, X)
+    map(i -> _logpdf(d, view(X, :, i)), axes(X, 2))
 end
 
 function pdf(d::MultivariateDistribution, X::AbstractMatrix)
     size(X, 1) == length(d) ||
         throw(DimensionMismatch("Inconsistent array dimensions."))
-    T = promote_type(partype(d), eltype(X))
-    _pdf!(Vector{T}(undef, size(X,2)), d, X)
+    map(i -> _pdf(d, view(X, :, i)), axes(X, 2))
 end
 
 """

--- a/src/multivariates.jl
+++ b/src/multivariates.jl
@@ -163,89 +163,49 @@ end
 # pdf and logpdf
 
 """
-    pdf(d::MultivariateDistribution, x::AbstractArray)
+    _logpdf(d::MultivariateDistribution, x::AbstractVector)
+
+Return the logarithm of the probability density of distribution `d` evaluated at `x`.
+
+This function does not need to perform dimension checking.
+"""
+_logpdf(d::MultivariateDistribution, x::AbstractVector)
+
+"""
+    _pdf(d::MultivariateDistribution, x::AbstractVector)
 
 Return the probability density of distribution `d` evaluated at `x`.
 
-- If `x` is a vector, it returns the result as a scalar.
-- If `x` is a matrix with n columns, it returns a vector `r` of length n, where `r[i]` corresponds
-to `x[:,i]` (i.e. treating each column as a sample).
-
-`pdf!(r, d, x)` will write the results to a pre-allocated array `r`.
+This function does not need to perform dimension checking. , this method falls
+back to [`_logpdf`](@ref) and does not need to be implemented.
 """
-pdf(d::MultivariateDistribution, x::AbstractArray)
-
-"""
-    logpdf(d::MultivariateDistribution, x::AbstractArray)
-
-Return the logarithm of probability density evaluated at `x`.
-
-- If `x` is a vector, it returns the result as a scalar.
-- If `x` is a matrix with n columns, it returns a vector `r` of length n, where `r[i]` corresponds to `x[:,i]`.
-
-`logpdf!(r, d, x)` will write the results to a pre-allocated array `r`.
-"""
-logpdf(d::MultivariateDistribution, x::AbstractArray)
-
 _pdf(d::MultivariateDistribution, X::AbstractVector) = exp(_logpdf(d, X))
 
+"""
+    logpdf(d::MultivariateDistribution, x::AbstractVector)
+
+Return the logarithm of the probability density of distribution `d` evaluated at `x`.
+
+The default implementation performs dimension checking and falls back to [`_logpdf`](@ref).
+"""
 function logpdf(d::MultivariateDistribution, X::AbstractVector)
     length(X) == length(d) ||
         throw(DimensionMismatch("Inconsistent array dimensions."))
     _logpdf(d, X)
 end
 
+"""
+    pdf(d::MultivariateDistribution, x::AbstractVector)
+
+Return the probability density of distribution `d` evaluated at `x`.
+
+The default implementation performs dimension checking and falls back to [`_pdf`](@ref).
+"""
 function pdf(d::MultivariateDistribution, X::AbstractVector)
     length(X) == length(d) ||
         throw(DimensionMismatch("Inconsistent array dimensions."))
     _pdf(d, X)
 end
-
-function _logpdf!(r::AbstractArray, d::MultivariateDistribution, X::AbstractMatrix)
-    for i in 1 : size(X,2)
-        @inbounds r[i] = logpdf(d, view(X,:,i))
-    end
-    return r
-end
-
-function _pdf!(r::AbstractArray, d::MultivariateDistribution, X::AbstractMatrix)
-    for i in 1 : size(X,2)
-        @inbounds r[i] = pdf(d, view(X,:,i))
-    end
-    return r
-end
-
-function logpdf!(r::AbstractArray, d::MultivariateDistribution, X::AbstractMatrix)
-    size(X) == (length(d), length(r)) ||
-        throw(DimensionMismatch("Inconsistent array dimensions."))
-    _logpdf!(r, d, X)
-end
-
-function pdf!(r::AbstractArray, d::MultivariateDistribution, X::AbstractMatrix)
-    size(X) == (length(d), length(r)) ||
-        throw(DimensionMismatch("Inconsistent array dimensions."))
-    _pdf!(r, d, X)
-end
-
-function logpdf(d::MultivariateDistribution, X::AbstractMatrix)
-    size(X, 1) == length(d) ||
-        throw(DimensionMismatch("Inconsistent array dimensions."))
-    map(i -> _logpdf(d, view(X, :, i)), axes(X, 2))
-end
-
-function pdf(d::MultivariateDistribution, X::AbstractMatrix)
-    size(X, 1) == length(d) ||
-        throw(DimensionMismatch("Inconsistent array dimensions."))
-    map(i -> _pdf(d, view(X, :, i)), axes(X, 2))
-end
-
-"""
-    _logpdf{T<:Real}(d::MultivariateDistribution, x::AbstractArray)
-
-Evaluate logarithm of pdf value for a given vector `x`. This function need not perform dimension checking.
-Generally, one does not need to implement `pdf` (or `_pdf`) as fallback methods are provided in `src/multivariates.jl`.
-"""
-_logpdf(d::MultivariateDistribution, x::AbstractArray)
 
 """
     loglikelihood(d::MultivariateDistribution, x::AbstractArray)

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -77,7 +77,6 @@ function test_mvnormal(g::AbstractMvNormal, n_tsamples::Int=10^6,
     for i = 1:min(100, n_tsamples)
         @test sqmahal(g, X[:,i]) ≈ sqm[i]
     end
-    @test sqmahal(g, X) ≈ sqm
 
     lp = -0.5 .* sqm .- 0.5 * (d * log(2.0 * pi) + ldcov)
     for i = 1:min(100, n_tsamples)


### PR DESCRIPTION
This PR removes the pre-allocation of output arrays for `logpdf` and `pdf`.

There seems little reason to fall back to the in-place methods since it does neither reduce allocations nor lines of code. Instead, I'd argue that the pre-allocation causes problems since the computation of the output type is only a heuristic and it seems easy to come up with examples where it fails since typically `logpdf` and `pdf` do not ensure that their output is of this specific type. Additionally, the pre-allocations lead to calls of mutating functions which break AD with e.g. Zygote. Moreover, it is consistent with `logpdf` and `pdf` implementations for univariate distributions that do not fall back to the mutating functions but use broadcasting (one could use the same implementation with `map` and `Base.Fix1` there as well) - however, it seems a bit strange that the use of `(log)pdf` with arrays is deprecated for univariate distributions but not for multi- and matrixvariate distributions.