### PR TITLE
Document NormalCanon parametrisation in docstring

### DIFF
--- a/src/univariate/continuous/normalcanon.jl
+++ b/src/univariate/continuous/normalcanon.jl
@@ -1,9 +1,10 @@
 """
     NormalCanon(η, λ)
 
-The canonical form of the normal distribution, which is an [exponential family distribution](http://en.wikipedia.org/wiki/Exponential_family).
-The two *canonical parameters* are ``\\eta = \\sigma^{-1} \\mu`` and ``\\lambda = \\sigma^{-1}``,
-where ``\\mu`` is the mean and ``\\sigma`` is the standard deviation.
+Canonical parametrisation of the Normal distribution with canonical parameters `η` and `λ`.
+
+The two *canonical parameters* of a normal distribution ``\\mathcal{N}(\\mu, \\sigma^2)`` with mean ``\\mu`` and
+standard deviation ``\\sigma`` are ``\\eta = \\sigma^{-2} \\mu`` and ``\\lambda = \\sigma^{-2}``.
 """
 struct NormalCanon{T<:Real} <: ContinuousUnivariateDistribution
     η::T       # σ^(-2) * μ

--- a/src/univariate/continuous/normalcanon.jl
+++ b/src/univariate/continuous/normalcanon.jl
@@ -1,7 +1,9 @@
 """
     NormalCanon(η, λ)
 
-Canonical Form of Normal distribution
+The canonical form of the normal distribution, which is an [exponential family distribution](http://en.wikipedia.org/wiki/Exponential_family).
+The two *canonical parameters* are ``\\eta = \\sigma^{-1} \\mu`` and ``\\lambda = \\sigma^{-1}``,
+where ``\\mu`` is the mean and ``\\sigma`` is the standard deviation.
 """
 struct NormalCanon{T<:Real} <: ContinuousUnivariateDistribution
     η::T       # σ^(-2) * μ


### PR DESCRIPTION
To allow users to quickly check the definition of `NormalCanon` from the REPL.