### PR TITLE
Remove test dependency on HypothesisTests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,11 +30,10 @@ Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
-HypothesisTests = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["StableRNGs", "Calculus", "Distributed", "FiniteDifferences", "ForwardDiff", "JSON", "StaticArrays", "HypothesisTests", "Test"]
+test = ["StableRNGs", "Calculus", "Distributed", "FiniteDifferences", "ForwardDiff", "JSON", "StaticArrays", "Test"]

--- a/test/matrixvariates.jl
+++ b/test/matrixvariates.jl
@@ -3,7 +3,6 @@ using Random
 using LinearAlgebra
 using PDMats
 using Statistics
-using HypothesisTests
 using Test
 import JSON
 import Distributions: _univariate, _multivariate, _rand_params
@@ -185,11 +184,26 @@ function test_against_univariate(D::MatrixDistribution, d::UnivariateDistributio
     nothing
 end
 
+# Equivalent to `ExactOneSampleKSTest` in HypothesisTests.jl
+# We implement it here to avoid a circular dependency on HypothesisTests
+# that causes test failures when preparing a breaking release of Distributions
+function pvalue_kolmogorovsmirnoff(x::AbstractVector, d::UnivariateDistribution)
+    # compute maximum absolute deviation from the empirical cdf
+    n = length(x)
+    cdfs = sort!(map(Base.Fix1(cdf, d), x))
+    dmax = maximum(zip(cdfs, (0:(n-1))/n, (1:n)/n)) do (cdf, lower, upper)
+        return max(cdf - lower, upper - cdf)
+    end
+
+    # compute asymptotic p-value (see `KSDist`)
+    return ccdf(KSDist(n), dmax)
+end
+
 function test_draws_against_univariate_cdf(D::MatrixDistribution, d::UnivariateDistribution)
     α = 0.05
     M = 100000
     matvardraws = [rand(D)[1] for m in 1:M]
-    @test pvalue(ExactOneSampleKSTest(matvardraws, d)) >= α
+    @test pvalue_kolmogorovsmirnoff(matvardraws, d) >= α
     nothing
 end
 
@@ -335,8 +349,7 @@ function test_special(dist::Type{Wishart})
         ρ = Chisq(ν)
         A = rand(q, M)
         z = [A[:, m]'*H[m]*A[:, m] / (A[:, m]'*Σ*A[:, m]) for m in 1:M]
-        kstest = ExactOneSampleKSTest(z, ρ)
-        @test pvalue(kstest) >= α
+        @test pvalue_kolmogorovsmirnoff(z, ρ) >= α
     end
     @testset "H ~ W(ν, I) ⟹ H[i, i] ~ χ²(ν)" begin
         κ = n + 1
@@ -347,8 +360,7 @@ function test_special(dist::Type{Wishart})
             mymats[:, :, m] = rand(g)
         end
         for i in 1:n
-            kstest = ExactOneSampleKSTest(mymats[i, i, :], ρ)
-            @test pvalue(kstest) >= α / n
+            @test pvalue_kolmogorovsmirnoff(mymats[i, i, :], ρ) >= α / n
         end
     end
     @testset "Check Singular Branch" begin
@@ -423,8 +435,7 @@ function test_special(dist::Type{LKJ})
         end
         for i in 1:d
             for j in 1:i-1
-                kstest = ExactOneSampleKSTest(mymats[i, j, :], ρ)
-                @test pvalue(kstest) >= α / L
+                @test pvalue_kolmogorovsmirnoff(mymats[i, j, :], ρ) >= α / L
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,6 @@ using Random
 using SpecialFunctions
 using StatsBase
 using LinearAlgebra
-using HypothesisTests
 
 import JSON
 import ForwardDiff


### PR DESCRIPTION
This PR removes the test dependency on HypothesisTests.jl and instead uses a custom implementation of the KS test.

The reason for this change is that HypothesisTests.jl introduces a circular dependency: it depends on Distributions.jl and therefore tests fail if a breaking release is prepared (see e.g. https://github.com/JuliaStats/Distributions.jl/pull/1308#discussion_r618720401).