### PR TITLE
No pre-allocation of outputs for `logpdf` and `pdf`

### DIFF
--- a/src/matrixvariates.jl
+++ b/src/matrixvariates.jl
@@ -197,14 +197,12 @@ function pdf!(r::AbstractArray, d::MatrixDistribution, X::AbstractArray{M}) wher
     _pdf!(r, d, X)
 end
 
-function logpdf(d::MatrixDistribution, X::AbstractArray{M}) where M<:Matrix
-    T = promote_type(partype(d), eltype(M))
-    _logpdf!(Array{T}(undef, size(X)), d, X)
+function logpdf(d::MatrixDistribution, X::AbstractArray{<:AbstractMatrix{<:Real}})
+    map(Base.Fix1(logpdf, d), X)
 end
 
-function pdf(d::MatrixDistribution, X::AbstractArray{M}) where M<:Matrix
-    T = promote_type(partype(d), eltype(M))
-    _pdf!(Array{T}(undef, size(X)), d, X)
+function pdf(d::MatrixDistribution, X::AbstractArray{<:AbstractMatrix{<:Real}})
+    map(Base.Fix1(pdf, d), X)
 end
 
 """

--- a/src/multivariates.jl
+++ b/src/multivariates.jl
@@ -230,15 +230,13 @@ end
 function logpdf(d::MultivariateDistribution, X::AbstractMatrix)
     size(X, 1) == length(d) ||
         throw(DimensionMismatch("Inconsistent array dimensions."))
-    T = promote_type(partype(d), eltype(X))
-    _logpdf!(Vector{T}(undef, size(X,2)), d, X)
+    map(i -> _logpdf(d, view(X, :, i)), axes(X, 2))
 end
 
 function pdf(d::MultivariateDistribution, X::AbstractMatrix)
     size(X, 1) == length(d) ||
         throw(DimensionMismatch("Inconsistent array dimensions."))
-    T = promote_type(partype(d), eltype(X))
-    _pdf!(Vector{T}(undef, size(X,2)), d, X)
+    map(i -> _pdf(d, view(X, :, i)), axes(X, 2))
 end
 
 """


### PR DESCRIPTION
This PR is a rebased version of https://github.com/JuliaStats/Distributions.jl/pull/1257 without the deprecations and refactoring that were suggested by @andreasnoack in the previous PR but might require some additional discussion since it implies that some special implementations for evaluating batches of samples (e.g. for `MvNormal`) are removed.

I hope that the subset of changes in this PR are potentially less controversial and hence can be merged faster.

Copied from the original PR:
This PR removes the pre-allocation of output arrays for logpdf and pdf.

There seems little reason to fall back to the in-place methods since it does neither reduce allocations nor lines of code. Instead, I'd argue that the pre-allocation causes problems since the computation of the output type is only a heuristic and it seems easy to come up with examples where it fails since typically logpdf and pdf do not ensure that their output is of this specific type. Additionally, the pre-allocations lead to calls of mutating functions which break AD with e.g. Zygote. Moreover, it is consistent with logpdf and pdf implementations for univariate distributions that do not fall back to the mutating functions but use broadcasting (one could use the same implementation with map and Base.Fix1 there as well).