### PR TITLE
Fix `Dirichlet` return type by adding `Dirichlet(d::Integer, alpha::Integer)` constructor.

### DIFF
--- a/src/multivariate/dirichlet.jl
+++ b/src/multivariate/dirichlet.jl
@@ -39,6 +39,7 @@ function Dirichlet(alpha::AbstractVector{<:Real}; check_args=true)
     Dirichlet{eltype(alpha)}(alpha; check_args=check_args)
 end
 Dirichlet(d::Integer, alpha::Real; kwargs...) = Dirichlet(Fill(alpha, d); kwargs...)
+Dirichlet(d::Integer, alpha::Integer; kwargs...) = Dirichlet(Fill(Float64(alpha), d); kwargs...)
 
 struct DirichletCanon{T<:Real,Ts<:AbstractVector{T}}
     alpha::Ts


### PR DESCRIPTION
After #1243 was merged, it looks like the old constructor for `Dirichlet(d::Integer, alpha::Integer)` was removed, and the new constructor introduced creates a situation where the `eltype` of `Dirichlet` ends up being `Int64` if `alpha` is given as an `Int64` (see https://github.com/JuliaStats/Distributions.jl/commit/ccebbd7b5f427515a3de194038d6b288982b841f#diff-65f8aff731d04673339bb6e204537e9f99b6ac88797bd476a816ceaab046077aL52-R41 ).

This was causing issues in some downstream code I've been using, which converts the return value of `rand(dist::Dirichlet{T}, ...)` to type `T`. When `T` was `Int64`, this created errors, because the conversion from a float wasn't possible.

This PR should address the issue by re-introducing a constructor that handles the case where `alpha` is an `Integer`, and converts `alpha` to `Float64`. 

