### PR TITLE
Add function to compute L2 norm of distributions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.1"
+version = "0.25.2"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/docs/src/univariate.md
+++ b/docs/src/univariate.md
@@ -63,6 +63,7 @@ entropy(::UnivariateDistribution, ::Bool)
 entropy(::UnivariateDistribution, ::Real)
 mgf(::UnivariateDistribution, ::Any)
 cf(::UnivariateDistribution, ::Any)
+pdfsquaredL2norm
 ```
 
 ### Probability Evaluation

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -285,6 +285,7 @@ include("conversion.jl")
 include("convolution.jl")
 include("qq.jl")
 include("estimators.jl")
+include("pdfnorm.jl")
 
 # mixture distributions (TODO: moveout)
 include("mixtures/mixturemodel.jl")

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -230,6 +230,7 @@ export
     params!,            # provide storage space to calculate the tuple of parameters for a multivariate distribution like mvlognormal
     partype,            # returns a type large enough to hold all of a distribution's parameters' element types
     pdf,                # probability density function (ContinuousDistribution)
+    pdfsquaredL2norm,   # squared L2 norm of the probability density function
     probs,              # Get the vector of probabilities
     probval,            # The pdf/pmf value for a uniform distribution
     product_distribution, # product of univariate distributions

--- a/src/pdfnorm.jl
+++ b/src/pdfnorm.jl
@@ -4,7 +4,7 @@
 Return the square of the L2 norm of the probability density function ``f(x)`` of the distribution `d`:
 
 ```math
-\\int_{S} f(x)^{2} \\mathrm{d} x
+\\big(\\int_{S} f(x)^{2} \\mathrm{d} x \\big)^{1/2}
 ```
 
 where ``S`` is the support of ``f(x)``.
@@ -18,7 +18,7 @@ function pdfsquaredL2norm(d::Beta)
     return α > 0.5 && β > 0.5 ? z : oftype(z, Inf)
 end
 
-pdfsquaredL2norm(d::Cauchy) = inv(twoπ * d.σ)
+pdfsquaredL2norm(d::Cauchy) = inv2π / d.σ
 
 function pdfsquaredL2norm(d::Chi)
     ν = d.ν

--- a/src/pdfnorm.jl
+++ b/src/pdfnorm.jl
@@ -1,0 +1,58 @@
+export pdfL2norm
+
+"""
+    pdfL2norm(d::Distribution)
+
+Return the L2 norm of the probability distribution function `f(x)` of the distribution `d`:
+
+```math
+\\int_{S} f(x)^{2} \\mathrm{d} x
+```
+
+where `S` is the support of `f(x)`.
+"""
+pdfL2norm
+
+pdfL2norm(d::Distribution) = throw(ArgumentError("L2 norm not implemented for $(d)"))
+
+function pdfL2norm(d::Beta{T}) where T
+    if d.α > 0.5 && d.β > 0.5
+        return beta(2 * d.α - 1, 2 * d.β - 1) / beta(d.α, d.β) ^ 2
+    else
+        return T(Inf)
+    end
+end
+
+pdfL2norm(d::Cauchy) =  1 / (d.σ * 2 * π)
+
+function pdfL2norm(d::Chi{T}) where {T}
+    if d.ν > 0.5
+        return (2 ^ (1 - d.ν) * gamma((2 * d.ν - 1) / 2)) / gamma(d.ν / 2) ^ 2
+    else
+        return T(Inf)
+    end
+end
+
+function pdfL2norm(d::Chisq{T}) where {T}
+    if d.ν > 1
+        return gamma(d.ν - 1) / (gamma(d.ν / 2) ^ 2 * 2 ^ d.ν)
+    else
+        return T(Inf)
+    end
+end
+
+pdfL2norm(d::Exponential) = 1 / (2 * d.θ)
+
+function pdfL2norm(d::Gamma{T}) where {T}
+    if d.α > 0.5
+        return (2^(1 - 2 * d.α) * gamma(2 * d.α - 1)) / (gamma(d.α) ^ 2 * d.θ)
+    else
+        return T(Inf)
+    end
+end
+
+pdfL2norm(d::Logistic) = 1 / (6 * d.θ)
+
+pdfL2norm(d::Normal{T}) where {T} = 1 / (2 * sqrt(T(π)) * d.σ)
+
+pdfL2norm(d::Uniform) = 1 / (d.b - d.a)

--- a/src/pdfnorm.jl
+++ b/src/pdfnorm.jl
@@ -1,58 +1,50 @@
-export pdfL2norm
-
 """
-    pdfL2norm(d::Distribution)
+    pdfsquaredL2norm(d::Distribution)
 
-Return the L2 norm of the probability distribution function `f(x)` of the distribution `d`:
+Return the square of the L2 norm of the probability density function ``f(x)`` of the distribution `d`:
 
 ```math
 \\int_{S} f(x)^{2} \\mathrm{d} x
 ```
 
-where `S` is the support of `f(x)`.
+where ``S`` is the support of ``f(x)``.
 """
-pdfL2norm
+pdfsquaredL2norm
 
-pdfL2norm(d::Distribution) = throw(ArgumentError("L2 norm not implemented for $(d)"))
-
-function pdfL2norm(d::Beta{T}) where T
-    if d.α > 0.5 && d.β > 0.5
-        return beta(2 * d.α - 1, 2 * d.β - 1) / beta(d.α, d.β) ^ 2
-    else
-        return T(Inf)
-    end
+function pdfsquaredL2norm(d::Beta)
+    α, β = params(d)
+    z = beta(2 * α - 1, 2 * β - 1) / beta(α, β) ^ 2
+    # L2 norm of the pdf converges only for α > 0.5 and β > 0.5
+    return α > 0.5 && β > 0.5 ? z : oftype(z, Inf)
 end
 
-pdfL2norm(d::Cauchy) =  1 / (d.σ * 2 * π)
+pdfsquaredL2norm(d::Cauchy) = inv(twoπ * d.σ)
 
-function pdfL2norm(d::Chi{T}) where {T}
-    if d.ν > 0.5
-        return (2 ^ (1 - d.ν) * gamma((2 * d.ν - 1) / 2)) / gamma(d.ν / 2) ^ 2
-    else
-        return T(Inf)
-    end
+function pdfsquaredL2norm(d::Chi)
+    ν = d.ν
+    z = (2 ^ (1 - ν) * gamma((2 * ν - 1) / 2)) / gamma(ν / 2) ^ 2
+    # L2 norm of the pdf converges only for ν > 0.5
+    return d.ν > 0.5 ? z : oftype(z, Inf)
 end
 
-function pdfL2norm(d::Chisq{T}) where {T}
-    if d.ν > 1
-        return gamma(d.ν - 1) / (gamma(d.ν / 2) ^ 2 * 2 ^ d.ν)
-    else
-        return T(Inf)
-    end
+function pdfsquaredL2norm(d::Chisq)
+    ν = d.ν
+    z = gamma(d.ν - 1) / (gamma(d.ν / 2) ^ 2 * 2 ^ d.ν)
+    # L2 norm of the pdf converges only for ν > 1
+    return ν > 1 ? z : oftype(z, Inf)
 end
 
-pdfL2norm(d::Exponential) = 1 / (2 * d.θ)
+pdfsquaredL2norm(d::Exponential) = 1 / (2 * d.θ)
 
-function pdfL2norm(d::Gamma{T}) where {T}
-    if d.α > 0.5
-        return (2^(1 - 2 * d.α) * gamma(2 * d.α - 1)) / (gamma(d.α) ^ 2 * d.θ)
-    else
-        return T(Inf)
-    end
+function pdfsquaredL2norm(d::Gamma{T}) where {T}
+    α, θ = params(d)
+    z = (2^(1 - 2 * α) * gamma(2 * α - 1)) / (gamma(α) ^ 2 * θ)
+    # L2 norm of the pdf converges only for α > 0.5
+    return α > 0.5 ? z : oftype(z, Inf)
 end
 
-pdfL2norm(d::Logistic) = 1 / (6 * d.θ)
+pdfsquaredL2norm(d::Logistic) = 1 / (6 * d.θ)
 
-pdfL2norm(d::Normal{T}) where {T} = 1 / (2 * sqrt(T(π)) * d.σ)
+pdfsquaredL2norm(d::Normal) = inv(sqrt4π * d.σ)
 
-pdfL2norm(d::Uniform) = 1 / (d.b - d.a)
+pdfsquaredL2norm(d::Uniform) = 1 / (d.b - d.a)

--- a/src/pdfnorm.jl
+++ b/src/pdfnorm.jl
@@ -4,7 +4,7 @@
 Return the square of the L2 norm of the probability density function ``f(x)`` of the distribution `d`:
 
 ```math
-\\big(\\int_{S} f(x)^{2} \\mathrm{d} x \\big)^{1/2}
+\\int_{S} f(x)^{2} \\mathrm{d} x
 ```
 
 where ``S`` is the support of ``f(x)``.
@@ -36,7 +36,7 @@ end
 
 pdfsquaredL2norm(d::Exponential) = 1 / (2 * d.θ)
 
-function pdfsquaredL2norm(d::Gamma{T}) where {T}
+function pdfsquaredL2norm(d::Gamma)
     α, θ = params(d)
     z = (2^(1 - 2 * α) * gamma(2 * α - 1)) / (gamma(α) ^ 2 * θ)
     # L2 norm of the pdf converges only for α > 0.5

--- a/test/pdfnorm.jl
+++ b/test/pdfnorm.jl
@@ -1,0 +1,63 @@
+using Test, Distributions, SpecialFunctions
+
+@testset "pdf L2 norm" begin
+    # Test error on a non implemented norm.
+    @test_throws ArgumentError pdfL2norm(Gumbel())
+
+    @testset "Beta" begin
+        @test pdfL2norm(Beta(1, 1)) ≈ 1
+        @test pdfL2norm(Beta(2, 2)) ≈ 6 / 5
+        @test pdfL2norm(Beta(0.25, 1)) ≈ Inf
+        @test pdfL2norm(Beta(1, 0.25)) ≈ Inf
+    end
+
+    @testset "Cauchy" begin
+        @test pdfL2norm(Cauchy(0, 1)) ≈ 1 / (2 * π)
+        @test pdfL2norm(Cauchy(0, 2)) ≈ 1 / (4 * π)
+        # The norm doesn't depend on the mean
+        @test pdfL2norm(Cauchy(100, 1)) == pdfL2norm(Cauchy(-100, 1)) == pdfL2norm(Cauchy(0, 1))
+    end
+
+    @testset "Chi" begin
+        @test pdfL2norm(Chi(2)) ≈ gamma(3 / 2) / 2
+        @test pdfL2norm(Chi(0.25)) ≈ Inf
+    end
+
+    @testset "Chisq" begin
+        @test pdfL2norm(Chisq(2)) ≈ 1 / 4
+        @test pdfL2norm(Chisq(1)) ≈ Inf
+    end
+
+    @testset "Exponential" begin
+        @test pdfL2norm(Exponential(1)) ≈ 1 / 2
+        @test pdfL2norm(Exponential(2)) ≈ 1 / 4
+    end
+
+    @testset "Gamma" begin
+        @test pdfL2norm(Gamma(1, 1)) ≈ 1 / 2
+        @test pdfL2norm(Gamma(1, 2)) ≈ 1 / 4
+        @test pdfL2norm(Gamma(2, 2)) ≈ 1 / 8
+        @test pdfL2norm(Gamma(1, 0.25)) ≈ 2
+        @test pdfL2norm(Gamma(0.5, 1)) ≈ Inf
+    end
+
+    @testset "Logistic" begin
+        @test pdfL2norm(Logistic(0, 1)) ≈ 1 / 6
+        @test pdfL2norm(Logistic(0, 2)) ≈ 1 / 12
+        # The norm doesn't depend on the mean
+        @test pdfL2norm(Logistic(100, 1)) == pdfL2norm(Logistic(-100, 1)) == pdfL2norm(Logistic(0, 1))
+    end
+
+    @testset "Normal" begin
+        @test pdfL2norm(Normal(0, 1)) ≈ 1 / (2 * sqrt(π))
+        @test pdfL2norm(Normal(0, 2)) ≈ 1 / (4 * sqrt(π))
+        @test pdfL2norm(Normal(1, 0)) ≈ Inf
+        # The norm doesn't depend on the mean
+        @test pdfL2norm(Normal(100, 1)) == pdfL2norm(Normal(-100, 1)) == pdfL2norm(Normal(0, 1))
+    end
+
+    @testset "Uniform" begin
+        @test pdfL2norm(Uniform(-1, 1)) ≈ 1 / 2
+        @test pdfL2norm(Uniform(1, 2)) ≈ 1
+    end
+end

--- a/test/pdfnorm.jl
+++ b/test/pdfnorm.jl
@@ -2,62 +2,62 @@ using Test, Distributions, SpecialFunctions
 
 @testset "pdf L2 norm" begin
     # Test error on a non implemented norm.
-    @test_throws ArgumentError pdfL2norm(Gumbel())
+    @test_throws MethodError pdfsquaredL2norm(Gumbel())
 
     @testset "Beta" begin
-        @test pdfL2norm(Beta(1, 1)) ≈ 1
-        @test pdfL2norm(Beta(2, 2)) ≈ 6 / 5
-        @test pdfL2norm(Beta(0.25, 1)) ≈ Inf
-        @test pdfL2norm(Beta(1, 0.25)) ≈ Inf
+        @test pdfsquaredL2norm(Beta(1, 1)) ≈ 1
+        @test pdfsquaredL2norm(Beta(2, 2)) ≈ 6 / 5
+        @test pdfsquaredL2norm(Beta(0.25, 1)) ≈ Inf
+        @test pdfsquaredL2norm(Beta(1, 0.25)) ≈ Inf
     end
 
     @testset "Cauchy" begin
-        @test pdfL2norm(Cauchy(0, 1)) ≈ 1 / (2 * π)
-        @test pdfL2norm(Cauchy(0, 2)) ≈ 1 / (4 * π)
+        @test pdfsquaredL2norm(Cauchy(0, 1)) ≈ 1 / (2 * π)
+        @test pdfsquaredL2norm(Cauchy(0, 2)) ≈ 1 / (4 * π)
         # The norm doesn't depend on the mean
-        @test pdfL2norm(Cauchy(100, 1)) == pdfL2norm(Cauchy(-100, 1)) == pdfL2norm(Cauchy(0, 1))
+        @test pdfsquaredL2norm(Cauchy(100, 1)) == pdfsquaredL2norm(Cauchy(-100, 1)) == pdfsquaredL2norm(Cauchy(0, 1))
     end
 
     @testset "Chi" begin
-        @test pdfL2norm(Chi(2)) ≈ gamma(3 / 2) / 2
-        @test pdfL2norm(Chi(0.25)) ≈ Inf
+        @test pdfsquaredL2norm(Chi(2)) ≈ gamma(3 / 2) / 2
+        @test pdfsquaredL2norm(Chi(0.25)) ≈ Inf
     end
 
     @testset "Chisq" begin
-        @test pdfL2norm(Chisq(2)) ≈ 1 / 4
-        @test pdfL2norm(Chisq(1)) ≈ Inf
+        @test pdfsquaredL2norm(Chisq(2)) ≈ 1 / 4
+        @test pdfsquaredL2norm(Chisq(1)) ≈ Inf
     end
 
     @testset "Exponential" begin
-        @test pdfL2norm(Exponential(1)) ≈ 1 / 2
-        @test pdfL2norm(Exponential(2)) ≈ 1 / 4
+        @test pdfsquaredL2norm(Exponential(1)) ≈ 1 / 2
+        @test pdfsquaredL2norm(Exponential(2)) ≈ 1 / 4
     end
 
     @testset "Gamma" begin
-        @test pdfL2norm(Gamma(1, 1)) ≈ 1 / 2
-        @test pdfL2norm(Gamma(1, 2)) ≈ 1 / 4
-        @test pdfL2norm(Gamma(2, 2)) ≈ 1 / 8
-        @test pdfL2norm(Gamma(1, 0.25)) ≈ 2
-        @test pdfL2norm(Gamma(0.5, 1)) ≈ Inf
+        @test pdfsquaredL2norm(Gamma(1, 1)) ≈ 1 / 2
+        @test pdfsquaredL2norm(Gamma(1, 2)) ≈ 1 / 4
+        @test pdfsquaredL2norm(Gamma(2, 2)) ≈ 1 / 8
+        @test pdfsquaredL2norm(Gamma(1, 0.25)) ≈ 2
+        @test pdfsquaredL2norm(Gamma(0.5, 1)) ≈ Inf
     end
 
     @testset "Logistic" begin
-        @test pdfL2norm(Logistic(0, 1)) ≈ 1 / 6
-        @test pdfL2norm(Logistic(0, 2)) ≈ 1 / 12
+        @test pdfsquaredL2norm(Logistic(0, 1)) ≈ 1 / 6
+        @test pdfsquaredL2norm(Logistic(0, 2)) ≈ 1 / 12
         # The norm doesn't depend on the mean
-        @test pdfL2norm(Logistic(100, 1)) == pdfL2norm(Logistic(-100, 1)) == pdfL2norm(Logistic(0, 1))
+        @test pdfsquaredL2norm(Logistic(100, 1)) == pdfsquaredL2norm(Logistic(-100, 1)) == pdfsquaredL2norm(Logistic(0, 1))
     end
 
     @testset "Normal" begin
-        @test pdfL2norm(Normal(0, 1)) ≈ 1 / (2 * sqrt(π))
-        @test pdfL2norm(Normal(0, 2)) ≈ 1 / (4 * sqrt(π))
-        @test pdfL2norm(Normal(1, 0)) ≈ Inf
+        @test pdfsquaredL2norm(Normal(0, 1)) ≈ 1 / (2 * sqrt(π))
+        @test pdfsquaredL2norm(Normal(0, 2)) ≈ 1 / (4 * sqrt(π))
+        @test pdfsquaredL2norm(Normal(1, 0)) ≈ Inf
         # The norm doesn't depend on the mean
-        @test pdfL2norm(Normal(100, 1)) == pdfL2norm(Normal(-100, 1)) == pdfL2norm(Normal(0, 1))
+        @test pdfsquaredL2norm(Normal(100, 1)) == pdfsquaredL2norm(Normal(-100, 1)) == pdfsquaredL2norm(Normal(0, 1))
     end
 
     @testset "Uniform" begin
-        @test pdfL2norm(Uniform(-1, 1)) ≈ 1 / 2
-        @test pdfL2norm(Uniform(1, 2)) ≈ 1
+        @test pdfsquaredL2norm(Uniform(-1, 1)) ≈ 1 / 2
+        @test pdfsquaredL2norm(Uniform(1, 2)) ≈ 1
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,6 +61,7 @@ const tests = [
     "skewnormal",
     "chi",
     "gumbel",
+    "pdfnorm",
 ]
 
 printstyled("Running tests:\n", color=:blue)


### PR DESCRIPTION
This implements the L2 norm of some distributions, as requested in #806.  I started with continuous univariate distributions for which I was able to work out the integral.  The default method throws an error explaining that the function isn't implemented for the given distribution, but other methods can be added later.  CC: @ablaom @fkiraly