### PR TITLE
Speed up pdf, cdf, mean, and var for FisherNoncentralHypergeometric

### DIFF
--- a/src/univariate/discrete/noncentralhypergeometric.jl
+++ b/src/univariate/discrete/noncentralhypergeometric.jl
@@ -55,36 +55,164 @@ FisherNoncentralHypergeometric(ns::Integer, nf::Integer, n::Integer, ω::Integer
 convert(::Type{FisherNoncentralHypergeometric{T}}, ns::Real, nf::Real, n::Real, ω::Real) where {T<:Real} = FisherNoncentralHypergeometric(ns, nf, n, T(ω))
 convert(::Type{FisherNoncentralHypergeometric{T}}, d::FisherNoncentralHypergeometric{S}) where {T<:Real, S<:Real} = FisherNoncentralHypergeometric(d.ns, d.nf, d.n, T(d.ω))
 
-# Properties
-function _P(d::FisherNoncentralHypergeometric, k::Int)
-    y = support(d)
-    p = -log(d.ns + 1) .- logbeta.(d.ns + 1 .- y, y .+ 1) .-
-            log(d.nf + 1) .- logbeta.(d.nf - d.n + 1 .+ y, d.n + 1 .- y) .+
-            xlogy.(y, d.ω) .+ xlogy.(k, y)
-    logsumexp(p)
-end
-
 function _mode(d::FisherNoncentralHypergeometric)
     A = d.ω - 1
     B = d.n - d.nf - (d.ns + d.n + 2)*d.ω
     C = (d.ns + 1)*(d.n + 1)*d.ω
-    -2C / (B - sqrt(B^2-4A*C))
+    return -2C / (B - sqrt(B^2 - 4A*C))
 end
 
-mean(d::FisherNoncentralHypergeometric) = exp.(_P(d,1) - _P(d,0))
-var(d::FisherNoncentralHypergeometric) = exp.(_P(d,2) .- _P(d,0)) .- exp.(2 .* (_P(d,1) .- _P(d,0)))
 mode(d::FisherNoncentralHypergeometric) = floor(Int, _mode(d))
 
 testfd(d::FisherNoncentralHypergeometric) = d.ω^3
 
-function logpdf(d::FisherNoncentralHypergeometric, k::Real)
-    if insupport(d, k)
-        return -log(d.ns + 1) - logbeta(d.ns - k + 1, k + 1) -
-            log(d.nf + 1) - logbeta(d.nf - d.n + k + 1, d.n - k + 1) +
-            xlogy(k, d.ω) - _P(d, 0)
-    else
-        return log(zero(k))
+# The pdf, cdf, mean, and var functions are based on
+#
+# Liao, J. G; Rosen, Ori (2001). Fast and Stable Algorithms for Computing and Sampling From the
+# Noncentral Hypergeometric Distribution. The American Statistician, 55(4), 366–369.
+# doi:10.1198/000313001753272547
+#
+# but the rule for terminating the summation has been slightly modified.
+function pdf(d::FisherNoncentralHypergeometric, k::Integer)
+    ω, _ = promote(d.ω, float(k))
+    l = max(0, d.n - d.nf)
+    u = min(d.ns, d.n)
+    if !insupport(d, k)
+        return zero(ω)
     end
+    η = mode(d)
+    s = one(ω)
+    fᵢ = one(ω)
+    fₖ = one(ω)
+    for i in (η + 1):u
+        rᵢ = (d.ns - i + 1)*ω/(i*(d.nf - d.n  + i))*(d.n - i + 1)
+        fᵢ *= rᵢ
+
+        # break if terms no longer contribute to s
+        sfᵢ = s + fᵢ
+        if sfᵢ == s && i > k
+            break
+        end
+        s = sfᵢ
+
+        if i == k
+            fₖ = fᵢ
+        end
+    end
+    fᵢ = one(ω)
+    for i in (η - 1):-1:l
+        rᵢ₊ = (d.ns - i)*ω/((i + 1)*(d.nf - d.n  + i + 1))*(d.n - i)
+        fᵢ /= rᵢ₊
+
+        # break if terms no longer contribute to s
+        sfᵢ = s + fᵢ
+        if sfᵢ == s && i < k
+            break
+        end
+        s = sfᵢ
+
+        if i == k
+            fₖ = fᵢ
+        end
+    end
+
+    return fₖ/s
+end
+
+logpdf(d::FisherNoncentralHypergeometric, k::Integer) = log(pdf(d, k))
+
+function cdf(d::FisherNoncentralHypergeometric, k::Integer)
+    ω, _ = promote(d.ω, float(k))
+    l = max(0, d.n - d.nf)
+    u = min(d.ns, d.n)
+    if k < l
+        return zero(ω)
+    elseif k >= u
+        return one(ω)
+    end
+    η = mode(d)
+    s = one(ω)
+    fᵢ = one(ω)
+    Fₖ = k >= η ? one(ω) : zero(ω)
+    for i in (η + 1):u
+        rᵢ = (d.ns - i + 1)*ω/(i*(d.nf - d.n  + i))*(d.n - i + 1)
+        fᵢ *= rᵢ
+
+        # break if terms no longer contribute to s
+        sfᵢ = s + fᵢ
+        if sfᵢ == s && i > k
+            break
+        end
+        s = sfᵢ
+        if i <= k
+            Fₖ += fᵢ
+        end
+    end
+    fᵢ = one(ω)
+    for i in (η - 1):-1:l
+        rᵢ₊ = (d.ns - i)*ω/((i + 1)*(d.nf - d.n + i + 1))*(d.n - i)
+        fᵢ /= rᵢ₊
+
+        # break if terms no longer contribute to s
+        sfᵢ = s + fᵢ
+        if sfᵢ == s && i < k
+            break
+        end
+        s = sfᵢ
+        if i <= k
+            Fₖ += fᵢ
+        end
+    end
+
+    return Fₖ/s
+end
+
+logcdf(d::FisherNoncentralHypergeometric, k::Integer) = log(cdf(d, k))
+
+function _expectation(f, d::FisherNoncentralHypergeometric)
+    ω = float(d.ω)
+    l = max(0, d.n - d.nf)
+    u = min(d.ns, d.n)
+    η = mode(d)
+    s = one(ω)
+    m = f(η)*s
+    fᵢ = one(ω)
+    for i in (η + 1):u
+        rᵢ = (d.ns - i + 1)*ω/(i*(d.nf - d.n  + i))*(d.n - i + 1)
+        fᵢ *= rᵢ
+
+        # break if terms no longer contribute to s
+        sfᵢ = s + fᵢ
+        if sfᵢ == s
+            break
+        end
+        s = sfᵢ
+
+        m += f(i)*fᵢ
+    end
+    fᵢ = one(ω)
+    for i in (η - 1):-1:l
+        rᵢ₊ = (d.ns - i)*ω/((i + 1)*(d.nf - d.n  + i + 1))*(d.n - i)
+        fᵢ /= rᵢ₊
+
+        # break if terms no longer contribute to s
+        sfᵢ = s + fᵢ
+        if sfᵢ == s
+            break
+        end
+        s = sfᵢ
+
+        m += f(i)*fᵢ
+    end
+
+    return m/s
+end
+
+mean(d::FisherNoncentralHypergeometric) = _expectation(identity, d)
+
+function var(d::FisherNoncentralHypergeometric)
+    μ = mean(d)
+    return _expectation(t -> (t - μ)^2, d)
 end
 
 ## Wallenius' noncentral hypergeometric distribution


### PR DESCRIPTION
 by implementing the method of Liao and Rosen. For the case in https://github.com/JuliaStats/HypothesisTests.jl/issues/224, I saw a 200k times speed up for `cdf` with this change.