### PR TITLE
Add vectorized rand! for uniform distribution

### DIFF
--- a/src/univariate/continuous/uniform.jl
+++ b/src/univariate/continuous/uniform.jl
@@ -111,6 +111,9 @@ end
 
 rand(rng::AbstractRNG, d::Uniform) = d.a + (d.b - d.a) * rand(rng)
 
+rand!(rng::AbstractRNG, d::Uniform, A::AbstractArray) =
+    A .= quantile.(d, rand!(rng, A))
+
 
 #### Fitting
 


### PR DESCRIPTION
If this is merged, performance for moderately sized calls to rand!() and rand() for a Uniform distribution will be roughly 3x faster (in Julia v1.5.3) than the generic fallback, defined in https://github.com/JuliaStats/Distributions.jl/blob/863844c88e4153af13996f571fcc612d159de542/src/univariates.jl#L163

Current performance:

```julia
julia> @time x = rand(123456);
  0.000244 seconds (2 allocations: 964.578 KiB)

julia> @time x = rand(Distributions.Uniform(1,3), 123456);
  0.001117 seconds (2 allocations: 964.578 KiB)

julia> @time begin x = Vector{Float64}(undef, 123456); Random.rand!(x) end;
  0.000246 seconds (2 allocations: 964.578 KiB)

julia> @time begin x = Vector{Float64}(undef, 123456); Random.rand!(Distributions.Uniform(1,3), x) end;
  0.001160 seconds (2 allocations: 964.578 KiB)
```

Performance if this is merged:

```julia
julia> @time x = rand(123456);
  0.000256 seconds (2 allocations: 964.578 KiB)

julia> @time x = rand(Distributions.Uniform(1,3), 123456);
  0.000266 seconds (2 allocations: 964.578 KiB)

julia> @time begin x = Vector{Float64}(undef, 123456); Random.rand!(x) end;
  0.000249 seconds (2 allocations: 964.578 KiB)

julia> @time begin x = Vector{Float64}(undef, 123456); Random.rand!(Distributions.Uniform(1,3), x) end;
  0.000261 seconds (2 allocations: 964.578 KiB)
```
