### PR TITLE
Change order of arguments in `expectation`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.28"
+version = "0.25.29"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -47,6 +47,7 @@ end
 @deprecate Wishart(df::Real, S::Matrix, warn::Bool) Wishart(df, S)
 @deprecate Wishart(df::Real, S::Cholesky, warn::Bool) Wishart(df, S)
 
-# Deprecate 3 arguments expectation
-@deprecate expectation(distr::DiscreteUnivariateDistribution, g::Function, epsilon::Real) expectation(distr, g; epsilon=epsilon) false
-@deprecate expectation(distr::ContinuousUnivariateDistribution, g::Function, epsilon::Real) expectation(distr, g) false
+# Deprecate 3 arguments expectation and once with function in second place
+@deprecate expectation(distr::DiscreteUnivariateDistribution, g::Function, epsilon::Real) expectation(g, distr; epsilon=epsilon) false
+@deprecate expectation(distr::ContinuousUnivariateDistribution, g::Function, epsilon::Real) expectation(g, distr) false
+@deprecate expectation(distr::Union{UnivariateDistribution,MultivariateDistribution}, g::Function; kwargs...) expectation(g, distr; kwargs...) false

--- a/test/binomial.jl
+++ b/test/binomial.jl
@@ -23,8 +23,8 @@ for (p, n) in [(0.6, 10), (0.8, 6), (0.5, 40), (0.04, 20), (1., 100), (0., 10), 
 end
 
 # Test calculation of expectation value for Binomial distribution
-@test Distributions.expectation(Binomial(6), identity) ≈ 3.0
-@test Distributions.expectation(Binomial(10, 0.2), x->-x) ≈ -2.0
+@test Distributions.expectation(identity, Binomial(6)) ≈ 3.0
+@test Distributions.expectation(x -> -x, Binomial(10, 0.2)) ≈ -2.0
 
 # Test mode
 @test Distributions.mode(Binomial(100, 0.4)) == 40

--- a/test/functionals.jl
+++ b/test/functionals.jl
@@ -24,13 +24,18 @@ end
 @testset "Expectations" begin
     # univariate distributions
     for d in (Normal(), Poisson(2.0), Binomial(10, 0.4))
-        @test Distributions.expectation(d, identity) ≈ mean(d) atol=1e-3
-        @test @test_deprecated(Distributions.expectation(d, identity, 1e-10)) ≈ mean(d) atol=1e-3
+        m = Distributions.expectation(identity, d)
+        @test m ≈ mean(d) atol=1e-3
+        @test Distributions.expectation(x -> (x - mean(d))^2, d) ≈ var(d) atol=1e-3
+
+        @test @test_deprecated(Distributions.expectation(d, identity, 1e-10)) == m
+        @test @test_deprecated(Distributions.expectation(d, identity)) == m
     end
 
     # multivariate distribution
     d = MvNormal([1.5, -0.5], I)
-    @test Distributions.expectation(d, identity; nsamples=10_000) ≈ mean(d) atol=1e-2
+    @test Distributions.expectation(identity, d; nsamples=10_000) ≈ mean(d) atol=5e-2
+    @test @test_deprecated(Distributions.expectation(d, identity; nsamples=10_000)) ≈ mean(d) atol=5e-2
 end
 
 @testset "KL divergences" begin

--- a/test/loguniform.jl
+++ b/test/loguniform.jl
@@ -59,7 +59,7 @@ import Random
         x = rand(rng, dist)
         @test cdf(u, log(x)) ≈ cdf(dist, x)
 
-        @test @inferred(entropy(dist)) ≈  Distributions.expectation(dist, x->-logpdf(dist,x))
+        @test @inferred(entropy(dist)) ≈  Distributions.expectation(x->-logpdf(dist,x), dist)
     end
 
     @test kldivergence(LogUniform(1,2), LogUniform(1,2)) ≈ 0 atol=100eps(Float64)


### PR DESCRIPTION
I noticed in https://github.com/JuliaStats/Distributions.jl/pull/1414 that the order of arguments in `expectation` does not follow the general Julia recommendations and style. IMO the function should be the first argument since this would also allow to use the `do` syntax. The PR fixes this issue.

Additionally, I wonder if `expectation` should be exported.