### PR TITLE
Fix support of `Dirac` and `LocationScale`

### DIFF
--- a/src/univariate/discrete/dirac.jl
+++ b/src/univariate/discrete/dirac.jl
@@ -27,9 +27,9 @@ Base.eltype(::Type{Dirac{T}}) where {T} = T
 insupport(d::Dirac, x::Real) = x == d.value
 minimum(d::Dirac) = d.value
 maximum(d::Dirac) = d.value
+support(d::Dirac) = (d.value,)
 
 #### Properties
-
 mean(d::Dirac) = d.value
 var(d::Dirac{T}) where {T} = zero(T)
 

--- a/src/univariate/discrete/dirac.jl
+++ b/src/univariate/discrete/dirac.jl
@@ -43,6 +43,7 @@ pdf(d::Dirac, x::Real) = insupport(d, x) ? 1.0 : 0.0
 logpdf(d::Dirac, x::Real) = insupport(d, x) ? 0.0 : -Inf
 
 cdf(d::Dirac, x::Real) = x < d.value ? 0.0 : 1.0
+cdf(d::Dirac, x::Integer) = x < d.value ? 0.0 : 1.0
 
 quantile(d::Dirac{T}, p::Real) where {T} = 0 <= p <= 1 ? d.value : T(NaN)
 

--- a/src/univariate/locationscale.jl
+++ b/src/univariate/locationscale.jl
@@ -60,6 +60,11 @@ Base.eltype(::Type{<:LocationScale{T}}) where T = T
 
 minimum(d::LocationScale) = d.μ + d.σ * minimum(d.ρ)
 maximum(d::LocationScale) = d.μ + d.σ * maximum(d.ρ)
+support(d::LocationScale) = locationscale_support(d.μ, d.σ, support(d.ρ))
+function locationscale_support(μ::Real, σ::Real, support::RealInterval)
+    return RealInterval(μ + σ * support.lb, μ + σ * support.ub)
+end
+locationscale_support(μ::Real, σ::Real, support) = μ .+ σ .* support
 
 LocationScale(μ::Real, σ::Real, d::LocationScale) = LocationScale(μ + d.μ * σ, σ * d.σ, d.ρ)
 

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -1,16 +1,16 @@
 #### Domain && Support
 
-struct RealInterval
-    lb::Float64
-    ub::Float64
-
-    RealInterval(lb::Real, ub::Real) = new(Float64(lb), Float64(ub))
+struct RealInterval{T<:Real}
+    lb::T
+    ub::T
 end
+
+RealInterval(lb::Real, ub::Real) = RealInterval(promote(lb, ub)...)
 
 minimum(r::RealInterval) = r.lb
 maximum(r::RealInterval) = r.ub
 extrema(r::RealInterval) = (r.lb, r.ub)
-in(x::Real, r::RealInterval) = (r.lb <= Float64(x) <= r.ub)
+in(x::Real, r::RealInterval) = r.lb <= x <= r.ub
 
 isbounded(d::Union{D,Type{D}}) where {D<:UnivariateDistribution} = isupperbounded(d) && islowerbounded(d)
 

--- a/test/dirac.jl
+++ b/test/dirac.jl
@@ -2,7 +2,7 @@ using Distributions
 using Test
 
 @testset "Dirac tests" begin
-    for val in [3, 3.0, -3.5]
+    for val in (3, 3.0, -3.5)
         d = Dirac(val)
 
         @test minimum(d) == val

--- a/test/dirac.jl
+++ b/test/dirac.jl
@@ -7,22 +7,22 @@ using Test
 
         @test minimum(d) == val
         @test maximum(d) == val
-        @test !insupport(d, prevfloat(val))
+        @test !insupport(d, prevfloat(float(val)))
         @test insupport(d, val)
-        @test !insupport(d, nextfloat(val))
+        @test !insupport(d, nextfloat(float(val)))
         @test support(d) == (val,)
 
-        @test iszero(pdf(d, prevfloat(val)))
+        @test iszero(pdf(d, prevfloat(float(val))))
         @test isone(pdf(d, val))
-        @test iszero(pdf(d, nextfloat(val)))
+        @test iszero(pdf(d, nextfloat(float(val))))
 
-        @test logpdf(d, prevfloat(val)) == -Inf
+        @test logpdf(d, prevfloat(float(val))) == -Inf
         @test iszero(logpdf(d, val))
-        @test logpdf(d, nextfloat(val)) == -Inf
+        @test logpdf(d, nextfloat(float(val))) == -Inf
 
-        @test iszero(cdf(d, prevfloat(val)))
+        @test iszero(cdf(d, prevfloat(float(val))))
         @test isone(cdf(d, val))
-        @test isone(cdf(d, nextfloat(val)))
+        @test isone(cdf(d, nextfloat(float(val))))
 
         @test quantile(d, 0) == val
         @test quantile(d, 0.5) == val

--- a/test/dirac.jl
+++ b/test/dirac.jl
@@ -10,6 +10,7 @@ using Test
         @test !insupport(d, prevfloat(val))
         @test insupport(d, val)
         @test !insupport(d, nextfloat(val))
+        @test support(d) == (val,)
 
         @test iszero(pdf(d, prevfloat(val)))
         @test isone(pdf(d, val))

--- a/test/locationscale.jl
+++ b/test/locationscale.jl
@@ -31,6 +31,12 @@ function test_location_scale(
             @test minimum(d) == minimum(dref)
             @test maximum(d) == maximum(dref)
             @test extrema(d) == (minimum(d), maximum(d))
+            @test extrema(support(d)) == extrema(d)
+            if support(d.ρ) isa RealInterval
+                @test support(d) isa RealInterval
+            elseif hasfinitesupport(d.ρ)
+                @test support(d) == d.μ .+ d.σ .* support(d.ρ)
+            end
         end
         @testset "$k" for (k,dtest) in d_dict
             test_support(dtest, dref)
@@ -61,12 +67,15 @@ function test_location_scale(
 
             @test var(d) ≈ var(dref)
             @test std(d) ≈ std(dref)
-            @test skewness(d) ≈ skewness(dref)
-            @test kurtosis(d) ≈ kurtosis(dref)
 
-            @test isplatykurtic(d) == isplatykurtic(dref)
-            @test isleptokurtic(d) == isleptokurtic(dref)
-            @test ismesokurtic(d) == ismesokurtic(dref)
+            if !(dref isa Dirac)
+                @test skewness(d) ≈ skewness(dref)
+                @test kurtosis(d) ≈ kurtosis(dref)
+
+                @test isplatykurtic(d) == isplatykurtic(dref)
+                @test isleptokurtic(d) == isleptokurtic(dref)
+                @test ismesokurtic(d) == ismesokurtic(dref)
+            end
 
             @test entropy(d) ≈ entropy(dref)
             @test mgf(d,-0.1) ≈ mgf(dref,-0.1)
@@ -150,6 +159,14 @@ function test_location_scale_discretenonparametric(
     return test_location_scale(rng, μ, σ, ρ, dref)
 end
 
+function test_location_scale_dirac(
+    rng::Union{AbstractRNG, Missing}, μ::Real, σ::Real, support,
+)
+    ρ = Dirac(support)
+    dref = Dirac(μ + σ * support)
+    return test_location_scale(rng, μ, σ, ρ, dref)
+end
+
 @testset "LocationScale" begin
     rng = MersenneTwister(123)
 
@@ -165,5 +182,11 @@ end
         test_location_scale_discretenonparametric(_rng, 1//3, 1//2, 1:10, probs)
         test_location_scale_discretenonparametric(_rng, -1//4, 1//3, (-10):(-1), probs)
         test_location_scale_discretenonparametric(_rng, 6//5, 3//2, 15:24, probs)
+    end
+
+    for _rng in (missing, rng)
+        test_location_scale_dirac(_rng, 1//3, 1//2, 1)
+        test_location_scale_dirac(_rng, -1//4, 1//3, 2)
+        test_location_scale_dirac(_rng, 6//5, 3//2, 3)
     end
 end

--- a/test/locationscale.jl
+++ b/test/locationscale.jl
@@ -68,14 +68,12 @@ function test_location_scale(
             @test var(d) ≈ var(dref)
             @test std(d) ≈ std(dref)
 
-            if !(dref isa Dirac)
-                @test skewness(d) ≈ skewness(dref)
-                @test kurtosis(d) ≈ kurtosis(dref)
+            @test skewness(d) ≈ skewness(dref)
+            @test kurtosis(d) ≈ kurtosis(dref)
 
-                @test isplatykurtic(d) == isplatykurtic(dref)
-                @test isleptokurtic(d) == isleptokurtic(dref)
-                @test ismesokurtic(d) == ismesokurtic(dref)
-            end
+            @test isplatykurtic(d) == isplatykurtic(dref)
+            @test isleptokurtic(d) == isleptokurtic(dref)
+            @test ismesokurtic(d) == ismesokurtic(dref)
 
             @test entropy(d) ≈ entropy(dref)
             @test mgf(d,-0.1) ≈ mgf(dref,-0.1)
@@ -159,14 +157,6 @@ function test_location_scale_discretenonparametric(
     return test_location_scale(rng, μ, σ, ρ, dref)
 end
 
-function test_location_scale_dirac(
-    rng::Union{AbstractRNG, Missing}, μ::Real, σ::Real, support,
-)
-    ρ = Dirac(support)
-    dref = Dirac(μ + σ * support)
-    return test_location_scale(rng, μ, σ, ρ, dref)
-end
-
 @testset "LocationScale" begin
     rng = MersenneTwister(123)
 
@@ -182,11 +172,5 @@ end
         test_location_scale_discretenonparametric(_rng, 1//3, 1//2, 1:10, probs)
         test_location_scale_discretenonparametric(_rng, -1//4, 1//3, (-10):(-1), probs)
         test_location_scale_discretenonparametric(_rng, 6//5, 3//2, 15:24, probs)
-    end
-
-    for _rng in (missing, rng)
-        test_location_scale_dirac(_rng, 1//3, 1//2, 1)
-        test_location_scale_dirac(_rng, -1//4, 1//3, 2)
-        test_location_scale_dirac(_rng, 6//5, 3//2, 3)
     end
 end


### PR DESCRIPTION
This PR fixes the support of `Dirac` and `LocationScale`.

Currently:
```julia
julia> d = LocationScale(1//2, 1//3, Categorical([0.2, 0.8]));

julia> support(d)
1:1

julia> d = Dirac(3.4);

julia> support(d)
3:3
```

With this PR:
```julia
julia> d = LocationScale(1//2, 1//3, Categorical([0.2, 0.8]));

julia> support(d)
5//6:1//3:7//6

julia> d = Dirac(3.4)
Dirac{Float64}(value=3.4)

julia> support(d)
(3.4,)
```