### PR TITLE
Fix `pdf` and `logpdf`  of `PoissonBinomial`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.3"
+version = "0.25.4"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/src/univariate/discrete/poissonbinomial.jl
+++ b/src/univariate/discrete/poissonbinomial.jl
@@ -123,15 +123,15 @@ function cf(d::PoissonBinomial, t::Real)
     end
 end
 
-pdf(d::PoissonBinomial, k::Real) = insupport(d, k) ? d.pmf[k+1] : zero(eltype(d.pmf))
+pdf(d::PoissonBinomial, k::Real) = insupport(d, k) ? d.pmf[Int(k+1)] : zero(eltype(d.pmf))
 logpdf(d::PoissonBinomial, k::Real) = log(pdf(d, k))
 
 # Computes the pdf of a poisson-binomial random variable using
 # simple, fast recursive formula
 #
-#      Marlin A. Thomas & Audrey E. Taub (1982) 
-#      Calculating binomial probabilities when the trial probabilities are unequal, 
-#      Journal of Statistical Computation and Simulation, 14:2, 125-131, DOI: 10.1080/00949658208810534 
+#      Marlin A. Thomas & Audrey E. Taub (1982)
+#      Calculating binomial probabilities when the trial probabilities are unequal,
+#      Journal of Statistical Computation and Simulation, 14:2, 125-131, DOI: 10.1080/00949658208810534
 #
 function poissonbinomial_pdf(p)
     S = zeros(eltype(p), length(p) + 1)

--- a/test/poissonbinomial.jl
+++ b/test/poissonbinomial.jl
@@ -62,8 +62,12 @@ for (p, n) in [(0.8, 6), (0.5, 10), (0.04, 20)]
         @test @inferred(quantile(d, i)) ≈ quantile(dref, i)
     end
     for i=0:n
-        @test isapprox(@inferred(cdf(d, i)), cdf(dref, i), atol=1e-15)
-        @test isapprox(@inferred(pdf(d, i)), pdf(dref, i), atol=1e-15)
+        @test @inferred(cdf(d, i)) ≈ cdf(dref, i) atol=1e-15
+        @test @inferred(cdf(d, i//1)) ≈ cdf(dref, i) atol=1e-15
+        @test @inferred(pdf(d, i)) ≈ pdf(dref, i) atol=1e-15
+        @test @inferred(pdf(d, i//1)) ≈ pdf(dref, i) atol=1e-15
+        @test @inferred(logpdf(d, i)) ≈ logpdf(dref, i)
+        @test @inferred(logpdf(d, i//1)) ≈ logpdf(dref, i)
     end
 
 end
@@ -105,7 +109,10 @@ for (n₁, n₂, n₃, p₁, p₂, p₃) in [(10, 10, 10, 0.1, 0.5, 0.9),
             end
             m += pmf1[i+1] * mc
         end
-        @test isapprox(@inferred(pdf(d, k)), m, atol=1e-15)
+        @test @inferred(pdf(d, k)) ≈ m atol=1e-15
+        @test @inferred(pdf(d, k//1)) ≈ m atol=1e-15
+        @test @inferred(logpdf(d, k)) ≈ log(m)
+        @test @inferred(logpdf(d, k//1)) ≈ log(m)
     end
 end
 


### PR DESCRIPTION
Fixes evaluation of `pdf` and `logpdf` of `PoissonBinomial` with non-integer values (e.g. `Rational`s).

This came up in https://github.com/devmotion/InferenceDiagnostics.jl/pull/7.