### PR TITLE
Add fitting methods for GeneralizedPareto

### DIFF
--- a/src/univariate/continuous/generalizedpareto.jl
+++ b/src/univariate/continuous/generalizedpareto.jl
@@ -322,7 +322,7 @@ end
 function _gpd_empirical_prior(μ, xsorted, n=length(x))
     xmax = xsorted[n]
     μ_star = -inv(xmax - μ)
-    x_25 = quantile(xsorted, oftype(μ_star, 0.25); sorted=true, alpha=0, beta=1)
+    x_25 = xsorted[fld(n + 2, 4)]
     σ_star = inv(6 * (x_25 - μ))
     ξ_star = 1//2
     return GeneralizedPareto(μ_star, σ_star, ξ_star)
@@ -333,7 +333,12 @@ function _gpd_empirical_prior_improved(μ, xsorted, n=length(x))
     xmax = xsorted[n]
     μ_star = -inv(xmax - μ) * ((n - 1) // (n + 1))
     p = (3:9) ./ oftype(μ_star, 10)
-    xquantiles = quantile(xsorted, [1 .- p; 1 .- p .^2]; sorted=true, alpha=0, beta=1)
+    q = [1 .- p; 1 .- p .^2]
+    xquantiles = if VERSION ≥ v"1.5.0"
+        quantile(xsorted, q; sorted=true, alpha=0, beta=1)
+    else
+        quantile(xsorted, q; sorted=true)
+    end
     x1mp, x1mp2 = @views xquantiles[1:7], xquantiles[8:14]
     expkp = @. (x1mp2 - x1mp) / (x1mp - μ)
     σp = @. log(p, expkp) * (x1mp - μ) / (1 - expkp)

--- a/src/univariate/continuous/generalizedpareto.jl
+++ b/src/univariate/continuous/generalizedpareto.jl
@@ -218,6 +218,135 @@ function fit_mle(d::GeneralizedParetoKnownMuTheta, ss::GeneralizedParetoKnownMuT
     return GeneralizedPareto(d.μ, ξ / d.θ, ξ)
 end
 
+#
+# empirical bayes
+#
+
+"""
+    GeneralizedParetoKnownMu(μ)
+
+Represents a [`GeneralizedPareto`](@ref) where ``\\mu`` is known.
+"""
+struct GeneralizedParetoKnownMu{T} <: IncompleteDistribution
+    μ::T
+end
+
+"""
+    fit(GeneralizedPareto, x; μ, kwargs...)
+
+Fit a [`GeneralizedPareto`](@ref) with known location `μ` to the data `x`.
+
+The fit is performed using the Empirical Bayes method of [^ZhangStephens2009][^Zhang2010].
+
+# Keywords
+- `sorted::Bool=issorted(x)`: If `true`, `x` is assumed to be sorted. If `false`, a sorted
+    copy of `x` is made.
+- `improved::Bool=true`: If `true`, use the adaptive empirical prior of [^Zhang2010].
+    If `false`, use the simpler prior of [^ZhangStephens2009].
+- `min_points::Int=30`: The minimum number of quadrature points to use when estimating the
+    posterior mean of ``\\theta = \\frac{\\xi}{\\sigma}``.
+
+[^ZhangStephens2009]: Jin Zhang & Michael A. Stephens (2009)
+                      A New and Efficient Estimation Method for the Generalized Pareto Distribution,
+                      Technometrics, 51:3, 316-325,
+                      DOI: [10.1198/tech.2009.08017](https://doi.org/10.1198/tech.2009.08017)
+[^Zhang2010]: Jin Zhang (2010) Improving on Estimation for the Generalized Pareto Distribution,
+              Technometrics, 52:3, 335-339,
+              DOI: [10.1198/TECH.2010.09206](https://doi.org/10.1198/TECH.2010.09206)
+"""
+function StatsBase.fit(::Type{<:GeneralizedPareto}, x::AbstractArray; μ::Real, kwargs...)
+    return fit(GeneralizedParetoKnownMu(μ), x; kwargs...)
+end
+function StatsBase.fit(g::GeneralizedParetoKnownMu, x::AbstractArray; kwargs...)
+    return fit_empiricalbayes(g, x; kwargs...)
+end
+
+# Note: our ξ is ZhangStephens2009's -k, and our θ is ZhangStephens2009's -θ
+
+function fit_empiricalbayes(
+    g::GeneralizedParetoKnownMu,
+    x::AbstractArray;
+    sorted::Bool=issorted(vec(x)),
+    improved::Bool=true,
+    min_points::Int=30,
+)
+    μ = g.μ
+    T = Base.promote_eltype(x, μ)
+    # fitting is faster when the data are sorted
+    xsorted = sorted ? vec(x) : sort(vec(x))
+    xmin, xmax = @inbounds xsorted[1], xsorted[end]
+    if xmin ≈ xmax
+        # support is nearly a point. solution is not unique; any solution satisfying the
+        # constraints σ/ξ ≈ 0 and ξ < 0 is acceptable. we choose the ξ = -1 solution, i.e.
+        # the uniform distribution
+        return GeneralizedPareto(μ, max(eps(zero(T)), xmax - μ), -one(μ))
+    end
+    # estimate θ using empirical bayes
+    θ_hat = _fit_gpd_θ_empirical_bayes(μ, xsorted, min_points, improved)
+    # estimate remaining parameters using MLE
+    return fit_mle(GeneralizedPareto, xsorted; μ=μ, θ=θ_hat)
+end
+
+# estimate θ̂ = ∫θp(θ|x,μ)dθ, i.e. the posterior mean using quadrature over grid
+# of minimum length `min_points + floor(sqrt(length(x)))` uniformly sampled over an
+# empirical prior
+function _fit_gpd_θ_empirical_bayes(μ, xsorted, min_points, improved)
+    T = Base.promote_eltype(xsorted, μ)
+    n = length(xsorted)
+
+    # empirical prior on y = r/(xmax-μ) + θ
+    θ_prior = if improved
+        _gpd_empirical_prior_improved(μ, xsorted, n)
+    else
+        _gpd_empirical_prior(μ, xsorted, n)
+    end
+
+    # quadrature points uniformly spaced on the quantiles of the θ prior
+    npoints = min_points + floor(Int, sqrt(n))
+    p = ((1:npoints) .- one(T)/2) ./ npoints
+    θ = quantile.(Ref(θ_prior), p)
+
+    # estimate mean θ over the quadrature points
+    # with weights as the normalized profile likelihood 
+    lθ = _gpd_profile_loglikelihood.(μ, θ, Ref(xsorted), n)
+    lθ_norm = logsumexp(lθ)
+    θ_hat = @inbounds sum(1:npoints) do j
+        wⱼ = exp(lθ[j] - lθ_norm)
+        return θ[j] * wⱼ
+    end
+
+    return θ_hat
+end
+
+# Zhang & Stephens, 2009
+function _gpd_empirical_prior(μ, xsorted, n=length(x))
+    xmax = xsorted[n]
+    μ_star = -inv(xmax - μ)
+    x_25 = quantile(xsorted, oftype(μ_star, 0.25); sorted=true, alpha=0, beta=1)
+    σ_star = inv(6 * (x_25 - μ))
+    ξ_star = 1//2
+    return GeneralizedPareto(μ_star, σ_star, ξ_star)
+end
+
+# Zhang, 2010
+function _gpd_empirical_prior_improved(μ, xsorted, n=length(x))
+    xmax = xsorted[n]
+    μ_star = -inv(xmax - μ) * ((n - 1) // (n + 1))
+    p = (3:9) ./ oftype(μ_star, 10)
+    xquantiles = quantile(xsorted, [1 .- p; 1 .- p .^2]; sorted=true, alpha=0, beta=1)
+    x1mp, x1mp2 = @views xquantiles[1:7], xquantiles[8:14]
+    expkp = @. (x1mp2 - x1mp) / (x1mp - μ)
+    σp = @. log(p, expkp) * (x1mp - μ) / (1 - expkp)
+    σ_star = inv(2 * median(σp))
+    ξ_star = 1
+    return GeneralizedPareto(μ_star, σ_star, ξ_star)
+end
+
+# compute log joint likelihood p(x|μ,θ), with ξ the MLE given θ and x
+function _gpd_profile_loglikelihood(μ, θ, x, n=length(x))
+    d = fit_mle(GeneralizedPareto, x; μ=μ, θ=θ)
+    return -n * (log(d.σ) + d.ξ + 1)
+end
 
 #### Sampling
 

--- a/src/univariate/continuous/generalizedpareto.jl
+++ b/src/univariate/continuous/generalizedpareto.jl
@@ -190,7 +190,7 @@ function suffstats(d::GeneralizedParetoKnownMuTheta, x::AbstractArray{<:Real})
 end
 
 """
-    fit_mle(GeneralizedPareto, x; μ, θ)
+    fit_mle(::Type{<:GeneralizedPareto}, x; μ, θ)
 
 Compute the maximum likelihood estimate of the parameters of a [`GeneralizedPareto`](@ref)
 where ``\\mu`` and ``\\theta=\\frac{\\xi}{\\sigma}`` are known.
@@ -220,7 +220,7 @@ struct GeneralizedParetoKnownMu{T} <: IncompleteDistribution
 end
 
 """
-    fit(GeneralizedPareto, x; μ, kwargs...)
+    fit(::Type{<:GeneralizedPareto}, x; μ, kwargs...)
 
 Fit a [`GeneralizedPareto`](@ref) with known location `μ` to the data `x`.
 

--- a/src/univariate/continuous/generalizedpareto.jl
+++ b/src/univariate/continuous/generalizedpareto.jl
@@ -153,6 +153,7 @@ function quantile(d::GeneralizedPareto{T}, p::Real) where T<:Real
     (μ, σ, ξ) = params(d)
     nlog1pp = -log1p(-p * one(T))
     z = abs(ξ) < eps() ? nlog1pp : expm1(ξ * nlog1pp) / ξ
+    return muladd(σ, z, μ)
 end
 
 #### Fitting

--- a/src/univariate/continuous/generalizedpareto.jl
+++ b/src/univariate/continuous/generalizedpareto.jl
@@ -323,8 +323,9 @@ function _gpd_empirical_prior_improved(μ, xsorted, n=length(xsorted))
     q2 = (91, 84, 75, 64, 51, 36, 19)  # 100 .* (1 .- p .^ 2)
     # q1/10- and q2/100- quantiles of xsorted without interpolation,
     # i.e. the α-quantile of x without interpolation is x[max(1, floor(Int, α * n + 1/2))]
-    x1mp = map(qi -> xsorted[max(1, div(qi * n, 10, RoundNearestTiesUp))], q1)
-    x1mp2 = map(qi -> xsorted[max(1, div(qi * n, 100, RoundNearestTiesUp))], q2)
+    twon = 2 * n
+    x1mp_2 = map(qi -> xsorted[max(1, fld(qi * twon + 1, 20))], q1)
+    x1mp2_2 = map(qi -> xsorted[max(1, fld(qi * twon + 1, 200))], q2)
     expkp = @. (x1mp2 - x1mp) / (x1mp - μ)
     σp = @. log(p, expkp) * (x1mp - μ) / (1 - expkp)
     σ_star = inv(2 * median(σp))

--- a/src/univariate/continuous/generalizedpareto.jl
+++ b/src/univariate/continuous/generalizedpareto.jl
@@ -305,11 +305,11 @@ function _fit_gpd_θ_empirical_bayes(μ, xsorted, min_points, improved)
     npoints = min_points + floor(Int, sqrt(n))
     pmin = 1 // (2 * npoints)
     p = pmin:(1//npoints):(1 - pmin)
-    θ = quantile.(Ref(θ_prior), p)
+    θ = map(Base.Fix1(quantile, θ_prior), p)
 
     # estimate mean θ over the quadrature points
     # with weights as the normalized profile likelihood 
-    lθ = _gpd_profile_loglikelihood.(μ, θ, Ref(xsorted), n)
+    lθ = map(θ -> _gpd_profile_loglikelihood(μ, θ, xsorted, n), θ)
     weights = softmax!(lθ)
     θ_hat = dot(weights, θ)
 

--- a/src/univariate/continuous/generalizedpareto.jl
+++ b/src/univariate/continuous/generalizedpareto.jl
@@ -309,8 +309,8 @@ function _fit_gpd_θ_empirical_bayes(μ, xsorted, min_points, improved)
     # estimate mean θ over the quadrature points
     # with weights as the normalized profile likelihood 
     lθ = _gpd_profile_loglikelihood.(μ, θ, Ref(xsorted), n)
-    softmax!(lθ)
-    θ_hat = dot(lθ, θ)
+    weights = softmax!(lθ)
+    θ_hat = dot(weights, θ)
 
     return θ_hat
 end

--- a/src/univariate/continuous/generalizedpareto.jl
+++ b/src/univariate/continuous/generalizedpareto.jl
@@ -292,7 +292,6 @@ end
 # of minimum length `min_points + floor(sqrt(length(x)))` uniformly sampled over an
 # empirical prior
 function _fit_gpd_θ_empirical_bayes(μ, xsorted, min_points, improved)
-    T = Base.promote_eltype(xsorted, μ)
     n = length(xsorted)
 
     # empirical prior on y = r/(xmax-μ) + θ
@@ -304,7 +303,8 @@ function _fit_gpd_θ_empirical_bayes(μ, xsorted, min_points, improved)
 
     # quadrature points uniformly spaced on the quantiles of the θ prior
     npoints = min_points + floor(Int, sqrt(n))
-    p = ((1:npoints) .- one(T)/2) ./ npoints
+    pmin = 1 // (2 * npoints)
+    p = pmin:(1//npoints):(1 - pmin)
     θ = quantile.(Ref(θ_prior), p)
 
     # estimate mean θ over the quadrature points

--- a/src/univariate/continuous/generalizedpareto.jl
+++ b/src/univariate/continuous/generalizedpareto.jl
@@ -334,9 +334,11 @@ function _gpd_empirical_prior_improved(μ, xsorted, n=length(x))
     q1 = (7//10, 3//5, 1//2, 2//5, 3//10, 1//5, 1//10)  # 1 .- p
     q2 = (91//100, 21//25, 3//4, 16//25, 51//100, 9//25, 19//100)  # 1 .- p .^ 2
     @static if VERSION ≥ v"1.5.0"
+        # alpha=0, beta=1 corresponds to no interpolation between points
         x1mp = quantile(xsorted, q1; sorted=true, alpha=0, beta=1)
         x1mp2 = quantile(xsorted, q2; sorted=true, alpha=0, beta=1)
     else
+        # older versions of Julia do not have the alpha/beta keywords
         x1mp = quantile(xsorted, q1; sorted=true)
         x1mp2 = quantile(xsorted, q2; sorted=true)
     end

--- a/src/univariate/continuous/generalizedpareto.jl
+++ b/src/univariate/continuous/generalizedpareto.jl
@@ -151,22 +151,8 @@ logcdf(d::GeneralizedPareto, x::Real) = log1mexp(logccdf(d, x))
 
 function quantile(d::GeneralizedPareto{T}, p::Real) where T<:Real
     (μ, σ, ξ) = params(d)
-
-    if p == 0
-        z = zero(T)
-    elseif p == 1
-        z = ξ < 0 ? -1 / ξ : T(Inf)
-    elseif 0 < p < 1
-        if abs(ξ) < eps()
-            z = -log1p(-p)
-        else
-            z = expm1(-ξ * log1p(-p)) / ξ
-        end
-    else
-      z = T(NaN)
-    end
-
-    return μ + σ * z
+    nlog1pp = -log1p(-p * one(T))
+    z = abs(ξ) < eps() ? nlog1pp : expm1(ξ * nlog1pp) / ξ
 end
 
 #### Fitting

--- a/src/univariate/continuous/generalizedpareto.jl
+++ b/src/univariate/continuous/generalizedpareto.jl
@@ -304,7 +304,7 @@ function _fit_gpd_θ_empirical_bayes(μ, xsorted, min_points, improved)
 end
 
 # Zhang & Stephens, 2009
-function _gpd_empirical_prior(μ, xsorted, n=length(x))
+function _gpd_empirical_prior(μ, xsorted, n=length(xsorted))
     xmax = xsorted[n]
     μ_star = -inv(xmax - μ)
     x_25 = xsorted[fld(n + 2, 4)]
@@ -314,7 +314,7 @@ function _gpd_empirical_prior(μ, xsorted, n=length(x))
 end
 
 # Zhang, 2010
-function _gpd_empirical_prior_improved(μ, xsorted, n=length(x))
+function _gpd_empirical_prior_improved(μ, xsorted, n=length(xsorted))
     xmax = xsorted[n]
     μ_star = (n - 1) / ((n + 1) *  (μ - xmax))
     p = (3//10, 2//5, 1//2, 3//5, 7//10, 4//5, 9//10)  # 0.3:0.1:0.9

--- a/src/univariate/continuous/generalizedpareto.jl
+++ b/src/univariate/continuous/generalizedpareto.jl
@@ -279,7 +279,8 @@ function fit_empiricalbayes(
         # support is nearly a point. solution is not unique; any solution satisfying the
         # constraints σ/ξ ≈ 0 and ξ < 0 is acceptable. we choose the ξ = -1 solution, i.e.
         # the uniform distribution
-        return GeneralizedPareto(μ, max(eps(zero(T)), xmax - μ), -one(μ))
+        σ = xmax - μ
+        return GeneralizedPareto(μ, max(eps(zero(σ)), σ), -1)
     end
     # estimate θ using empirical bayes
     θ_hat = _fit_gpd_θ_empirical_bayes(μ, xsorted, min_points, improved)

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -325,8 +325,8 @@ end
 end
 
 @testset "Testing fit_mle for GeneralizedPareto" begin
-    for func in funcs, dist in (GeneralizedPareto, GeneralizedPareto{Float64})
-        for (μ, σ, ξ) in ((-1.5, 0.5, 2.0), (-10.0, 1.0, -0.5))
+    for func in funcs, dist in (GeneralizedPareto,)
+        for (μ, σ, ξ) in ((-1.5, 0.5, 2), (-10, 1, -0.5))
             x = func[2](dist(μ, σ, ξ), N)
 
             ss = suffstats(Distributions.GeneralizedParetoKnownMuTheta(μ, ξ/σ), x)
@@ -345,14 +345,17 @@ end
 end
 
 @testset "Testing fit for GeneralizedPareto" begin
-    for func in funcs, dist in (GeneralizedPareto, GeneralizedPareto{Float64})
-        for (μ, σ, ξ) in ((-1.5, 0.5, 2.0), (-10.0, 1.0, -0.5)), improved in (true, false)
-            x = func[2](dist(μ, σ, ξ), N)
+    for func in funcs, dist in (GeneralizedPareto,), T in (Float64, Float32)
+        for (μ, σ, ξ) in ((-T(1.5), T(0.5), 2), (-10, 1, -T(0.5))), improved in (true, false)
+            x = T.(func[2](dist(μ, σ, ξ), N))
             d = @inferred fit(dist, x; μ=μ, improved=improved)
-            @test isa(d, dist)
+            @test isa(d, GeneralizedPareto{T})
             @test minimum(d) == μ
             @test isapprox(scale(d), σ, rtol=0.1)
             @test isapprox(shape(d), ξ, rtol=0.1)
+            if T <: Float32
+                @test isa(fit(dist, x[1:n0]; μ=Float64(μ), improved=improved), GeneralizedPareto{Float64})
+            end
 
             d2 = fit(dist, sort(x); μ=μ, improved=improved, sorted=true)
             @test d2 == d

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -324,6 +324,26 @@ end
     end
 end
 
+@testset "Testing fit_mle for GeneralizedPareto" begin
+    for func in funcs, dist in (GeneralizedPareto, GeneralizedPareto{Float64})
+        for (μ, σ, ξ) in ((-1.5, 0.5, 2.0), (-10.0, 1.0, -0.5))
+            x = func[2](dist(μ, σ, ξ), N)
+
+            ss = suffstats(Distributions.GeneralizedParetoKnownMuTheta(μ, ξ/σ), x)
+            @test isa(ss, Distributions.GeneralizedParetoKnownMuThetaStats)
+            @test ss.μ == μ
+            @test ss.θ == ξ/σ
+            @test isapprox(ss.ξ, ξ; rtol=1e-2)
+
+            d = @inferred fit_mle(dist, x; μ=μ, θ=ξ/σ)
+            @test isa(d, dist)
+            @test minimum(d) == μ
+            @test isapprox(scale(d), σ, rtol=1e-2)
+            @test isapprox(shape(d), ξ, rtol=1e-2)
+        end
+    end
+end
+
 @testset "Testing fit for Geometric" begin
     for func in funcs, dist in (Geometric, Geometric{Float64})
         x = func[2](dist(0.3), n0)

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -344,6 +344,27 @@ end
     end
 end
 
+@testset "Testing fit for GeneralizedPareto" begin
+    for func in funcs, dist in (GeneralizedPareto, GeneralizedPareto{Float64})
+        for (μ, σ, ξ) in ((-1.5, 0.5, 2.0), (-10.0, 1.0, -0.5)), improved in (true, false)
+            x = func[2](dist(μ, σ, ξ), N)
+            d = @inferred fit(dist, x; μ=μ, improved=improved)
+            @test isa(d, dist)
+            @test minimum(d) == μ
+            @test isapprox(scale(d), σ, rtol=0.1)
+            @test isapprox(shape(d), ξ, rtol=0.1)
+
+            d2 = fit(dist, sort(x); μ=μ, improved=improved, sorted=true)
+            @test d2 == d
+        end
+        x = ones(N)
+        d = fit(dist, x; μ=1.0)
+        @test minimum(d) == 1.0
+        @test scale(d) ≈ eps(0.0)
+        @test shape(d) ≈ -1
+    end
+end
+
 @testset "Testing fit for Geometric" begin
     for func in funcs, dist in (Geometric, Geometric{Float64})
         x = func[2](dist(0.3), n0)


### PR DESCRIPTION
Because of the [Pickands–Balkema–De Haan Theorem](https://en.wikipedia.org/wiki/Pickands%E2%80%93Balkema%E2%80%93De_Haan_theorem), it's common to fit a `GeneralizedPareto` to the draws from some unknown distribution above a threshold (`μ`) to analyze the tail behavior.

This PR adds two methods for fitting the GPD:
- `fit_mle(GeneralizedPareto, x; μ, θ)` computes the MLE when the location `μ` and `θ = ξ/σ` is known. For this method, both parameters must be provided. A future PR could allow for  `θ` to be fit to data, but it's somewhat complicated.
- `fit(GeneralizedPareto, x; μ)` computes an Empirical Bayes estimate of the parameters of the GPD using the method in https://www.jstor.org/stable/40586625 and its sequel https://www.jstor.org/stable/27867255, which shows decreased bias and increased statistical efficiency compared to the complete MLE estimator. It internally uses the `fit_mle` method.

EDIT: This code was adapted from [PSIS.jl](https://github.com/arviz-devs/PSIS.jl)