### PR TITLE
fix the rand!() function for the Beta distribution.

### DIFF
--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -161,8 +161,7 @@ rand(rng::AbstractRNG, s::Sampleable{Univariate,Continuous}, dims::Dims) =
     rand!(rng, sampler(s), Array{float(eltype(s))}(undef, dims))
 
 # multiple univariate with pre-allocated array
-function rand!(rng::AbstractRNG, s::Sampleable{Univariate}, A::AbstractArray)
-    smp = sampler(s)
+function rand!(rng::AbstractRNG, s::Sampleable{Univariate}, A::AbstractArray;smp=sampler(s))
     for i in eachindex(A)
         @inbounds A[i] = rand(rng, smp)
     end


### PR DESCRIPTION
For the Beta distribution, the compiler cannot infer the type of the output, so this causes unnecessary memory allocation. Defining the sampler at the argument level of the function solve the problem.