### PR TITLE
More efficient `PoissonBinomial`

### DIFF
--- a/test/poissonbinomial.jl
+++ b/test/poissonbinomial.jl
@@ -29,6 +29,7 @@ naive_sol = naive_pb(p)
 
 @test Distributions.poissonbinomial_pdf_fft(p) ≈ naive_sol
 @test Distributions.poissonbinomial_pdf(p) ≈ naive_sol
+@test Distributions.poissonbinomial_pdf(Tuple(p)) ≈ naive_sol
 
 @test Distributions.poissonbinomial_pdf_fft(p) ≈ Distributions.poissonbinomial_pdf(p)
 
@@ -46,23 +47,23 @@ for (p, n) in [(0.8, 6), (0.5, 10), (0.04, 20)]
     @test maximum(d) == n
     @test extrema(d) == (0, n)
     @test ntrials(d) == n
-    @test entropy(d)  ≈ entropy(dref)
-    @test median(d)   ≈ median(dref)
-    @test mean(d)     ≈ mean(dref)
-    @test var(d)      ≈ var(dref)
-    @test kurtosis(d) ≈ kurtosis(dref)
-    @test skewness(d) ≈ skewness(dref)
+    @test @inferred(entropy(d))  ≈ entropy(dref)
+    @test @inferred(median(d))   ≈ median(dref)
+    @test @inferred(mean(d))     ≈ mean(dref)
+    @test @inferred(var(d))      ≈ var(dref)
+    @test @inferred(kurtosis(d)) ≈ kurtosis(dref)
+    @test @inferred(skewness(d)) ≈ skewness(dref)
 
     for t=0:5
-        @test mgf(d, t) ≈ mgf(dref, t)
-        @test cf(d, t)  ≈ cf(dref, t)
+        @test @inferred(mgf(d, t)) ≈ mgf(dref, t)
+        @test @inferred(cf(d, t))  ≈ cf(dref, t)
     end
     for i=0.1:0.1:.9
-        @test quantile(d, i) ≈ quantile(dref, i)
+        @test @inferred(quantile(d, i)) ≈ quantile(dref, i)
     end
     for i=0:n
-        @test isapprox(cdf(d, i), cdf(dref, i), atol=1e-15)
-        @test isapprox(pdf(d, i), pdf(dref, i), atol=1e-15)
+        @test isapprox(@inferred(cdf(d, i)), cdf(dref, i), atol=1e-15)
+        @test isapprox(@inferred(pdf(d, i)), pdf(dref, i), atol=1e-15)
     end
 
 end
@@ -88,11 +89,11 @@ for (n₁, n₂, n₃, p₁, p₂, p₃) in [(10, 10, 10, 0.1, 0.5, 0.9),
     pmf2 = pdf.(b2, support(b2))
     pmf3 = pdf.(b3, support(b3))
 
-    @test mean(d) ≈ (mean(b1) + mean(b2) + mean(b3))
-    @test var(d)  ≈ (var(b1) + var(b2) + var(b3))
+    @test @inferred(mean(d)) ≈ (mean(b1) + mean(b2) + mean(b3))
+    @test @inferred(var(d))  ≈ (var(b1) + var(b2) + var(b3))
     for t=0:5
-        @test mgf(d, t) ≈ (mgf(b1, t) * mgf(b2, t) * mgf(b3, t))
-        @test cf(d, t)  ≈ (cf(b1, t) * cf(b2, t) * cf(b3, t))
+        @test @inferred(mgf(d, t)) ≈ (mgf(b1, t) * mgf(b2, t) * mgf(b3, t))
+        @test @inferred(cf(d, t))  ≈ (cf(b1, t) * cf(b2, t) * cf(b3, t))
     end
 
     for k=0:n
@@ -104,7 +105,7 @@ for (n₁, n₂, n₃, p₁, p₂, p₃) in [(10, 10, 10, 0.1, 0.5, 0.9),
             end
             m += pmf1[i+1] * mc
         end
-        @test isapprox(pdf(d, k), m, atol=1e-15)
+        @test isapprox(@inferred(pdf(d, k)), m, atol=1e-15)
     end
 end
 


### PR DESCRIPTION
For many computations, such as e.g. `mean` and `var`, it is not necessary to evaluate the probability mass function of `PoissonBinomial` for all possible outcomes. However, currently, it is computed when `PoissonBinomial` is constructed. For large number of trials this induces a significant delay and might even make it too inefficient to work with `PoissonBinomial` at all.

In this PR, instead the values of the probability mass function are only computed when a user performs an evaluation that requires it.

Simple benchmark on my computer:

## master

```julia
julia> using Distributions, BenchmarkTools, Random

julia> Random.seed!(1234);

julia> p = rand(100);

julia> @btime PoissonBinomial($p);
  4.993 μs (1 allocation: 896 bytes)

julia> @btime PoissonBinomial($p; check_args=false);
  4.885 μs (1 allocation: 896 bytes)

julia> @btime mean(PoissonBinomial($p));
  5.000 μs (1 allocation: 896 bytes)

julia> @btime var(PoissonBinomial($p));
  5.035 μs (3 allocations: 2.63 KiB)

julia> @btime mode(PoissonBinomial($p));
  5.239 μs (1 allocation: 896 bytes)

julia> @btime median(PoissonBinomial($p));
  5.256 μs (2 allocations: 1.75 KiB)

julia> @btime modes(PoissonBinomial($p));
  6.412 μs (50 allocations: 6.23 KiB)

julia> @btime mgf(PoissonBinomial($p), 0.1);
  5.221 μs (2 allocations: 1.75 KiB)

julia> @btime cf(PoissonBinomial($p), 0.1);
  5.380 μs (2 allocations: 2.64 KiB)

julia> @btime entropy(PoissonBinomial($p));
  5.988 μs (2 allocations: 1.75 KiB)

julia> @btime mgf($(PoissonBinomial(p)), 0.1);
  87.389 ns (1 allocation: 896 bytes)

julia> @btime cf($(PoissonBinomial(p)), 0.1);
  337.177 ns (1 allocation: 1.77 KiB)
```

## This PR

```julia
julia> using Distributions, BenchmarkTools, Random

julia> Random.seed!(1234);

julia> p = rand(100);

julia> @btime PoissonBinomial($p);
  90.943 ns (1 allocation: 32 bytes)

julia> @btime PoissonBinomial($p; check_args=false);
  5.545 ns (1 allocation: 32 bytes)

julia> @btime mean(PoissonBinomial($p));
  104.703 ns (0 allocations: 0 bytes)

julia> @btime var(PoissonBinomial($p));
  191.663 ns (0 allocations: 0 bytes)

julia> @btime mode(PoissonBinomial($p));
  5.118 μs (2 allocations: 928 bytes)

julia> @btime median(PoissonBinomial($p));
  5.004 μs (3 allocations: 1.78 KiB)

julia> @btime modes(PoissonBinomial($p));
  6.132 μs (50 allocations: 6.17 KiB)

julia> @btime mgf(PoissonBinomial($p), 0.1);
  136.762 ns (0 allocations: 0 bytes)

julia> @btime cf(PoissonBinomial($p), 0.1);
  332.973 ns (0 allocations: 0 bytes)

julia> @btime entropy(PoissonBinomial($p));
  5.617 μs (2 allocations: 928 bytes)

julia> @btime mgf($(PoissonBinomial(p)), 0.1);
  43.553 ns (0 allocations: 0 bytes)

julia> @btime cf($(PoissonBinomial(p)), 0.1);
  245.246 ns (0 allocations: 0 bytes)
```

This PR is motivated by https://github.com/TuringLang/MCMCChains.jl/pull/263: often it is sufficient to evaluate the mean and the variance (as an uncertainty measure) of the Poisson binomial distribution of the statistic of interest, and therefor the quadratic complexity of the evaluation of the probability mass function slows down the computations for large number of trials (e.g., MCMC samples in this case) unnecessarily.