### PR TITLE
document Dirac

### DIFF
--- a/docs/src/univariate.md
+++ b/docs/src/univariate.md
@@ -149,6 +149,7 @@ Bernoulli
 BetaBinomial
 Binomial
 Categorical
+Dirac
 DiscreteUniform
 DiscreteNonParametric
 Geometric


### PR DESCRIPTION
as added in #1231

currently its existence is not evident in the docs.
not sure what else (if anything) might need to be done to make its docstring appear in the docs too.
hopefully Documenter takes care f that?