### PR TITLE
Fix `rand(Uniform{Float32})`

### DIFF
--- a/src/univariate/continuous/uniform.jl
+++ b/src/univariate/continuous/uniform.jl
@@ -109,7 +109,7 @@ end
 
 #### Sampling
 
-rand(rng::AbstractRNG, d::Uniform) = d.a + (d.b - d.a) * rand(rng)
+rand(rng::AbstractRNG, d::Uniform{T}) where {T <: Real} = d.a + (d.b - d.a) * rand(rng, T)
 
 rand!(rng::AbstractRNG, d::Uniform, A::AbstractArray) =
     A .= quantile.(d, rand!(rng, A))


### PR DESCRIPTION
generate random numbers using the type of the distribution.