### PR TITLE
Vectorize rand on uniform distribution for increased performance

### DIFF
--- a/src/univariate/continuous/uniform.jl
+++ b/src/univariate/continuous/uniform.jl
@@ -109,8 +109,7 @@ end
 
 #### Sampling
 
-rand(rng::AbstractRNG, d::Uniform) = d.a + (d.b - d.a) * rand(rng)
-
+rand(rng::AbstractRNG, d::Uniform, dims::Dims) = d.a .+ (d.b - d.a) .* rand(rng, Float64, Dims(dims))
 
 #### Fitting
 


### PR DESCRIPTION
Hello, I noticed this anomaly earlier:
```
julia> @time x = rand(123456);
  0.000244 seconds (2 allocations: 964.578 KiB)

julia> @time x = rand(Distributions.Uniform(1,3), 123456);
  0.001117 seconds (2 allocations: 964.578 KiB)

julia> @time x = 1 .+ (3 - 1) .* rand(123456);
  0.000642 seconds (4 allocations: 1.884 MiB)

julia> @time begin x = rand(123456); x .= 1 .+ (3 - 1) .* x end;
  0.000361 seconds (6 allocations: 964.703 KiB)

julia> @time begin x = (rand(123456) .*= (3 - 1)) .+= 1 end;
  0.000521 seconds (2 allocations: 964.578 KiB)
```

Exact times elapsed are a bit variable, but the order of time elapsed is almost always the following: 2 > 3 > 5 > 4 > 1.

Generally, calling `rand` on `Distributions.Uniform` for a moderate amount of multiple values seems to be around 3x slower than it needs to be.

It is because https://github.com/JuliaStats/Distributions.jl/blob/master/src/univariate/continuous/uniform.jl#L112 is not vectorized in an efficient way.

This small fix results in the following more consistent performance:

```
julia> @time x = rand(123456);
  0.000256 seconds (2 allocations: 964.578 KiB)

julia> @time x = rand(Distributions.Uniform(1,3), 123456);
  0.000266 seconds (2 allocations: 964.578 KiB)
```

Unvectorized performance is generally unaffected:

Old implementation:
```
julia> @time (rand(Distributions.Uniform(1,3)) for i in 1:123456);
  0.003321 seconds (2.11 k allocations: 131.140 KiB)
```

This modified implementation:
```
julia> @time (rand(Distributions.Uniform(1,3)) for i in 1:123456);
  0.003437 seconds (2.11 k allocations: 131.140 KiB)
```
