### PR TITLE
`meanform(::NormalCanon)`

### DIFF
--- a/src/univariate/continuous/normalcanon.jl
+++ b/src/univariate/continuous/normalcanon.jl
@@ -32,6 +32,7 @@ convert(::Type{NormalCanon{T}}, d::NormalCanon{S}) where {T <: Real, S <: Real} 
 
 convert(::Type{Normal}, d::NormalCanon) = Normal(d.μ, 1 / sqrt(d.λ))
 convert(::Type{NormalCanon}, d::Normal) = (λ = 1 / d.σ^2; NormalCanon(λ * d.μ, λ))
+meanform(d::NormalCanon) = convert(Normal, d)
 canonform(d::Normal) = convert(NormalCanon, d)
 
 

--- a/test/normal.jl
+++ b/test/normal.jl
@@ -172,3 +172,12 @@ end
     @test rand(d, 10) isa Vector{Float64}
     @test rand(d, (3, 2)) isa Matrix{Float64}
 end
+
+@testset "NormalCanon and conversion" begin
+    @test canonform(Normal()) == NormalCanon()
+    @test meanform(NormalCanon()) == Normal()
+    @test meanform(canonform(Normal(0.25, 0.7))) ≈ Normal(0.25, 0.7)
+    @test convert(NormalCanon, convert(Normal, NormalCanon(0.3, 0.8))) ≈ NormalCanon(0.3, 0.8)
+    @test mean(canonform(Normal(0.25, 0.7))) ≈ 0.25
+    @test std(canonform(Normal(0.25, 0.7))) ≈ 0.7
+end


### PR DESCRIPTION
just as there are `canonform(::Normal)` as well as `meanform(::MvNormalCanon)` and `canonform(::MvNormal)`.