### PR TITLE
fixed documentation link

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -306,7 +306,7 @@ API overview (major features):
 
 These represent just a few of the operations supported by this
 package; users are encouraged to refer to the full documentation at
-http://distributionsjl.readthedocs.org/en/latest/ for further
+https://JuliaStats.github.io/Distributions.jl/stable/ for further
 information.
 
 Supported distributions:


### PR DESCRIPTION
The link to the documentation in the docstring for Distributions.jl leads to an inactive `readthedocs` site. I updated the link to match the one in the README.