### PR TITLE
Added mle for weibull distribution

### DIFF
--- a/docs/src/fit.md
+++ b/docs/src/fit.md
@@ -53,6 +53,7 @@ The `fit_mle` method has been implemented for the following distributions:
 - [`Rayleigh`](@ref)
 - [`InverseGaussian`](@ref)
 - [`Uniform`](@ref)
+- [`Weibull`](@ref)
 
 **Multivariate:**
 

--- a/src/univariate/continuous/weibull.jl
+++ b/src/univariate/continuous/weibull.jl
@@ -156,7 +156,7 @@ function fit_mle(::Type{<:Weibull}, x::AbstractArray{<:Real};
 
     α = α0
 
-    lnx = log.(x)
+    lnx = map(log, x)
     n = length(x)
 
     while ϵ > tol && N < maxiter

--- a/src/univariate/continuous/weibull.jl
+++ b/src/univariate/continuous/weibull.jl
@@ -143,14 +143,13 @@ rand(rng::AbstractRNG, d::Weibull) = xv(d, randexp(rng))
 #### Fit model
 
 """
-    fit_mle(::Type{<:Weibull}, x::AbstractArray{T}; 
-    α0::Float64 = 1.0, maxiter::Int = 1000, tol::Float64 = 1e-16)
+    fit_mle(::Type{<:Weibull}, x::AbstractArray{<:Real}; 
+    alpha0::Real = 1, maxiter::Int = 1000, tol::Real = 1e-16)
 
-Maximum Likelihood Estimate of `Weibull` Distribution via Newton's Method
-
+Compute the maximum likelihood estimate of the [`Weibull`](@ref) distribution with Newton's method.
 """
-function fit_mle(::Type{<:Weibull}, x::AbstractArray{T};
-    α0::Float64 = 1.0, maxiter::Int = 1000, tol::Float64 = 1e-16) where T <: Real
+function fit_mle(::Type{<:Weibull}, x::AbstractArray{<:Real};
+    alpha0::Real = 1, maxiter::Int = 1000, tol::Real = 1e-16)
 
     ϵ = Inf
     N = 0

--- a/src/univariate/continuous/weibull.jl
+++ b/src/univariate/continuous/weibull.jl
@@ -156,7 +156,6 @@ function fit_mle(::Type{<:Weibull}, x::AbstractArray{<:Real};
     lnx = map(log, x)
     lnxsq = lnx.^2
     mean_lnx = mean(lnx)
-    n = length(x)
 
     # first iteration outside loop, prevents type instabililty in α, ϵ
 
@@ -167,9 +166,10 @@ function fit_mle(::Type{<:Weibull}, x::AbstractArray{<:Real};
     fx = dot_xpowlnx0 / sum_xpow0 - mean_lnx - 1 / alpha0
     ∂fx = (-dot_xpowlnx0^2 + sum_xpow0 * dot(lnxsq, xpow0)) / (sum_xpow0^2) + 1 / alpha0^2
 
-    α = alpha0 - fx / ∂fx
+    Δα = fx / ∂fx
+    α = alpha0 - Δα
 
-    ϵ = abs(α - alpha0)
+    ϵ = abs(Δα)
     N += 1
 
     while ϵ > tol && N < maxiter
@@ -181,10 +181,10 @@ function fit_mle(::Type{<:Weibull}, x::AbstractArray{<:Real};
         fx = dot_xpowlnx / sum_xpow - mean_lnx - 1 / α
         ∂fx = (-dot_xpowlnx^2 + sum_xpow * dot(lnxsq, xpow)) / (sum_xpow^2) + 1 / α^2
 
-        αold = α
-        α -= fx / ∂fx
+        Δα = fx / ∂fx
+        α -= Δα
 
-        ϵ = abs(α - αold)
+        ϵ = abs(Δα)
         N += 1
     end
 

--- a/src/univariate/continuous/weibull.jl
+++ b/src/univariate/continuous/weibull.jl
@@ -188,6 +188,6 @@ function fit_mle(::Type{<:Weibull}, x::AbstractArray{<:Real};
         N += 1
     end
 
-    θ = sum((x.^α) ./ n)^(1 / α)
+    θ = mean(x.^α)^(1 / α)
     return Weibull(α, θ)
 end

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -443,3 +443,13 @@ end
         @test all(ForwardDiff.gradient(f, x) .>= 0)
     end
 end
+
+@testset "Testing fit for Weibull" begin
+    for func in funcs, dist in (Weibull, Weibull{Float64})
+        d = fit(dist, func[2](dist(8.1, 4.3), N))
+        @test isa(d, dist)
+        @test isapprox(d.α, 8.1, atol = 0.1)
+        @test isapprox(d.θ, 4.3, atol = 0.1)
+
+    end
+end


### PR DESCRIPTION
I added an implementation that solves for the [Weibull maximum likelihood estimators](https://en.wikipedia.org/wiki/Weibull_distribution#Parameter_estimation) using newtons method. Included some basic tests as sanity checks and updated the docs.

I noticed that there was some discussion in #1267 on whether or not use a generic newtons method and wondering if that's been decided on. 

Merging this can close #702.