### PR TITLE
fix fit for Laplace distribution

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.24.17"
+version = "0.24.18"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/univariate/continuous/laplace.jl
+++ b/src/univariate/continuous/laplace.jl
@@ -114,36 +114,10 @@ rand(rng::AbstractRNG, d::Laplace) =
 
 #### Fitting
 
-function fit_mle(::Type{<:Laplace}, x::AbstractArray{T}) where {T<:Real}
-    μ = median(x)
-    θ = zero(T)
-    for v ∈ x
-        θ += abs(v - μ)
-    end
-    θ /= length(x)
-    return Laplace(μ, θ)
-end
-
-function fit_mle(::Type{<:Laplace}, x::AbstractArray{T}, w::AbstractArray{T}) where {T <: Real}
-    sp = sortperm(x)
-    n = length(x)
-    sw = sum(w)
-    highsum = sw
-    lowsum = zero(T)
-    idx = 0
-    for i = 1:n
-        lowsum += w[sp[i]]
-        highsum -= w[sp[i]]
-        if lowsum >= highsum
-            idx = sp[i]
-            break
-        end
-    end
-    μ = x[idx]
-    θ = zero(T)
-    for i = 1:length(x)
-        θ += w[i] * abs(x[i] - μ)
-    end
-    θ /= sw
-    return Laplace(μ, θ)
+function fit_mle(::Type{<:Laplace}, x::AbstractArray{<:Real})
+    xc = similar(x)
+    copyto!(xc, x)
+    m = median!(xc)
+    xc .= abs.(x .- m)
+    return Laplace(m, mean(xc))
 end

--- a/src/univariate/continuous/laplace.jl
+++ b/src/univariate/continuous/laplace.jl
@@ -114,8 +114,13 @@ rand(rng::AbstractRNG, d::Laplace) =
 
 #### Fitting
 
-function fit_mle(::Type{<:Laplace}, x::AbstractArray{T}) where {T <: Real}
+function fit_mle(::Type{<:Laplace}, x::AbstractArray{T}) where {T<:Real}
     μ = median(x)
+    θ = zero(T)
+    for v ∈ x
+        θ += abs(v - μ)
+    end
+    θ /= length(x)
     return Laplace(μ, mean(abs.(x .- μ)))
 end
 
@@ -135,6 +140,10 @@ function fit_mle(::Type{<:Laplace}, x::AbstractArray{T}, w::AbstractArray{T}) wh
         end
     end
     μ = x[idx]
-    θ = sum(w .* abs.(x .- μ)) / sw
+    θ = zero(T)
+    for i = 1:length(x)
+        θ += w[i] * abs(x[i] - μ)
+    end
+    θ /= sw
     return Laplace(μ, θ)
 end

--- a/src/univariate/continuous/laplace.jl
+++ b/src/univariate/continuous/laplace.jl
@@ -121,7 +121,7 @@ function fit_mle(::Type{<:Laplace}, x::AbstractArray{T}) where {T<:Real}
         θ += abs(v - μ)
     end
     θ /= length(x)
-    return Laplace(μ, mean(abs.(x .- μ)))
+    return Laplace(μ, θ)
 end
 
 function fit_mle(::Type{<:Laplace}, x::AbstractArray{T}, w::AbstractArray{T}) where {T <: Real}

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -355,10 +355,10 @@ end
 
 @testset "Testing fit for Laplace" begin
     for func in funcs, dist in (Laplace, Laplace{Float64})
-        d = fit(dist, func[2](dist(5.0, 3.0), N))
+        d = fit(dist, func[2](dist(5.0, 3.0), N + 1))
         @test isa(d, dist)
-        @test isapprox(location(d), 5.0, atol=0.1)
-        @test isapprox(scale(d)   , 3.0, atol=0.2)
+        @test isapprox(location(d), 5.0, atol=0.02)
+        @test isapprox(scale(d)   , 3.0, atol=0.02)
     end
 end
 


### PR DESCRIPTION
The current mle fit for Laplace calculates the mean using the median absolute deviation instead of mean absolute deviation.  The former is not MLE.  Also, I added functionality for a weighted Laplace MLE. 