### PR TITLE
Improve `pdf`, `logpdf`, `cdf`, and `ccdf` of `Uniform`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.20"
+version = "0.25.21"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/univariate/continuous/uniform.jl
+++ b/src/univariate/continuous/uniform.jl
@@ -70,20 +70,23 @@ entropy(d::Uniform) = log(d.b - d.a)
 
 #### Evaluation
 
-pdf(d::Uniform{T}, x::Real) where {T<:Real} = insupport(d, x) ? 1 / (d.b - d.a) : zero(T)
-logpdf(d::Uniform{T}, x::Real) where {T<:Real} = insupport(d, x) ? -log(d.b - d.a) : -T(Inf)
+function pdf(d::Uniform, x::Real)
+    val = inv(d.b - d.a)
+    return insupport(d, x) ? val : zero(val)
+end
+function logpdf(d::Uniform, x::Real)
+    diff = d.b - d.a
+    return insupport(d, x) ? -log(diff) : log(zero(diff))
+end
 gradlogpdf(d::Uniform{T}, x::Real) where {T<:Real} = zero(T)
 
-function cdf(d::Uniform{T}, x::Real) where T<:Real
-    (a, b) = params(d)
-    x <= a ? zero(T) :
-    x >= d.b ? one(T) : (x - a) / (b - a)
+function cdf(d::Uniform, x::Real)
+    a, b = params(d)
+    return clamp((x - a) / (b - a), 0, 1)
 end
-
-function ccdf(d::Uniform{T}, x::Real) where T<:Real
-    (a, b) = params(d)
-    x <= a ? one(T) :
-    x >= d.b ? zero(T) : (b - x) / (b - a)
+function ccdf(d::Uniform, x::Real)
+    a, b = params(d)
+    return clamp((b - x) / (b - a), 0, 1)
 end
 
 quantile(d::Uniform, p::Real) = d.a + p * (d.b - d.a)

--- a/test/univariates.jl
+++ b/test/univariates.jl
@@ -175,3 +175,27 @@ end
     @test invlogcdf(d, log(0.2)) isa Int
     @test invlogccdf(d, log(0.6)) isa Int
 end
+
+@testset "Uniform type inference" begin
+    for T in (Int, Float32)
+        d = Uniform{T}(T(2), T(3))
+        FT = float(T)
+        XFT = promote_type(FT, Float64)
+
+        @test @inferred(pdf(d, 1.5)) === zero(FT)
+        @test @inferred(pdf(d, 2.5)) === one(FT)
+        @test @inferred(pdf(d, 3.5)) === zero(FT)
+
+        @test @inferred(logpdf(d, 1.5)) === FT(-Inf)
+        @test @inferred(logpdf(d, 2.5)) === -zero(FT) # negative zero
+        @test @inferred(logpdf(d, 3.5)) === FT(-Inf)
+
+        @test @inferred(cdf(d, 1.5)) === zero(XFT)
+        @test @inferred(cdf(d, 2.5)) === XFT(1//2)
+        @test @inferred(cdf(d, 3.5)) === one(XFT)
+
+        @test @inferred(ccdf(d, 1.5)) === one(XFT)
+        @test @inferred(ccdf(d, 2.5)) === XFT(1//2)
+        @test @inferred(ccdf(d, 3.5)) === zero(XFT)
+    end
+end


### PR DESCRIPTION
Currently, these functions for `Uniform` have type stability issues or just error:
```julia
julia> using Distributions, Test

julia> @inferred pdf(Uniform{Int}(0, 1), 0.5)
ERROR: return type Float64 does not match inferred return type Union{Float64, Int64}
...

julia> @inferred logpdf(Uniform{Int}(0, 1), 3)
ERROR: InexactError: Int64(Inf)
...

julia> @inferred cdf(Uniform(0f0, 1f0), 0.5)
ERROR: return type Float64 does not match inferred return type Union{Float32, Float64}
...

julia> @inferred ccdf(Uniform(0f0, 1f0), 0.5)
ERROR: return type Float64 does not match inferred return type Union{Float32, Float64}
...
```
The PR fixes these problems.