### PR TITLE
Remove `truncated(d, ::Integer, ::Integer)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.26"
+version = "0.25.27"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -39,8 +39,6 @@ function truncated(d::UnivariateDistribution, l::T, u::T) where {T <: Real}
     Truncated(d, promote(l, u, lcdf, ucdf, tp, logtp)...)
 end
 
-truncated(d::UnivariateDistribution, l::Integer, u::Integer) = truncated(d, float(l), float(u))
-
 """
     Truncated
 

--- a/src/truncated/uniform.jl
+++ b/src/truncated/uniform.jl
@@ -2,6 +2,4 @@
 ##### Shortcut for truncating uniform distributions.
 #####
 
-truncated(d::Uniform, l::T, u::T) where {T <: Real} = Uniform(promote(max(l, d.a), min(u, d.b))...)
-
-truncated(d::Uniform, l::Integer, u::Integer) = truncated(d, float(l), float(u))
+truncated(d::Uniform, l::T, u::T) where {T <: Real} = Uniform(max(l, d.a), min(u, d.b))


### PR DESCRIPTION
This PR removes a default fallback for `truncated(d::UnivariateDistribution, lo::Integer, hi::Integer)` which is not needed anymore (possibly due to recent changes in the default implementation of `truncated`).

The main advantage is that it makes it easier to overload `truncated`: currently one has to resolve method ambiguities that arise from the `Integer` fallback (see e.g. https://github.com/JuliaStats/Distributions.jl/pull/1349).