### PR TITLE
Switch to using native samplers for Poisson and consequently also

### DIFF
--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -110,15 +110,7 @@ invlogcdf( d::NegativeBinomial, lq::Real) = convert(Int, nbinominvlogcdf( d.r, d
 invlogccdf(d::NegativeBinomial, lq::Real) = convert(Int, nbinominvlogccdf(d.r, d.p, lq))
 
 ## sampling
-# TODO: remove RFunctions dependency once Poisson has its removed
-@rand_rdist(NegativeBinomial)
-rand(d::NegativeBinomial) =
-    convert(Int, StatsFuns.RFunctions.nbinomrand(d.r, d.p))
-
-function rand(rng::AbstractRNG, d::NegativeBinomial)
-    lambda = rand(rng, Gamma(d.r, (1-d.p)/d.p))
-    return rand(rng, Poisson(lambda))
-end
+rand(rng::AbstractRNG, d::NegativeBinomial) = rand(rng, Poisson(rand(rng, Gamma(d.r, (1 - d.p)/d.p))))
 
 struct RecursiveNegBinomProbEvaluator <: RecursiveProbabilityEvaluator
     r::Float64

--- a/src/univariate/discrete/poisson.jl
+++ b/src/univariate/discrete/poisson.jl
@@ -162,3 +162,5 @@ function sampler(d::Poisson)
         return PoissonADSampler(d)
     end
 end
+
+rand(rng::AbstractRNG, d::Poisson) = rand(rng, sampler(d))

--- a/src/univariate/discrete/skellam.jl
+++ b/src/univariate/discrete/skellam.jl
@@ -106,9 +106,5 @@ end
 cdf(d::Skellam, t::Real) = cdf(d, floor(Int, t))
 
 #### Sampling
-# TODO: remove RFunctions dependency once Poisson has its removed
-@rand_rdist(Skellam)
-rand(d::Skellam) = rand(Poisson(d.μ1)) - rand(Poisson(d.μ2))
-
 rand(rng::AbstractRNG, d::Skellam) =
     rand(rng, Poisson(d.μ1)) - rand(rng, Poisson(d.μ2))


### PR DESCRIPTION
Skellam and NegativeBinomial. That will give us three more check marks in the https://github.com/JuliaStats/Distributions.jl/issues/294 list. I'm wondering if we should simply finish the list (in a separate PR) by switching to the inversion method for the remaining distributions. It's really slow but the current situation where the distributions use Rmath when using the global RNG and inversion when an RNG is passed is not good IMO. Ref https://github.com/JuliaStats/Distributions.jl/issues/973