### PR TITLE
Reduce code duplication in randnt and marginally improve compiler performance.

### DIFF
--- a/src/truncated/normal.jl
+++ b/src/truncated/normal.jl
@@ -165,37 +165,44 @@ function randnt(rng::AbstractRNG, lb::Float64, ub::Float64, tp::Float64)
         return r
 
     else
+        # cb and fb (close and far bounds) extend lb and ub to be sign-agnostic.
+        @inline function _check_helper(cb::Float64, span::Float64)
+            return cb > 0 && span > 2.0 / (cb + sqrt(cb^2 + 4.0)) * exp((cb^2 - cb * sqrt(cb^2 + 4.0)) / 4.0)
+        end
+
         span = ub - lb
-        if lb > 0 && span > 2.0 / (lb + sqrt(lb^2 + 4.0)) * exp((lb^2 - lb * sqrt(lb^2 + 4.0)) / 4.0)
-            a = (lb + sqrt(lb^2 + 4.0))/2.0
-            while true
-                r = rand(rng, Exponential(1.0 / a)) + lb
-                u = rand(rng)
-                if u < exp(-0.5 * (r - a)^2) && r < ub
-                    return r
-                end
-            end
-        elseif ub < 0 && ub - lb > 2.0 / (-ub + sqrt(ub^2 + 4.0)) * exp((ub^2 + ub * sqrt(ub^2 + 4.0)) / 4.0)
-            a = (-ub + sqrt(ub^2 + 4.0)) / 2.0
-            while true
-                r = rand(rng, Exponential(1.0 / a)) - ub
-                u = rand(rng)
-                if u < exp(-0.5 * (r - a)^2) && r < -lb
-                    return -r
-                end
-            end
+        if _check_helper(lb, span)
+            use_exponential = true
+            cb, fb = lb, ub
+        elseif _check_helper(-ub, span)
+            use_exponential = true
+            cb, fb = -ub, -lb
         else
+            use_exponential = false
+        end
+
+        if use_exponential
+            a = (cb + sqrt(cb^2 + 4.0))/2.0
+            while true
+                r = rand(rng, Exponential(1.0 / a)) + cb
+                u = rand(rng)
+                if u < exp(-0.5 * (r - a)^2) && r < fb
+                    return sign(lb) * r 
+                end
+            end
+        else # use uniform-based sampling
             while true
                 r = lb + rand(rng) * (ub - lb)
                 u = rand(rng)
                 if lb > 0
-                    rho = exp((lb^2 - r^2) * 0.5)
+                    cb = lb
                 elseif ub < 0
-                    rho = exp((ub^2 - r^2) * 0.5)
+                    cb = ub
                 else
-                    rho = exp(-r^2 * 0.5)
+                    cb = 0
                 end
-                if u < rho
+
+                if u < exp((cb^2 - r^2) * 0.5)
                     return r
                 end
             end


### PR DESCRIPTION
I noticed that there was a large amount of code duplication in `randnt` (the function called to sample from truncated normal distributions). Furthermore, the meaning of the code seems somewhat unclear when one first looks at it.

I made some changes which I believe make the relationship between the different `if` statements clearer.

I performed some testing and found this version to be around as performant as the previous implementation (possibly marginally faster), while JIT memory allocations have also been marginally reduced in quantity. It seems to me that the compiler (as of Julia v1.5.3) has a slightly easier time understanding the intent of the code for the exponential distribution sampling case of the algorithm.

Current implementation:
```
julia> # trigger exponential distribution case

julia> t = Distributions.truncated(Distributions.Normal(0,1), 10, 20)
Truncated(Main.Distributions.Normal{Float64}(μ=0.0, σ=1.0), range=(10.0, 20.0))

julia> @time rand(t, 1000);
  0.067620 seconds (156.99 k allocations: 7.762 MiB)

julia> @time rand(t, 1000);
  0.000048 seconds (1 allocation: 7.938 KiB)

julia> @time rand(t, 1000);
  0.000049 seconds (1 allocation: 7.938 KiB)

julia> @time rand(t, 1000);
  0.000049 seconds (1 allocation: 7.938 KiB)

julia> @time rand(t, 1000);
  0.000048 seconds (1 allocation: 7.938 KiB)

julia> # trigger uniform distribution case

julia> t2 = Distributions.truncated(Distributions.Normal(0,1), -.001, .001)
Truncated(Main.Distributions.Normal{Float64}(μ=0.0, σ=1.0), range=(-0.001, 0.001))

julia> @time rand(t2, 1000);
  0.000024 seconds (1 allocation: 7.938 KiB)

julia> @time rand(t2, 1000);
  0.000026 seconds (1 allocation: 7.938 KiB)

julia> @time rand(t2, 1000);
  0.000027 seconds (1 allocation: 7.938 KiB)

julia> @time rand(t2, 1000);
  0.000026 seconds (1 allocation: 7.938 KiB)
```

This proposal:
```
julia> # trigger exponential distribution case

julia> t = Distributions.truncated(Distributions.Normal(0,1), 10, 20)
Truncated(Main.Distributions.Normal{Float64}(μ=0.0, σ=1.0), range=(10.0, 20.0))

julia> @time rand(t, 1000);
  0.064036 seconds (150.70 k allocations: 7.506 MiB)

julia> @time rand(t, 1000);
  0.000049 seconds (1 allocation: 7.938 KiB)

julia> @time rand(t, 1000);
  0.000046 seconds (1 allocation: 7.938 KiB)

julia> @time rand(t, 1000);
  0.000046 seconds (1 allocation: 7.938 KiB)

julia> @time rand(t, 1000);
  0.000046 seconds (1 allocation: 7.938 KiB)

julia> # trigger uniform distribution case

julia> t2 = Distributions.truncated(Distributions.Normal(0,1), -.001, .001)
Truncated(Main.Distributions.Normal{Float64}(μ=0.0, σ=1.0), range=(-0.001, 0.001))

julia> @time rand(t2, 1000);
  0.000024 seconds (1 allocation: 7.938 KiB)

julia> @time rand(t2, 1000);
  0.000024 seconds (1 allocation: 7.938 KiB)

julia> @time rand(t2, 1000);
  0.000025 seconds (1 allocation: 7.938 KiB)

julia> @time rand(t2, 1000);
  0.000025 seconds (1 allocation: 7.938 KiB)
```