### PR TITLE
MvNormal Test Suite inside src

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.25"
+version = "0.25.26"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 ChainRulesCore = "1"

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -304,6 +304,9 @@ include("mixtures/unigmm.jl")
 # Implementation of DensityInterface API
 include("density_interface.jl")
 
+# Testing utilities for other packages which implement distributions.
+include("test_utils.jl")
+
 include("deprecates.jl")
 
 """

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -5,6 +5,13 @@ using LinearAlgebra
 using Random
 using Test
 
+
+__rand(::Nothing, args...) = rand(args...)
+__rand(rng::AbstractRNG, args...) = rand(rng, args...)
+
+__rand!(::Nothing, args...) = rand!(args...)
+__rand!(rng::AbstractRNG, args...) = rand!(rng, args...)
+
 """
     test_mvnormal(
         g::AbstractMvNormal, n_tsamples::Int=10^6, rng::AbstractRNG=Random.GLOBAL_RNG
@@ -13,7 +20,7 @@ using Test
 Test that `AbstractMvNormal` implements the expected API.
 """
 function test_mvnormal(
-    g::AbstractMvNormal, n_tsamples::Int=10^6, rng::AbstractRNG=Random.GLOBAL_RNG
+    g::AbstractMvNormal, n_tsamples::Int=10^6, rng::Union{AbstractRNG, Nothing}=nothing
 )
     d = length(g)
     μ = mean(g)
@@ -33,12 +40,12 @@ function test_mvnormal(
     @test isless(extrema(g)...)
 
     # test sampling for AbstractMatrix (here, a SubArray):
-    subX = view(rand(rng, d, 2d), :, 1:d)
-    @test isa(rand!(rng, g, subX), SubArray)
+    subX = view(__rand(rng, d, 2d), :, 1:d)
+    @test isa(__rand!(rng, g, subX), SubArray)
 
     # sampling
-    @test isa(rand(rng, g), Vector{Float64})
-    X = rand(rng, g, n_tsamples)
+    @test isa(__rand(rng, g), Vector{Float64})
+    X = __rand(rng, g, n_tsamples)
     emp_mu = vec(mean(X, dims=2))
     Z = X .- emp_mu
     emp_cov = (Z * Z') * inv(n_tsamples)

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1,0 +1,89 @@
+module TestUtils
+
+using Distributions
+using LinearAlgebra
+using Random
+using Test
+
+"""
+    test_mvnormal(
+        g::AbstractMvNormal, n_tsamples::Int=10^6, rng::AbstractRNG=Random.GLOBAL_RNG
+    )
+
+Test that `AbstractMvNormal` implements the expected API.
+"""
+function test_mvnormal(
+    g::AbstractMvNormal, n_tsamples::Int=10^6, rng::AbstractRNG=Random.GLOBAL_RNG
+)
+    d = length(g)
+    μ = mean(g)
+    Σ = cov(g)
+    @test length(μ) == d
+    @test size(Σ) == (d, d)
+    @test var(g) ≈ diag(Σ)
+    @test entropy(g) ≈ 0.5 * logdet(2π * ℯ * Σ)
+    ldcov = logdetcov(g)
+    @test ldcov ≈ logdet(Σ)
+    vs = diag(Σ)
+    @test g == typeof(g)(params(g)...)
+    @test g == deepcopy(g)
+    @test minimum(g) == fill(-Inf, d)
+    @test maximum(g) == fill(Inf, d)
+    @test extrema(g) == (minimum(g), maximum(g))
+    @test isless(extrema(g)...)
+
+    # test sampling for AbstractMatrix (here, a SubArray):
+    subX = view(rand(rng, d, 2d), :, 1:d)
+    @test isa(rand!(rng, g, subX), SubArray)
+
+    # sampling
+    @test isa(rand(rng, g), Vector{Float64})
+    X = rand(rng, g, n_tsamples)
+    emp_mu = vec(mean(X, dims=2))
+    Z = X .- emp_mu
+    emp_cov = (Z * Z') * inv(n_tsamples)
+
+    mean_atols = 8 .* sqrt.(vs ./ n_tsamples)
+    cov_atols = 10 .* sqrt.(vs .* vs') ./ sqrt.(n_tsamples)
+    for i = 1:d
+        @test isapprox(emp_mu[i], μ[i], atol=mean_atols[i])
+    end
+    for i = 1:d, j = 1:d
+        @test isapprox(emp_cov[i,j], Σ[i,j], atol=cov_atols[i,j])
+    end
+
+    X = rand(MersenneTwister(14), g, n_tsamples)
+    Y = rand(MersenneTwister(14), g, n_tsamples)
+    @test X == Y
+    emp_mu = vec(mean(X, dims=2))
+    Z = X .- emp_mu
+    emp_cov = (Z * Z') * inv(n_tsamples)
+    for i = 1:d
+        @test isapprox(emp_mu[i]   , μ[i]  , atol=mean_atols[i])
+    end
+    for i = 1:d, j = 1:d
+        @test isapprox(emp_cov[i,j], Σ[i,j], atol=cov_atols[i,j])
+    end
+
+
+    # evaluation of sqmahal & logpdf
+    U = X .- μ
+    sqm = vec(sum(U .* (Σ \ U), dims=1))
+    for i = 1:min(100, n_tsamples)
+        @test sqmahal(g, X[:,i]) ≈ sqm[i]
+    end
+    @test sqmahal(g, X) ≈ sqm
+
+    lp = -0.5 .* sqm .- 0.5 * (d * log(2.0 * pi) + ldcov)
+    for i = 1:min(100, n_tsamples)
+        @test logpdf(g, X[:,i]) ≈ lp[i]
+    end
+    @test logpdf(g, X) ≈ lp
+
+    # log likelihood
+    @test loglikelihood(g, X) ≈ sum(i -> Distributions._logpdf(g, X[:,i]), 1:n_tsamples)
+    @test loglikelihood(g, X[:, 1]) ≈ logpdf(g, X[:, 1])
+    @test loglikelihood(g, [X[:, i] for i in axes(X, 2)]) ≈ loglikelihood(g, X)
+end
+
+end

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -10,92 +10,6 @@ using LinearAlgebra, Random, Test
 using SparseArrays
 using FillArrays
 
-import Distributions: distrname
-
-
-
-####### Core testing procedure
-
-function test_mvnormal(g::AbstractMvNormal, n_tsamples::Int=10^6,
-                       rng::Union{AbstractRNG, Missing} = missing)
-    d = length(g)
-    μ = mean(g)
-    Σ = cov(g)
-    @test length(μ) == d
-    @test size(Σ) == (d, d)
-    @test var(g)     ≈ diag(Σ)
-    @test entropy(g) ≈ 0.5 * logdet(2π * ℯ * Σ)
-    ldcov = logdetcov(g)
-    @test ldcov ≈ logdet(Σ)
-    vs = diag(Σ)
-    @test g == typeof(g)(params(g)...)
-    @test g == deepcopy(g)
-    @test minimum(g) == fill(-Inf, d)
-    @test maximum(g) == fill(Inf, d)
-    @test extrema(g) == (minimum(g), maximum(g))
-    @test isless(extrema(g)...)
-
-    # test sampling for AbstractMatrix (here, a SubArray):
-    if ismissing(rng)
-        subX = view(rand(d, 2d), :, 1:d)
-        @test isa(rand!(g, subX), SubArray)
-    else
-        subX = view(rand(rng, d, 2d), :, 1:d)
-        @test isa(rand!(rng, g, subX), SubArray)
-    end
-
-    # sampling
-    if ismissing(rng)
-        @test isa(rand(g), Vector{Float64})
-        X = rand(g, n_tsamples)
-    else
-        @test isa(rand(rng, g), Vector{Float64})
-        X = rand(rng, g, n_tsamples)
-    end
-    emp_mu = vec(mean(X, dims=2))
-    Z = X .- emp_mu
-    emp_cov = (Z * Z') * inv(n_tsamples)
-    for i = 1:d
-        @test isapprox(emp_mu[i], μ[i], atol=sqrt(vs[i] / n_tsamples) * 8.0)
-    end
-    for i = 1:d, j = 1:d
-        @test isapprox(emp_cov[i,j], Σ[i,j], atol=sqrt(vs[i] * vs[j]) * 10.0 / sqrt(n_tsamples))
-    end
-
-    X = rand(MersenneTwister(14), g, n_tsamples)
-    Y = rand(MersenneTwister(14), g, n_tsamples)
-    @test X == Y
-    emp_mu = vec(mean(X, dims=2))
-    Z = X .- emp_mu
-    emp_cov = (Z * Z') * inv(n_tsamples)
-    for i = 1:d
-        @test isapprox(emp_mu[i]   , μ[i]  , atol=sqrt(vs[i] / n_tsamples) * 8.0)
-    end
-    for i = 1:d, j = 1:d
-        @test isapprox(emp_cov[i,j], Σ[i,j], atol=sqrt(vs[i] * vs[j]) * 10.0 / sqrt(n_tsamples))
-    end
-
-
-    # evaluation of sqmahal & logpdf
-    U = X .- μ
-    sqm = vec(sum(U .* (Σ \ U), dims=1))
-    for i = 1:min(100, n_tsamples)
-        @test sqmahal(g, X[:,i]) ≈ sqm[i]
-    end
-    @test sqmahal(g, X) ≈ sqm
-
-    lp = -0.5 .* sqm .- 0.5 * (d * log(2.0 * pi) + ldcov)
-    for i = 1:min(100, n_tsamples)
-        @test logpdf(g, X[:,i]) ≈ lp[i]
-    end
-    @test logpdf(g, X) ≈ lp
-
-    # log likelihood
-    @test loglikelihood(g, X) ≈ sum([Distributions._logpdf(g, X[:,i]) for i in 1:size(X, 2)])
-    @test loglikelihood(g, X[:, 1]) ≈ logpdf(g, X[:, 1])
-    @test loglikelihood(g, [X[:, i] for i in axes(X, 2)]) ≈ loglikelihood(g, X)
-end
-
 ###### General Testing
 
 @testset "MvNormal tests" begin
@@ -136,7 +50,7 @@ end
         @test mean(g)   ≈ μ
         @test cov(g)    ≈ Σ
         @test invcov(g) ≈ inv(Σ)
-        test_mvnormal(g, 10^4)
+        Distributions.TestUtils.test_mvnormal(g, 10^4)
 
         # conversion between mean form and canonical form
         if isa(g, MvNormal)


### PR DESCRIPTION
This PR moves the tests for the MvNormal type inside a new module inside Distributions entitled `TestUtils`. The benefit of locating this code here is that it makes it easy for other packages which implement subtypes of `AbstractMvNormal` to run the same tests as Distributions to make them confident that they have implemented Distributions' `AbstractMvNormal` API properly.

This is non-breaking.

I've also sorted a couple of style-related things, but no additional tests have been added / removed.

cc @devmotion 