### PR TITLE
faster rand generation for Chisq with 1, 3 and 4 df

### DIFF
--- a/src/samplers/gamma.jl
+++ b/src/samplers/gamma.jl
@@ -210,6 +210,21 @@ function rand(rng::AbstractRNG, s::GammaIPSampler)
     x*exp(s.nia*e)
 end
 
+struct ChisqNaiveSampler{T<:Real} <: Sampleable{Univariate,Continuous}
+    ν::T
+end
+function rand(rng::AbstractRNG, s::ChisqNaiveSampler)
+    ν = s.ν
+    if ν == 1.0
+        randn(rng) ^ 2
+    elseif ν == 3.0
+        randn(rng) ^ 2 + randn(rng) ^ 2 + randn(rng) ^ 2
+    elseif ν == 4.0
+        randn(rng) ^ 2 + randn(rng) ^ 2 + randn(rng) ^ 2 + randn(rng) ^ 2
+    end
+end
+
+
 # function sampler(d::Gamma)
 #     if d.shape < 1.0
 #         # TODO: d.shape = 0.5 : use scaled chisq

--- a/src/univariate/continuous/gamma.jl
+++ b/src/univariate/continuous/gamma.jl
@@ -88,7 +88,9 @@ gradlogpdf(d::Gamma{T}, x::Real) where {T<:Real} =
     insupport(Gamma, x) ? (d.α - 1) / x - 1 / d.θ : zero(T)
 
 function rand(rng::AbstractRNG, d::Gamma)
-    if shape(d) < 1.0
+    if scale(d) == 2.0 && shape(d) ∈ (1.0/2.0,3.0/2.0,4.0/2.0)
+        return rand(rng, ChisqNaiveSampler(shape(d) * 2.0))
+    elseif shape(d) < 1.0
         # TODO: shape(d) = 0.5 : use scaled chisq
         return rand(rng, GammaIPSampler(d))
     elseif shape(d) == 1.0
@@ -99,7 +101,9 @@ function rand(rng::AbstractRNG, d::Gamma)
 end
 
 function sampler(d::Gamma)
-    if shape(d) < 1.0
+    if scale(d) == 2.0 && shape(d) ∈ (1.0/2.0,3.0/2.0,4.0/2.0)
+        return ChisqNaiveSampler(shape(d) * 2.0)
+    elseif shape(d) < 1.0
         # TODO: shape(d) = 0.5 : use scaled chisq
         return GammaIPSampler(d)
     elseif shape(d) == 1.0


### PR DESCRIPTION
This PR uses direct relation between Chisq and Normal to generate random numbers. It improves the performance of generating random numbers for some distributions:

main

```julia
julia> @btime rand(Chisq(1),10^6);
  52.115 ms (2 allocations: 7.63 MiB)

julia> @btime rand(TDist(1),10^6);
  73.850 ms (2 allocations: 7.63 MiB)

julia> @btime rand(TDist(2),10^6);
  17.767 ms (2 allocations: 7.63 MiB)

julia> @btime rand(TDist(3),10^6);
  51.120 ms (2 allocations: 7.63 MiB)

julia> @btime rand(TDist(4),10^6);
  50.623 ms (2 allocations: 7.63 MiB)
```

this PR

```julia
julia> @btime rand(Chisq(1), 10^6);
  8.227 ms (3 allocations: 7.63 MiB)

julia> @btime rand(TDist(1),10^6);
  25.911 ms (2 allocations: 7.63 MiB)

julia> @btime rand(TDist(2),10^6);
  22.226 ms (2 allocations: 7.63 MiB)

julia> @btime rand(TDist(3),10^6);
  35.325 ms (2 allocations: 7.63 MiB)

julia> @btime rand(TDist(4),10^6);
  39.573 ms (2 allocations: 7.63 MiB)
```