### PR TITLE
Fix sampling from distributions with integer-valued parameters (e.g. `MvNormal` and `Dirichlet`)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.24.11"
+version = "0.24.12"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/matrixvariates.jl
+++ b/src/matrixvariates.jl
@@ -130,10 +130,14 @@ end
 # multiple matrix-variates, must allocate array of arrays
 rand(rng::AbstractRNG, s::Sampleable{Matrixvariate}, dims::Dims) =
     rand!(rng, s, Array{Matrix{eltype(s)}}(undef, dims), true)
+rand(rng::AbstractRNG, s::Sampleable{Matrixvariate,Continuous}, dims::Dims) =
+    rand!(rng, s, Array{Matrix{float(eltype(s))}}(undef, dims), true)
 
 # single matrix-variate, must allocate one matrix
 rand(rng::AbstractRNG, s::Sampleable{Matrixvariate}) =
     _rand!(rng, s, Matrix{eltype(s)}(undef, size(s)))
+rand(rng::AbstractRNG, s::Sampleable{Matrixvariate,Continuous}) =
+    _rand!(rng, s, Matrix{float(eltype(s))}(undef, size(s)))
 
 # single matrix-variate with pre-allocated matrix
 function rand!(rng::AbstractRNG, s::Sampleable{Matrixvariate},

--- a/src/multivariate/dirichlet.jl
+++ b/src/multivariate/dirichlet.jl
@@ -46,7 +46,7 @@ end
 
 length(d::DirichletCanon) = length(d.alpha)
 
-Base.eltype(::Type{<:Dirichlet{T}}) where {T} = T
+Base.eltype(::Type{<:Dirichlet{T}}) where {T} = float(T)
 
 #### Conversions
 convert(::Type{Dirichlet{T}}, cf::DirichletCanon) where {T<:Real} =

--- a/src/multivariate/dirichlet.jl
+++ b/src/multivariate/dirichlet.jl
@@ -46,7 +46,7 @@ end
 
 length(d::DirichletCanon) = length(d.alpha)
 
-Base.eltype(::Type{<:Dirichlet{T}}) where {T} = float(T)
+Base.eltype(::Type{<:Dirichlet{T}}) where {T} = T
 
 #### Conversions
 convert(::Type{Dirichlet{T}}, cf::DirichletCanon) where {T<:Real} =

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -278,7 +278,7 @@ _rand!(rng::AbstractRNG, d::MvNormal, x::VecOrMat) =
 # Workaround: randn! only works for Array, but not generally for AbstractArray
 function _rand!(rng::AbstractRNG, d::MvNormal, x::AbstractVector)
     for i in eachindex(x)
-        @inbounds x[i] = randn(rng,eltype(d))
+        @inbounds x[i] = randn(rng, eltype(x))
     end
     add!(unwhiten!(d.Σ, x), d.μ)
 end

--- a/src/multivariates.jl
+++ b/src/multivariates.jl
@@ -69,12 +69,18 @@ end
 rand(s::Sampleable{Multivariate}, n::Int) = rand(GLOBAL_RNG, s, n)
 rand(rng::AbstractRNG, s::Sampleable{Multivariate}, n::Int) =
     _rand!(rng, s, Matrix{eltype(s)}(undef, length(s), n))
+rand(rng::AbstractRNG, s::Sampleable{Multivariate,Continuous}, n::Int) =
+    _rand!(rng, s, Matrix{float(eltype(s))}(undef, length(s), n))
 rand(rng::AbstractRNG, s::Sampleable{Multivariate}, dims::Dims) =
-    rand(rng, s, Array{Vector{eltype(s)}}(undef, dims), true)
+    rand!(rng, s, Array{Vector{eltype(s)}}(undef, dims), true)
+rand(rng::AbstractRNG, s::Sampleable{Multivariate,Continuous}, dims::Dims) =
+    rand!(rng, s, Array{Vector{float(eltype(s))}}(undef, dims), true)
 
 # single multivariate, must allocate vector
 rand(rng::AbstractRNG, s::Sampleable{Multivariate}) =
     _rand!(rng, s, Vector{eltype(s)}(undef, length(s)))
+rand(rng::AbstractRNG, s::Sampleable{Multivariate,Continuous}) =
+    _rand!(rng, s, Vector{float(eltype(s))}(undef, length(s)))
 
 ## domain
 

--- a/src/univariate/continuous/normal.jl
+++ b/src/univariate/continuous/normal.jl
@@ -240,7 +240,7 @@ cf(d::Normal, t::Real) = exp(im * t * d.μ - d.σ^2 / 2 * t^2)
 
 #### Sampling
 
-rand(rng::AbstractRNG, d::Normal{T}) where {T} = d.μ + d.σ * randn(rng, T)
+rand(rng::AbstractRNG, d::Normal{T}) where {T} = d.μ + d.σ * randn(rng, float(T))
 
 #### Fitting
 

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -157,6 +157,8 @@ end
 # multiple univariate, must allocate array
 rand(rng::AbstractRNG, s::Sampleable{Univariate}, dims::Dims) =
     rand!(rng, sampler(s), Array{eltype(s)}(undef, dims))
+rand(rng::AbstractRNG, s::Sampleable{Univariate,Continuous}, dims::Dims) =
+    rand!(rng, sampler(s), Array{float(eltype(s))}(undef, dims))
 
 # multiple univariate with pre-allocated array
 function rand!(rng::AbstractRNG, s::Sampleable{Univariate}, A::AbstractArray)

--- a/test/dirichlet.jl
+++ b/test/dirichlet.jl
@@ -16,7 +16,7 @@ rng = MersenneTwister(123)
         d = Dirichlet(3, T(2))
 
         @test length(d) == 3
-        @test eltype(d) === Float64
+        @test eltype(d) === T
         @test d.alpha == [2, 2, 2]
         @test d.alpha0 == 6
 
@@ -46,7 +46,7 @@ rng = MersenneTwister(123)
         v = [2, 1, 3]
         d = Dirichlet(T.(v))
 
-        @test eltype(d) === Float64
+        @test eltype(d) === T
         @test Dirichlet([2, 1, 3]).alpha == d.alpha
 
         @test length(d) == length(v)

--- a/test/dirichlet.jl
+++ b/test/dirichlet.jl
@@ -12,100 +12,104 @@ rng = MersenneTwister(123)
     Dict("rand(...)" => [rand, rand],
          "rand(rng, ...)" => [dist -> rand(rng, dist), (dist, n) -> rand(rng, dist, n)])
 
-d = Dirichlet(3, 2.0)
+    for T in (Int, Float64)
+        d = Dirichlet(3, T(2))
 
-@test length(d) == 3
-@test d.alpha == [2.0, 2.0, 2.0]
-@test d.alpha0 == 6.0
+        @test length(d) == 3
+        @test eltype(d) === Float64
+        @test d.alpha == [2, 2, 2]
+        @test d.alpha0 == 6
 
-@test mean(d) ≈ fill(1.0/3, 3)
-@test cov(d)  ≈ [8 -4 -4; -4 8 -4; -4 -4 8] / (36 * 7)
-@test var(d)  ≈ diag(cov(d))
+        @test mean(d) ≈ fill(1/3, 3)
+        @test cov(d)  ≈ [8 -4 -4; -4 8 -4; -4 -4 8] / (36 * 7)
+        @test var(d)  ≈ diag(cov(d))
 
-@test pdf(Dirichlet([1, 1]), [0, 1]) ≈ 1.0
-@test pdf(Dirichlet([1f0, 1f0]), [0f0, 1f0]) ≈ 1.0f0
-@test typeof(pdf(Dirichlet([1f0, 1f0]), [0f0, 1f0])) == Float32
+        @test pdf(Dirichlet([1, 1]), [0, 1]) ≈ 1
+        @test pdf(Dirichlet([1f0, 1f0]), [0f0, 1f0]) ≈ 1
+        @test typeof(pdf(Dirichlet([1f0, 1f0]), [0f0, 1f0])) === Float32
 
-@test pdf(d, [-1, 1, 0])         ≈ 0.0
-@test pdf(d, [0, 0, 1])          ≈ 0.0
-@test pdf(d, [0.2, 0.3, 0.5])    ≈ 3.6
-@test pdf(d, [0.4, 0.5, 0.1])    ≈ 2.4
-@test logpdf(d, [0.2, 0.3, 0.5]) ≈ log(3.6)
-@test logpdf(d, [0.4, 0.5, 0.1]) ≈ log(2.4)
+        @test iszero(pdf(d, [-1, 1, 0]))
+        @test iszero(pdf(d, [0, 0, 1]))
+        @test pdf(d, [0.2, 0.3, 0.5]) ≈ 3.6
+        @test pdf(d, [0.4, 0.5, 0.1]) ≈ 2.4
+        @test logpdf(d, [0.2, 0.3, 0.5]) ≈ log(3.6)
+        @test logpdf(d, [0.4, 0.5, 0.1]) ≈ log(2.4)
 
-x = func[2](d, 100)
-p = pdf(d, x)
-lp = logpdf(d, x)
-for i in 1 : size(x, 2)
-    @test lp[i] ≈ logpdf(d, x[:,i])
-    @test p[i]  ≈ pdf(d, x[:,i])
-end
+        x = func[2](d, 100)
+        p = pdf(d, x)
+        lp = logpdf(d, x)
+        for i in 1 : size(x, 2)
+            @test lp[i] ≈ logpdf(d, x[:,i])
+            @test p[i]  ≈ pdf(d, x[:,i])
+        end
 
-v = [2.0, 1.0, 3.0]
-d = Dirichlet(v)
+        v = [2, 1, 3]
+        d = Dirichlet(T.(v))
 
-@test Dirichlet([2, 1, 3]).alpha == d.alpha
+        @test eltype(d) === Float64
+        @test Dirichlet([2, 1, 3]).alpha == d.alpha
 
-@test length(d) == length(v)
-@test d.alpha == v
-@test d.alpha0 == sum(v)
-@test d == Dirichlet{eltype(d)}(params(d)...)
-@test d == deepcopy(d)
+        @test length(d) == length(v)
+        @test d.alpha == v
+        @test d.alpha0 == sum(v)
+        @test d == Dirichlet{T}(params(d)...)
+        @test d == deepcopy(d)
 
-@test mean(d) ≈ v / sum(v)
-@test cov(d)  ≈ [8 -2 -6; -2 5 -3; -6 -3 9] / (36 * 7)
-@test var(d)  ≈ diag(cov(d))
+        @test mean(d) ≈ v / sum(v)
+        @test cov(d)  ≈ [8 -2 -6; -2 5 -3; -6 -3 9] / (36 * 7)
+        @test var(d)  ≈ diag(cov(d))
 
-@test pdf(d, [0.2, 0.3, 0.5])    ≈ 3.0
-@test pdf(d, [0.4, 0.5, 0.1])    ≈ 0.24
-@test logpdf(d, [0.2, 0.3, 0.5]) ≈ log(3.0)
-@test logpdf(d, [0.4, 0.5, 0.1]) ≈ log(0.24)
+        @test pdf(d, [0.2, 0.3, 0.5]) ≈ 3
+        @test pdf(d, [0.4, 0.5, 0.1]) ≈ 0.24
+        @test logpdf(d, [0.2, 0.3, 0.5]) ≈ log(3)
+        @test logpdf(d, [0.4, 0.5, 0.1]) ≈ log(0.24)
 
-x = func[2](d, 100)
-p = pdf(d, x)
-lp = logpdf(d, x)
-for i in 1 : size(x, 2)
-    @test p[i]  ≈ pdf(d, x[:,i])
-    @test lp[i] ≈ logpdf(d, x[:,i])
-end
+        x = func[2](d, 100)
+        p = pdf(d, x)
+        lp = logpdf(d, x)
+        for i in 1 : size(x, 2)
+            @test p[i]  ≈ pdf(d, x[:,i])
+            @test lp[i] ≈ logpdf(d, x[:,i])
+        end
 
-# Sampling
+        # Sampling
 
-x = func[1](d)
-@test isa(x, Vector{Float64})
-@test length(x) == 3
+        x = func[1](d)
+        @test isa(x, Vector{Float64})
+        @test length(x) == 3
 
-x = func[2](d, 10)
-@test isa(x, Matrix{Float64})
-@test size(x) == (3, 10)
+        x = func[2](d, 10)
+        @test isa(x, Matrix{Float64})
+        @test size(x) == (3, 10)
 
-v = [2.0, 1.0, 3.0]
-d = Dirichlet(Float32.(v))
+        v = [2, 1, 3]
+        d = Dirichlet(Float32.(v))
+        @test eltype(d) === Float32
 
-x = func[1](d)
-@test isa(x, Vector{Float32})
-@test length(x) == 3
+        x = func[1](d)
+        @test isa(x, Vector{Float32})
+        @test length(x) == 3
 
-x = func[2](d, 10)
-@test isa(x, Matrix{Float32})
-@test size(x) == (3, 10)
+        x = func[2](d, 10)
+        @test isa(x, Matrix{Float32})
+        @test size(x) == (3, 10)
 
 
-# Test MLE
+        # Test MLE
 
-v = [2.0, 1.0, 3.0]
-d = Dirichlet(v)
+        v = [2, 1, 3]
+        d = Dirichlet(v)
 
-n = 10000
-x = func[2](d, n)
-x = x ./ sum(x, dims=1)
+        n = 10000
+        x = func[2](d, n)
+        x = x ./ sum(x, dims=1)
 
-r = fit_mle(Dirichlet, x)
-@test isapprox(r.alpha, d.alpha, atol=0.25)
-r = fit(Dirichlet{Float32}, x)
-@test isapprox(r.alpha, d.alpha, atol=0.25)
+        r = fit_mle(Dirichlet, x)
+        @test r.alpha ≈ d.alpha atol=0.25
+        r = fit(Dirichlet{Float32}, x)
+        @test r.alpha ≈ d.alpha atol=0.25
 
-# r = fit_mle(Dirichlet, x, fill(2.0, n))
-# @test isapprox(r.alpha, d.alpha, atol=0.25)
-
+        # r = fit_mle(Dirichlet, x, fill(2.0, n))
+        # @test r.alpha ≈ d.alpha atol=0.25
+    end
 end

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -347,3 +347,10 @@ end
         @test_throws DimensionMismatch dot(o3, d4)
     end
 end
+
+@testset "MvNormal: Sampling with integer-valued parameters (#1004)" begin
+    d = MvNormal([0, 0], [1, 1])
+    @test rand(d) isa Vector{Float64}
+    @test rand(d, 10) isa Matrix{Float64}
+    @test rand(d, (3, 2)) isa Matrix{Vector{Float64}}
+end

--- a/test/normal.jl
+++ b/test/normal.jl
@@ -159,3 +159,10 @@ end
     @test isnan_type(Float32, @inferred(cquantile(Normal(1.0f0, 0.0f0), NaN32)))
     @test @inferred(cquantile(Normal(1//1, 0//1), 1//2))    ===  1.0
 end
+
+@testset "Normal: Sampling with integer-valued parameters" begin
+    d = Normal{Int}(0, 1)
+    @test rand(d) isa Float64
+    @test rand(d, 10) isa Vector{Float64}
+    @test rand(d, (3, 2)) isa Matrix{Float64}
+end


### PR DESCRIPTION
This PR fixes and tests sampling from `Dirichlet` with integer-valued parameters which is broken in 0.24.11 and not tested currently:
```julia
julia> rand(Dirichlet(3, 4))
ERROR: InexactError: Int64(2.581230906529874)
Stacktrace:
 [1] Int64 at ./float.jl:710 [inlined]
 [2] convert at ./number.jl:7 [inlined]
 [3] setindex! at ./array.jl:847 [inlined]
 [4] rand!(::Random._GLOBAL_RNG, ::Gamma{Float64}, ::Array{Int64,1}) at /home/david/.julia/packages/Distributions/KDTM8/src/univariates.jl:165
 [5] _rand!(::Random._GLOBAL_RNG, ::Dirichlet{Int64,FillArrays.Fill{Int64,1,Tuple{Base.OneTo{Int64}}},Float64}, ::Array{Int64,1}) at /home/david/.julia/packages/Distributions/KDTM8/src/multivariate/dirichlet.jl:162
 [6] rand at /home/david/.julia/packages/Distributions/KDTM8/src/multivariates.jl:76 [inlined]
 [7] rand(::Dirichlet{Int64,FillArrays.Fill{Int64,1,Tuple{Base.OneTo{Int64}}},Float64}) at /home/david/.julia/packages/Distributions/KDTM8/src/genericrand.jl:22
 [8] top-level scope at REPL[4]:1
```

IMO the main underlying problem is that `rand` falls back to the in-place method `rand!` and uses a heuristic to determine the type of the samples. This problem seems similar to the one described (and fixed) for `(log)pdf` in https://github.com/JuliaStats/Distributions.jl/pull/1257. However, I did not want to make any major to Distributions in this PR and therefore it is just a fix for the problem with `Dirichlet`.

*Edit:* This PR also fixes #1004 and similar issues for other distributions by using containers with floating point numbers for sampling from continuous distributions in the default implementation of `rand`. E.g, the PR fixes the following example as well:
```julia
julia> d = MvNormal([0, 0], [1, 1]);

julia> rand(d)
ERROR: MethodError: no method matching randn(::Random._GLOBAL_RNG, ::Type{Int64})
Closest candidates are:
  randn(::Random.AbstractRNG, ::Type{T}, ::Tuple{Vararg{Int64,N}} where N) where T at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Random/src/normal.jl:201
  randn(::Random.AbstractRNG, ::Type{T}, ::Integer, ::Integer...) where T at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Random/src/normal.jl:204
  randn(::Random.AbstractRNG) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Random/src/normal.jl:38
  ...
Stacktrace:
 [1] randn!(::Random._GLOBAL_RNG, ::Array{Int64,1}) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.5/Random/src/normal.jl:178
 [2] _rand! at /home/david/.julia/packages/Distributions/7Ifyw/src/multivariate/mvnormal.jl:275 [inlined]
 [3] rand at /home/david/.julia/packages/Distributions/7Ifyw/src/multivariates.jl:76 [inlined]
 [4] rand(::MvNormal{Int64,PDMats.PDiagMat{Int64,Array{Int64,1}},Array{Int64,1}}) at /home/david/.julia/packages/Distributions/7Ifyw/src/genericrand.jl:22
 [5] top-level scope at REPL[5]:1
```