### PR TITLE
Add `quantile` for `UnivariateMixture`

### DIFF
--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -219,6 +219,26 @@ function var(d::UnivariateMixture)
     return v
 end
 
+"""
+    quantile(d::UnivariateMixture, p::Real; tol=1e-12)
+
+Compute `p`th quantile of a `UnivariateMixture`.
+"""
+function quantile(d::UnivariateMixture, p::Real; tol=1e-12)
+    # The quantile of the mixture is
+    # greater than the smallest quantile of its components (`x_left`)
+    # and less than the greatest quantile of its components (`x_right`)
+    components_quantiles = [
+        quantile(c, p)
+        for c ∈ components(d)
+    ]
+    x_left = minimum(components_quantiles)
+    x_right = maximum(components_quantiles)
+	
+    # Search for the quantile ∀x ∈ [x_left, x_right]
+	quantile_bisect(d, p, x_left, x_right, tol)
+end
+
 function var(d::MultivariateMixture)
     return diag(cov(d))
 end

--- a/test/mixture.jl
+++ b/test/mixture.jl
@@ -42,6 +42,12 @@ function test_mixture(g::UnivariateMixture, n::Int, ns::Int,
     end
     @test cdf.(g, X) ≈ cf
 
+    # quantiles
+    for i = 1:n
+        @test @inferred(quantile(g, cf[i])) ≈ X[i]
+    end
+    @test quantile.(g, cf) ≈ X
+
     # evaluation
     P0 = zeros(T, n, K)
     LP0 = zeros(T, n, K)


### PR DESCRIPTION
Added the `quantile` function for `UnivariateMixture`s using `quantile_bisect`. Inspired by [this blog post](http://www.awebb.info/probability/2017/05/12/quantiles-of-mixture-distributions.html).