### PR TITLE
Add `minimum`, `maximum`, `extrema` for `AbstractMvNormal` and `Product`

### DIFF
--- a/docs/src/multivariate.md
+++ b/docs/src/multivariate.md
@@ -71,6 +71,9 @@ invcov(::Distributions.AbstractMvNormal)
 logdetcov(::Distributions.AbstractMvNormal)
 sqmahal(::Distributions.AbstractMvNormal, ::AbstractArray)
 rand(::AbstractRNG, ::Distributions.AbstractMvNormal)
+minimum(::Distributions.AbstractMvNormal)
+maximum(::Distributions.AbstractMvNormal)
+extrema(::Distributions.AbstractMvNormal)
 ```
 
 ### MvLogNormal

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -80,8 +80,25 @@ abstract type AbstractMvNormal <: ContinuousMultivariateDistribution end
 insupport(d::AbstractMvNormal, x::AbstractVector) =
     length(d) == length(x) && all(isfinite, x)
 
+"""
+    minimum(d::AbstractMvNormal)
+
+Return the minimum of the support of `d`.
+"""
 minimum(d::AbstractMvNormal) = fill(-Inf, length(d))
+
+"""
+    maximum(d::AbstractMvNormal)
+
+Return the maximum of the support of `d`.
+"""
 maximum(d::AbstractMvNormal) = fill(Inf, length(d))
+
+"""
+    extrema(d::AbstractMvNormal)
+
+Return the minimum and maximum of the support of `d` as a 2-tuple.
+"""
 extrema(d::AbstractMvNormal) = minimum(d), maximum(d)
 
 mode(d::AbstractMvNormal) = mean(d)

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -80,6 +80,10 @@ abstract type AbstractMvNormal <: ContinuousMultivariateDistribution end
 insupport(d::AbstractMvNormal, x::AbstractVector) =
     length(d) == length(x) && all(isfinite, x)
 
+minimum(d::AbstractMvNormal) = fill(-Inf, length(d))
+maximum(d::AbstractMvNormal) = fill(Inf, length(d))
+extrema(d::AbstractMvNormal) = minimum(d), maximum(d)
+
 mode(d::AbstractMvNormal) = mean(d)
 modes(d::AbstractMvNormal) = [mean(d)]
 

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -83,21 +83,21 @@ insupport(d::AbstractMvNormal, x::AbstractVector) =
 """
     minimum(d::AbstractMvNormal)
 
-Return the minimum of the support of `d`.
+Return the minimum of the support of each dimension of `d`.
 """
-minimum(d::AbstractMvNormal) = fill(-Inf, length(d))
+minimum(d::AbstractMvNormal) = fill(eltype(d)(-Inf), length(d))
 
 """
     maximum(d::AbstractMvNormal)
 
-Return the maximum of the support of `d`.
+Return the maximum of the support of each dimension of `d`.
 """
-maximum(d::AbstractMvNormal) = fill(Inf, length(d))
+maximum(d::AbstractMvNormal) = fill(eltype(d)(Inf), length(d))
 
 """
     extrema(d::AbstractMvNormal)
 
-Return the minimum and maximum of the support of `d` as a 2-tuple.
+Return the minimum and maximum of the support of each dimenison of `d` as a 2-tuple.
 """
 extrema(d::AbstractMvNormal) = minimum(d), maximum(d)
 

--- a/src/multivariate/product.jl
+++ b/src/multivariate/product.jl
@@ -42,23 +42,23 @@ entropy(d::Product) = sum(entropy, d.v)
 insupport(d::Product, x::AbstractVector) = all(insupport.(d.v, x))
 
 """
-    minimum(d::AbstractMvNormal)
+    minimum(d::Product)
 
-Return the minimum of the support of `d`.
+Return the minimum of the support of each dimension of `d`.
 """
 minimum(d::Product) = minimum.(d.v)
 
 """
-    maximum(d::AbstractMvNormal)
+    maximum(d::Product)
 
-Return the maximum of the support of `d`.
+Return the maximum of the support of each dimension of `d`.
 """
 maximum(d::Product) = maximum.(d.v)
 
 """
-    extrema(d::AbstractMvNormal)
+    extrema(d::Product)
 
-Return the minimum and maximum of the support of `d` as a 2-tuple.
+Return the minimum and maximum of the support of each dimension of `d` as a 2-tuple.
 """
 extrema(d::Product) = minimum(d), maximum(d)
 

--- a/src/multivariate/product.jl
+++ b/src/multivariate/product.jl
@@ -40,6 +40,9 @@ var(d::Product) = var.(d.v)
 cov(d::Product) = Diagonal(var(d))
 entropy(d::Product) = sum(entropy, d.v)
 insupport(d::Product, x::AbstractVector) = all(insupport.(d.v, x))
+minimum(d::Product) = minimum.(d.v)
+maximum(d::Product) = maximum.(d.v)
+extrema(d::Product) = minimum(d), maximum(d)
 
 """
     product_distribution(dists::AbstractVector{<:UnivariateDistribution})

--- a/src/multivariate/product.jl
+++ b/src/multivariate/product.jl
@@ -40,8 +40,26 @@ var(d::Product) = var.(d.v)
 cov(d::Product) = Diagonal(var(d))
 entropy(d::Product) = sum(entropy, d.v)
 insupport(d::Product, x::AbstractVector) = all(insupport.(d.v, x))
+
+"""
+    minimum(d::AbstractMvNormal)
+
+Return the minimum of the support of `d`.
+"""
 minimum(d::Product) = minimum.(d.v)
+
+"""
+    maximum(d::AbstractMvNormal)
+
+Return the maximum of the support of `d`.
+"""
 maximum(d::Product) = maximum.(d.v)
+
+"""
+    extrema(d::AbstractMvNormal)
+
+Return the minimum and maximum of the support of `d` as a 2-tuple.
+"""
 extrema(d::Product) = minimum(d), maximum(d)
 
 """

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -29,6 +29,9 @@ function test_mvnormal(g::AbstractMvNormal, n_tsamples::Int=10^6,
     vs = diag(Σ)
     @test g == typeof(g)(params(g)...)
     @test g == deepcopy(g)
+    @test minimum(g) == fill(-Inf, d)
+    @test maximum(g) == fill(Inf, d)
+    @test extrema(g) == (minimum(g), maximum(g))
 
     # test sampling for AbstractMatrix (here, a SubArray):
     if ismissing(rng)

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -32,6 +32,7 @@ function test_mvnormal(g::AbstractMvNormal, n_tsamples::Int=10^6,
     @test minimum(g) == fill(-Inf, d)
     @test maximum(g) == fill(Inf, d)
     @test extrema(g) == (minimum(g), maximum(g))
+    @test isless(extrema(g)...)
 
     # test sampling for AbstractMatrix (here, a SubArray):
     if ismissing(rng)

--- a/test/product.jl
+++ b/test/product.jl
@@ -29,7 +29,7 @@ end
     N = 11
     # Construct independent distributions and `Product` distribution from these.
     ubound = rand(N)
-    ds = Uniform.(0.0, ubound)
+    ds = Uniform.(-ubound, ubound)
     x = rand.(ds)
     d_product = product_distribution(ds)
     @test d_product isa Product
@@ -43,6 +43,9 @@ end
     @test entropy(d_product) == sum(entropy.(ds))
     @test insupport(d_product, ubound) == true
     @test insupport(d_product, ubound .+ 1) == false
+    @test minimum(d_product) == -ubound
+    @test maximum(d_product) == ubound
+    @test extrema(d_product) == (-ubound, ubound)
 
     y = rand(d_product)
     @test y isa typeof(x)

--- a/test/product.jl
+++ b/test/product.jl
@@ -46,6 +46,7 @@ end
     @test minimum(d_product) == -ubound
     @test maximum(d_product) == ubound
     @test extrema(d_product) == (-ubound, ubound)
+    @test isless(extrema(d_product)...)
 
     y = rand(d_product)
     @test y isa typeof(x)


### PR DESCRIPTION
This PR adds `minimum`, `maximum`, `extrema` for `AbstractMvNormal` and `Product`. The definition extends that currently used for univariate distributions, i.e. `minimum` and `maximum` returns the min/max of the support for each dimension. 

This extends a common interface between Univariate distributions and as subset of MV distributions for querying the bounds of the support for upstream applications such as DiffEqUncertainty, where quadrature is solved over the support. 