### PR TITLE
Add LKJCholesky

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -36,6 +36,7 @@ export
     Univariate,
     Multivariate,
     Matrixvariate,
+    CholeskyVariate,
     Discrete,
     Continuous,
     Sampleable,

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -110,6 +110,7 @@ export
     Laplace,
     Levy,
     LKJ,
+    LKJCholesky,
     LocationScale,
     Logistic,
     LogNormal,
@@ -279,6 +280,7 @@ include("univariates.jl")
 include("edgeworth.jl")
 include("multivariates.jl")
 include("matrixvariates.jl")
+include("cholesky/lkjcholesky.jl")
 include("samplers.jl")
 
 # others
@@ -323,7 +325,7 @@ Supported distributions:
     Frechet, FullNormal, FullNormalCanon, Gamma, GeneralizedPareto,
     GeneralizedExtremeValue, Geometric, Gumbel, Hypergeometric,
     InverseWishart, InverseGamma, InverseGaussian, IsoNormal,
-    IsoNormalCanon, Kolmogorov, KSDist, KSOneSided, Laplace, Levy, LKJ,
+    IsoNormalCanon, Kolmogorov, KSDist, KSOneSided, Laplace, Levy, LKJ, LKJCholesky,
     Logistic, LogNormal, MatrixBeta, MatrixFDist, MatrixNormal,
     MatrixReshaped, MatrixTDist, MixtureModel, Multinomial,
     MultivariateNormal, MvLogNormal, MvNormal, MvNormalCanon,

--- a/src/cholesky/lkjcholesky.jl
+++ b/src/cholesky/lkjcholesky.jl
@@ -108,6 +108,13 @@ end
 
 logpdf(d::LKJCholesky, R::Cholesky) = logkernel(d, R) + d.logc0
 
+pdf(d::LKJCholesky, R::Cholesky) = exp(logpdf(d, R))
+
+loglikelihood(d::LKJCholesky, R::Cholesky) = logpdf(d, R)
+function loglikelihood(d::LKJCholesky, Rs::AbstractArray{<:Cholesky})
+    return sum(R -> logpdf(d, R), Rs)
+end
+
 #  -----------------------------------------------------------------------------
 #  Sampling
 #  -----------------------------------------------------------------------------

--- a/src/cholesky/lkjcholesky.jl
+++ b/src/cholesky/lkjcholesky.jl
@@ -62,6 +62,12 @@ function insupport(d::LKJCholesky, R::Cholesky)
     return true
 end
 
+function mode(d::LKJCholesky)
+    p = dim(d)
+    factors = Matrix{partype(d)}(I, p, p)
+    return Cholesky(factors, d.uplo, 0)
+end
+
 params(d::LKJCholesky) = (d.d, d.η, d.uplo)
 
 @inline partype(::LKJCholesky{T}) where {T <: Real} = T

--- a/src/cholesky/lkjcholesky.jl
+++ b/src/cholesky/lkjcholesky.jl
@@ -1,0 +1,6 @@
+struct LKJCholesky{T <: Real, D <: Integer} <: Distribution{CholeskyVariate,Continuous}
+    d::D
+    η::T
+    uplo::Char
+    logc0::T
+end

--- a/src/cholesky/lkjcholesky.jl
+++ b/src/cholesky/lkjcholesky.jl
@@ -39,3 +39,22 @@ params(d::LKJCholesky) = (d.d, d.η, d.uplo)
 
 @inline partype(::LKJCholesky{T}) where {T <: Real} = T
 
+#  -----------------------------------------------------------------------------
+#  Evaluation
+#  -----------------------------------------------------------------------------
+
+function logkernel(d::LKJCholesky, x::Cholesky)
+    factors = x.factors
+    p, η = params(d)
+    c = p + 2(η - 1)
+    T = typeof(one(c) * log(one(eltype(factors))))
+    logp = zero(T)
+    di = diagind(factors)
+    for i in 2:p
+        logp += (c - i) * log(factors[di[i]])
+    end
+    return logp
+end
+
+logpdf(d::LKJCholesky, x::Cholesky) = logkernel(d, x) + d.logc0
+

--- a/src/cholesky/lkjcholesky.jl
+++ b/src/cholesky/lkjcholesky.jl
@@ -25,6 +25,23 @@ _as_char(c::Char) = c
 _as_char(x) = only(string(x))
 
 #  -----------------------------------------------------------------------------
+#  REPL display
+#  -----------------------------------------------------------------------------
+
+show(io::IO, d::LKJCholesky) = show_multline(io, d, [(:d, d.d), (:η, d.η), (:uplo, d.uplo)])
+
+#  -----------------------------------------------------------------------------
+#  Conversion
+#  -----------------------------------------------------------------------------
+
+function convert(::Type{LKJCholesky{T}}, d::LKJCholesky) where T <: Real
+    return LKJCholesky{T, typeof(d.d)}(d.d, T(d.η), d.uplo, T(d.logc0))
+end
+function convert(::Type{LKJCholesky{T}}, d::Integer, η, logc0) where T <: Real
+    return LKJCholesky{T, typeof(d)}(d, T(η), d.uplo, T(logc0))
+end
+
+#  -----------------------------------------------------------------------------
 #  Properties
 #  -----------------------------------------------------------------------------
 

--- a/src/cholesky/lkjcholesky.jl
+++ b/src/cholesky/lkjcholesky.jl
@@ -23,3 +23,19 @@ end
 
 _as_char(c::Char) = c
 _as_char(x) = only(string(x))
+
+#  -----------------------------------------------------------------------------
+#  Properties
+#  -----------------------------------------------------------------------------
+
+dim(d::LKJCholesky) = d.d
+
+function size(d::LKJCholesky)
+    p = dim(d)
+    return (p, p)
+end
+
+params(d::LKJCholesky) = (d.d, d.η, d.uplo)
+
+@inline partype(::LKJCholesky{T}) where {T <: Real} = T
+

--- a/src/cholesky/lkjcholesky.jl
+++ b/src/cholesky/lkjcholesky.jl
@@ -4,3 +4,22 @@ struct LKJCholesky{T <: Real, D <: Integer} <: Distribution{CholeskyVariate,Cont
     uplo::Char
     logc0::T
 end
+
+#  -----------------------------------------------------------------------------
+#  Constructors
+#  -----------------------------------------------------------------------------
+
+function LKJCholesky(d::Integer, η::Real, _uplo::Union{Char,Symbol} = 'L'; check_args = true)
+    if check_args
+        d > 0 || throw(ArgumentError("Matrix dimension must be positive."))
+        η > 0 || throw(ArgumentError("Shape parameter must be positive."))
+    end
+    logc0 = lkj_logc0(d, η)
+    uplo = _as_char(_uplo)
+    uplo ∈ ('U', 'L') || throw(ArgumentError("uplo must be 'U' or 'L'."))
+    T = Base.promote_eltype(η, logc0)
+    LKJCholesky{T, typeof(d)}(d, T(η), uplo, T(logc0))
+end
+
+_as_char(c::Char) = c
+_as_char(x) = only(string(x))

--- a/src/cholesky/lkjcholesky.jl
+++ b/src/cholesky/lkjcholesky.jl
@@ -93,8 +93,8 @@ params(d::LKJCholesky) = (d.d, d.η, d.uplo)
 #  Evaluation
 #  -----------------------------------------------------------------------------
 
-function logkernel(d::LKJCholesky, x::Cholesky)
-    factors = x.factors
+function logkernel(d::LKJCholesky, R::Cholesky)
+    factors = R.factors
     p, η = params(d)
     c = p + 2(η - 1)
     T = typeof(one(c) * log(one(eltype(factors))))
@@ -106,7 +106,7 @@ function logkernel(d::LKJCholesky, x::Cholesky)
     return logp
 end
 
-logpdf(d::LKJCholesky, x::Cholesky) = logkernel(d, x) + d.logc0
+logpdf(d::LKJCholesky, R::Cholesky) = logkernel(d, R) + d.logc0
 
 #  -----------------------------------------------------------------------------
 #  Sampling

--- a/src/cholesky/lkjcholesky.jl
+++ b/src/cholesky/lkjcholesky.jl
@@ -35,6 +35,33 @@ function size(d::LKJCholesky)
     return (p, p)
 end
 
+function insupport(d::LKJCholesky, R::Cholesky)
+    p = dim(d)
+    factors = R.factors
+    (isreal(factors) && size(factors, 1) == p) || return false
+    iinds, jinds = axes(factors)
+    T = typeof(one(eltype(R))^2)
+    # check that the diagonal of U'*U or L*L' is all ones
+    @inbounds if R.uplo === 'U'
+        for j in 1:p
+            s = zero(T)
+            for i in 1:j
+                s += factors[iinds[i], jinds[j]]^2
+            end
+            isapprox(s, 1) || return false
+        end
+    else  # R.uplo === 'L'
+        for i in 1:p
+            s = zero(T)
+            for j in 1:i
+                s += factors[iinds[i], jinds[j]]^2
+            end
+            isapprox(s, 1) || return false
+        end
+    end
+    return true
+end
+
 params(d::LKJCholesky) = (d.d, d.η, d.uplo)
 
 @inline partype(::LKJCholesky{T}) where {T <: Real} = T

--- a/src/common.jl
+++ b/src/common.jl
@@ -17,6 +17,12 @@ const Multivariate  = ArrayLikeVariate{1}
 const Matrixvariate = ArrayLikeVariate{2}
 
 """
+`F <: CholeskyVariate` specifies that the variate or a sample is of type
+`LinearAlgebra.Cholesky`.
+"""
+abstract type CholeskyVariate <: VariateForm end
+
+"""
 `S <: ValueSupport` specifies the support of sample elements,
 either discrete or continuous.
 """


### PR DESCRIPTION
This PR adds an `LKJCholesky` distribution whose support are `LinearAlgebra.Cholesky` factorizations of correlation matrices, as discussed in #1336. Essentially all of the functionality is there; I just need to add tests.