### PR TITLE
Introduce ArrayLikeVariate as common supertype for Univariate, Multivariate and Matrixvariate

### DIFF
--- a/docs/src/starting.md
+++ b/docs/src/starting.md
@@ -49,9 +49,9 @@ julia> rand(Normal(1, 2), 100)
 
 The package contains a large number of additional distributions of three main types:
 
-* `Univariate`
-* `Multivariate`
-* `Matrixvariate`
+* `Univariate == ArrayLikeVariate{0}`
+* `Multivariate == ArrayLikeVariate{1}`
+* `Matrixvariate == ArrayLikeVariate{2}`
 
 Each type splits further into `Discrete` and `Continuous`.
 

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -27,9 +27,9 @@ The `VariateForm` sub-types defined in `Distributions.jl` are:
 
 **Type** | **A single sample** | **Multiple samples**
 --- | --- |---
-`Univariate` | a scalar number | A numeric array of arbitrary shape, each element being a sample
-`Multivariate` | a numeric vector | A matrix, each column being a sample
-`Matrixvariate` | a numeric matrix | An array of matrices, each element being a sample matrix
+`Univariate == ArrayLikeVariate{0}` | a scalar number | A numeric array of arbitrary shape, each element being a sample
+`Multivariate == ArrayLikeVariate{1}` | a numeric vector | A matrix, each column being a sample
+`Matrixvariate == ArrayLikeVariate{2}` | a numeric matrix | An array of matrices, each element being a sample matrix
 
 ### ValueSupport
 

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -31,6 +31,7 @@ export
 
     # generic types
     VariateForm,
+    NVariate,
     ValueSupport,
     Univariate,
     Multivariate,

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -31,7 +31,7 @@ export
 
     # generic types
     VariateForm,
-    NVariate,
+    ArrayLikeVariate,
     ValueSupport,
     Univariate,
     Multivariate,

--- a/src/common.jl
+++ b/src/common.jl
@@ -6,15 +6,15 @@
 abstract type VariateForm end
 
 """
-`F <: NVariate{N}` specifies the form of the variate a sample for
-variates with an array-like shape, e.g. univariate (scalar, `N == 0`),
-multivariate (vector, `N == 1`), matrix-variate (matrix, , `N == 2`).
+`F <: ArrayLikeVariate{N}` specifies the number of axes of a variate or
+a sample with an array-like shape, e.g. univariate (scalar, `N == 0`),
+multivariate (vector, `N == 1`) or matrix-variate (matrix, `N == 2`).
 """
-abstract type NVariate{N} <: VariateForm end
+abstract type ArrayLikeVariate{N} <: VariateForm end
 
-const Univariate    = NVariate{0}
-const Multivariate  = NVariate{1}
-const Matrixvariate = NVariate{2}
+const Univariate    = ArrayLikeVariate{0}
+const Multivariate  = ArrayLikeVariate{1}
+const Matrixvariate = ArrayLikeVariate{2}
 
 """
 `S <: ValueSupport` specifies the support of sample elements,

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,13 +1,20 @@
 ## sample space/domain
 
 """
-`F <: VariateForm` specifies the form of the variate or
-dimension of a sample, univariate (scalar), multivariate (vector), matrix-variate (matrix).
+`F <: VariateForm` specifies the form of the variate or a sample.
 """
 abstract type VariateForm end
-struct Univariate    <: VariateForm end
-struct Multivariate  <: VariateForm end
-struct Matrixvariate <: VariateForm end
+
+"""
+`F <: NVariate{N}` specifies the form of the variate a sample for
+variates with an array-like shape, e.g. univariate (scalar, `N == 0`),
+multivariate (vector, `N == 1`), matrix-variate (matrix, , `N == 2`).
+"""
+abstract type NVariate{N} <:VariateForm end
+
+const Univariate    = NVariate{0}
+const Multivariate  = NVariate{1}
+const Matrixvariate = NVariate{2}
 
 """
 `S <: ValueSupport` specifies the support of sample elements,

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,7 +1,7 @@
 ## sample space/domain
 
 """
-`F <: VariateForm` specifies the form of the variate or a sample.
+`F <: VariateForm` specifies the form or shape of the variate or a sample.
 """
 abstract type VariateForm end
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -10,7 +10,7 @@ abstract type VariateForm end
 variates with an array-like shape, e.g. univariate (scalar, `N == 0`),
 multivariate (vector, `N == 1`), matrix-variate (matrix, , `N == 2`).
 """
-abstract type NVariate{N} <:VariateForm end
+abstract type NVariate{N} <: VariateForm end
 
 const Univariate    = NVariate{0}
 const Multivariate  = NVariate{1}


### PR DESCRIPTION
When writing generic code that deals with Univariate, Multivariate and Matrixvariate distributions, I often find myself having to code separate methods for each variate type. Having a common supertype `NVariate{N}` should make generic coding for distributions a bit easier.

I propose to introduce `Union{Univariate,Multivariate,Matrixvariate} <: NVariate <: VariateForm` here, instead of changing `VariateForm` to `VariateForm{N}`, to continue leaving room for custom non-scalar/matrix-like variate type (representated by other subtypes of `VariateForm`). [ValueShapes.jl](https://github.com/oschulz/ValueShapes.jl), for example, supports distributions with [`NamedTuple` variates](https://github.com/oschulz/ValueShapes.jl/blob/master/src/distributions.jl#L36).