### PR TITLE
Von mises range fix

### DIFF
--- a/docs/src/univariate.md
+++ b/docs/src/univariate.md
@@ -30,6 +30,7 @@ rate(::UnivariateDistribution)
 ncategories(::UnivariateDistribution)
 ntrials(::UnivariateDistribution)
 dof(::UnivariateDistribution)
+isperiodic(::UnivariateDistribution)
 ```
 
 For distributions for which success and failure have a meaning,

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -193,6 +193,7 @@ export
     isplatykurtic,      # Is excess kurtosis > 0.0?
     isleptokurtic,      # Is excess kurtosis < 0.0?
     ismesokurtic,       # Is excess kurtosis = 0.0?
+    isperiodic,         # Has a periodic pdf?
     isprobvec,          # Is a probability vector?
     isupperbounded,
     islowerbounded,

--- a/src/univariate/continuous/vonmises.jl
+++ b/src/univariate/continuous/vonmises.jl
@@ -38,6 +38,8 @@ show(io::IO, d::VonMises) = show(io, d, (:μ, :κ))
 
 @distr_support VonMises d.μ - π d.μ + π
 
+isperiodic(d::VonMises) = true
+
 #### Conversions
 
 convert(::Type{VonMises{T}}, μ::Real, κ::Real) where {T<:Real} = VonMises(T(μ), T(κ))
@@ -65,10 +67,8 @@ cf(d::VonMises, t::Real) = (besselix(abs(t), d.κ) / d.I0κx) * cis(t * d.μ)
 #### Evaluations
 
 #pdf(d::VonMises, x::Real) = exp(d.κ * (cos(x - d.μ) - 1)) / (twoπ * d.I0κx)
-pdf(d::VonMises{T}, x::Real) where T<:Real =
-    minimum(d) ≤ x ≤ maximum(d) ? exp(d.κ * (cos(x - d.μ) - 1)) / (twoπ * d.I0κx) : zero(T)
-logpdf(d::VonMises{T}, x::Real) where T<:Real =
-    minimum(d) ≤ x ≤ maximum(d) ? d.κ * (cos(x - d.μ) - 1) - log(d.I0κx) - log2π : -T(Inf)
+pdf(d::VonMises{T}, x::Real) where T<:Real = exp(d.κ * (cos(x - d.μ) - 1)) / (twoπ * d.I0κx)
+logpdf(d::VonMises{T}, x::Real) where T<:Real = d.κ * (cos(x - d.μ) - 1) - log(d.I0κx) - log2π 
 
 cdf(d::VonMises, x::Real) = _vmcdf(d.κ, d.I0κx, x - d.μ, 1e-15)
 

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -20,6 +20,8 @@ isupperbounded(d::Union{D,Type{D}}) where {D<:UnivariateDistribution} = maximum(
 hasfinitesupport(d::Union{D,Type{D}}) where {D<:DiscreteUnivariateDistribution} = isbounded(d)
 hasfinitesupport(d::Union{D,Type{D}}) where {D<:ContinuousUnivariateDistribution} = false
 
+isperiodic(d::UnivariateDistribution) = false
+
 """
     params(d::UnivariateDistribution)
 

--- a/test/univariate_bounds.jl
+++ b/test/univariate_bounds.jl
@@ -58,6 +58,7 @@ get_subtypes(x::Type) = _subtypes_in(Base.loaded_modules_array(), x)
 dists = get_subtypes(UnivariateDistribution)
 filter!(x -> hasmethod(x, ()), dists)
 filter!(x -> isbounded(x()), dists)
+filter!(x -> !isperiodic(x()), dists)
 
 @testset "bound checking $dist" for dist in dists
     d = dist()


### PR DESCRIPTION
This pull request reverts part of #965 which added bound checking to the pdf of several distributions.
This shouldn't be done for the von Mises distribution as it is designed to be periodic, repeating every 2π, so values for the pdf beyond the support of the distribution are entirely valid.

To enable the univariate_bounds tests to continue working with as few changes as possible, this also adds an `isperiodic()` method which is set to false in univariates.jl and then set to true in vonmises.jl