### PR TITLE
Re-export from LinearAlgebra and FillArrays

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -29,6 +29,13 @@ export
     # re-export Statistics
     mean, median, quantile, std, var, cov, cor,
 
+    # re-export from LinearAlgebra
+    Diagonal,
+    I,
+
+    # re-export from FillArrays
+    Fill,
+
     # generic types
     VariateForm,
     ArrayLikeVariate,


### PR DESCRIPTION
Deprecations introduced in #1362 suggest alternatives that use the following:
- `LinearAlgebra.Diagonal`
- `LinearAlgebra.I`
- `FillArrays.Fill`

It seems like these should then also be re-exported, in particular since Distributions.jl is a package that is often used by Julia beginners who might not be aware of where the above can be found.