### PR TITLE
Add ChainRules definitions for pdf of `PoissonBinomial`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["JuliaStats"]
 version = "0.25.14"
 
 [deps]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150"
@@ -17,6 +18,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 
 [compat]
+ChainRulesCore = "1"
 FillArrays = "0.9, 0.10, 0.11, 0.12"
 PDMats = "0.10, 0.11"
 QuadGK = "2"
@@ -27,6 +29,7 @@ julia = "1"
 
 [extras]
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
+ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -36,4 +39,4 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["StableRNGs", "Calculus", "Distributed", "FiniteDifferences", "ForwardDiff", "JSON", "StaticArrays", "Test"]
+test = ["StableRNGs", "Calculus", "ChainRulesTestUtils", "Distributed", "FiniteDifferences", "ForwardDiff", "JSON", "StaticArrays", "Test"]

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -25,6 +25,8 @@ import PDMats: dim, PDMat, invquad
 
 using SpecialFunctions
 
+import ChainRulesCore
+
 export
     # re-export Statistics
     mean, median, quantile, std, var, cov, cor,

--- a/test/poissonbinomial.jl
+++ b/test/poissonbinomial.jl
@@ -153,7 +153,9 @@ end
     @test isapprox(ForwardDiff.gradient(f, at), fdm(f, at), atol=1e-6)
 
     # Test ChainRules definition
-    test_rrule(Distributions.poissonbinomial_pdf_fft, rand(50))
-    test_rrule(Distributions.poissonbinomial_pdf, rand(50))
+    for f in (Distributions.poissonbinomial_pdf, Distributions.poissonbinomial_pdf_fft)
+        test_frule(f, rand(50))
+        test_rrule(f, rand(50))
+    end
 end
 end

--- a/test/poissonbinomial.jl
+++ b/test/poissonbinomial.jl
@@ -1,4 +1,5 @@
 using Distributions
+using ChainRulesTestUtils
 using ForwardDiff
 using Test
 
@@ -145,8 +146,14 @@ end
     @test x ≈ fftw_fft
 end
 
-# Test autodiff using ForwardDiff
-f = x -> logpdf(PoissonBinomial(x), 0)
-at = [0.5, 0.5]
-@test isapprox(ForwardDiff.gradient(f, at), fdm(f, at), atol=1e-6)
+@testset "automatic differentiation" begin
+    # Test autodiff using ForwardDiff
+    f = x -> logpdf(PoissonBinomial(x), 0)
+    at = [0.5, 0.5]
+    @test isapprox(ForwardDiff.gradient(f, at), fdm(f, at), atol=1e-6)
+
+    # Test ChainRules definition
+    test_rrule(Distributions.poissonbinomial_pdf_fft, rand(50))
+    test_rrule(Distributions.poissonbinomial_pdf, rand(50))
+end
 end


### PR DESCRIPTION
I am in the process of updating DistributionsAD to ChainRules 1. I thought it would be a good opportunity to reduce the amount of type piracy and move rules for functions in Distributions here. Currently, there's only one such rule in DistributionsAD. It defines the pullback for the pdf of the `PoissonBinomial` distribution, so the PR adds and tests only this rule.

ChainRulesCore 1 is a very lightweight package (see [@oxinabox's comment](https://github.com/JuliaStats/StatsFuns.jl/pull/106#issuecomment-905063473) for more details) and Distributions already depends on ChainRulesCore indirectly via SpecialFunctions and StatsFuns (support for ChainRules was added in version 0.9.10 which was released today). DistributionsAD does not support ChainRulesCore 1 yet, so the definitions in Distributions won't lead to any conflicts with DistributionsAD if we remove the `rrule`s in DistributionsAD before we tag a CR1-compatible release.

The implementation is based on the same dynamic programming "trick" as the implementation of `poissonbinomial_pdf`. I didn't find any reference for it, I only derived it a while ago and added it to DistributionsAD. However, I am pretty confident that the ChainRules tests utilities would have revealed any errors.

/ cc: @bdeonovic who added the primal definition in https://github.com/JuliaStats/Distributions.jl/pull/1198