### PR TITLE
Faster sampling from `Gumbel`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.24.16"
+version = "0.24.17"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/univariate/continuous/gumbel.jl
+++ b/src/univariate/continuous/gumbel.jl
@@ -42,6 +42,8 @@ Gumbel() = Gumbel(0.0, 1.0, check_args=false)
 
 const DoubleExponential = Gumbel
 
+Base.eltype(::Type{Gumbel{T}}) where {T} = T
+
 #### Conversions
 
 convert(::Type{Gumbel{T}}, μ::S, θ::S) where {T <: Real, S <: Real} = Gumbel(T(μ), T(θ))
@@ -54,6 +56,14 @@ scale(d::Gumbel) = d.θ
 params(d::Gumbel) = (d.μ, d.θ)
 partype(::Gumbel{T}) where {T} = T
 
+function Base.rand(rng::Random.AbstractRNG, d::Gumbel)
+    return d.μ - d.θ * log(randexp(rng, float(eltype(d))))
+end
+function Random.rand!(rng::Random.AbstractRNG, d::Gumbel, x::AbstractArray)
+    randexp!(rng, x)
+    x .= d.μ .- d.θ .* log.(x)
+    return x
+end
 
 #### Statistics
 

--- a/test/gumbel.jl
+++ b/test/gumbel.jl
@@ -1,0 +1,24 @@
+@testset "Gumbel" begin
+    @testset "eltype" begin
+        @test eltype(Gumbel()) === Float64
+        @test eltype(Gumbel(1f0)) === Float32
+        @test eltype(Gumbel{Int}(0, 1)) === Int
+    end
+
+    @testset "rand" begin
+        d = Gumbel(randn(), rand())
+
+        samples = [rand(d) for _ in 1:10_000]
+        @test mean(samples) ≈ mean(d) atol=1e-2
+        @test std(samples) ≈ std(d) atol=1e-2
+
+        samples = rand(d, 10_000)
+        @test mean(samples) ≈ mean(d) atol=1e-2
+        @test std(samples) ≈ std(d) atol=1e-2
+
+        d = Gumbel{Int}(0, 1)
+        @test rand(d) isa Float64
+        @test rand(d, 10) isa Vector{Float64}
+        @test rand(d, (3, 2)) isa Matrix{Float64}
+    end
+end

--- a/test/gumbel.jl
+++ b/test/gumbel.jl
@@ -6,15 +6,15 @@
     end
 
     @testset "rand" begin
-        d = Gumbel(randn(), rand())
+        d = Gumbel(rand(), rand())
 
         samples = [rand(d) for _ in 1:10_000]
-        @test mean(samples) ≈ mean(d) atol=1e-2
-        @test std(samples) ≈ std(d) atol=1e-2
+        @test mean(samples) ≈ mean(d) rtol=5e-2
+        @test std(samples) ≈ std(d) rtol=5e-2
 
         samples = rand(d, 10_000)
-        @test mean(samples) ≈ mean(d) atol=1e-2
-        @test std(samples) ≈ std(d) atol=1e-2
+        @test mean(samples) ≈ mean(d) rtol=5e-2
+        @test std(samples) ≈ std(d) rtol=5e-2
 
         d = Gumbel{Int}(0, 1)
         @test rand(d) isa Float64

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,6 +61,7 @@ const tests = [
     "soliton",
     "skewnormal",
     "chi",
+    "gumbel",
 ]
 
 printstyled("Running tests:\n", color=:blue)


### PR DESCRIPTION
On master:
```julia
julia> using Distributions, BenchmarkTools

julia> @btime rand($(Gumbel()));
  34.065 ns (0 allocations: 0 bytes)

julia> @btime rand($(Gumbel()), 100);
  3.433 μs (1 allocation: 896 bytes)
```
With this PR:
```julia
julia> using Distributions, BenchmarkTools

julia> @btime rand($(Gumbel()));
  22.429 ns (0 allocations: 0 bytes)

julia> @btime rand($(Gumbel()), 100);
  1.655 μs (1 allocation: 896 bytes)
```