### PR TITLE
Fix the numerical instability in `Truncated`.

### DIFF
--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -25,8 +25,11 @@ function truncated(d::UnivariateDistribution, l::T, u::T) where {T <: Real}
     T2 = promote_type(T, eltype(d))
     lcdf = isinf(l) ? zero(T2) : T2(cdf(d, l))
     ucdf = isinf(u) ? one(T2) : T2(cdf(d, u))
-    tp = ucdf - lcdf
-    Truncated(d, promote(l, u, lcdf, ucdf, tp, log(tp))...)
+    logcdf_l = isinf(l) ? T2(-Inf) : T2(logcdf(d, l))
+    logcdf_u = isinf(u) ? zero(T2) : T2(logcdf(d, u))
+    log_tp = logsubexp(logcdf_l, logcdf_u)
+    tp = exp(log_tp)
+    Truncated(d, promote(l, u, lcdf, ucdf, tp, log_tp)...)
 end
 
 truncated(d::UnivariateDistribution, l::Integer, u::Integer) = truncated(d, float(l), float(u))
@@ -59,12 +62,7 @@ end
 
 ### Constructors
 function Truncated(d::UnivariateDistribution, l::T, u::T) where {T <: Real}
-    l < u || error("lower bound should be less than upper bound.")
-    T2 = promote_type(T, eltype(d))
-    lcdf = isinf(l) ? zero(T2) : T2(cdf(d, l))
-    ucdf = isinf(u) ? one(T2) : T2(cdf(d, u))
-    tp = ucdf - lcdf
-    Truncated(d, promote(l, u, lcdf, ucdf, tp, log(tp))...)
+    truncated(d, l, u)
 end
 
 Truncated(d::UnivariateDistribution, l::Integer, u::Integer) = Truncated(d, float(l), float(u))

--- a/test/truncnormal.jl
+++ b/test/truncnormal.jl
@@ -41,3 +41,13 @@ end
         @test abs(var(X) - var(trunc)) < 0.01
     end
 end
+
+@testset "Truncated normal should be numerically stable at probability regions" begin
+    original = Normal(-5.0, 0.2)
+    test_point = 0.5
+    trunc = truncated(original, 0.0, 5.0)
+    for x in LinRange(0.0, 5.0, 100)
+        @test isfinite(logpdf(original, test_point))
+        @test isfinite(logpdf(trunc, test_point))
+    end
+end


### PR DESCRIPTION
The current constructor for Truncated is not numerically stable, for example, 
```julia
original = Normal(-5.0, 0.2)
trunc = truncated(original, 0.0, 5.0)
test_point = 0.5
logpdf(trunc, test_point)  # returns Inf!
```
This is because the constructor directly performs the computation using probabilities instead of log probabilities:
```julia
function truncated(d::UnivariateDistribution, l::T, u::T) where {T <: Real}
    l < u || error("lower bound should be less than upper bound.")
    T2 = promote_type(T, eltype(d))
    lcdf = isinf(l) ? zero(T2) : T2(cdf(d, l))
    ucdf = isinf(u) ? one(T2) : T2(cdf(d, u))
    tp = ucdf - lcdf
    Truncated(d, promote(l, u, lcdf, ucdf, tp, log(tp))...)
end
```

This pull request fixes this issue by using `logcdf` and the numerically stable operation `logsubexp`.