### PR TITLE
Support DensityInterface v0.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 ChainRulesCore = "1"
-DensityInterface = "0.3.2"
+DensityInterface = "0.3.2, 0.4"
 FillArrays = "0.9, 0.10, 0.11, 0.12"
 PDMats = "0.10, 0.11"
 QuadGK = "2"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.29"
+version = "0.25.30"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 ChainRulesCore = "1"
-DensityInterface = "0.3.2, 0.4"
+DensityInterface = "0.4"
 FillArrays = "0.9, 0.10, 0.11, 0.12"
 PDMats = "0.10, 0.11"
 QuadGK = "2"

--- a/docs/src/density_interface.md
+++ b/docs/src/density_interface.md
@@ -2,4 +2,6 @@
 
 `Distributions` supports [`DensityInterface`](https://github.com/JuliaMath/DensityInterface.jl) for distributions.
 
+A probability distribution has a probability density, so `DensityInterface.DensityKind(::Distribution) === HasDensity()`.
+
 For *single* variate values `x`, `DensityInterface.logdensityof(d::Distribution, x)` is equivalent to `logpdf(d, x)` and `DensityInterface.densityof(d::Distribution, x)` is equivalent to `pdf(d, x)`.

--- a/src/density_interface.jl
+++ b/src/density_interface.jl
@@ -1,9 +1,4 @@
-@static if isdefined(DensityInterface, :DensityKind)
-    @inline DensityInterface.DensityKind(::Distribution) = HasDensity()
-else
-    # DensityInterface v0.3
-    @inline DensityInterface.hasdensity(::Distribution) = true
-end
+@inline DensityInterface.DensityKind(::Distribution) = HasDensity()
 
 for (di_func, d_func) in ((:logdensityof, :logpdf), (:densityof, :pdf))
     @eval begin

--- a/src/density_interface.jl
+++ b/src/density_interface.jl
@@ -1,4 +1,9 @@
-@inline DensityInterface.hasdensity(::Distribution) = true
+@static if isdefined(DensityInterface, :DensityKind)
+    @inline DensityInterface.DensityKind(::Distribution) = HasDensity()
+else
+    # DensityInterface v0.3
+    @inline DensityInterface.hasdensity(::Distribution) = true
+end
 
 for (di_func, d_func) in ((:logdensityof, :logpdf), (:densityof, :pdf))
     @eval begin

--- a/src/density_interface.jl
+++ b/src/density_interface.jl
@@ -1,4 +1,4 @@
-@inline DensityInterface.DensityKind(::Distribution) = HasDensity()
+@inline DensityInterface.DensityKind(::Distribution) = DensityInterface.HasDensity()
 
 for (di_func, d_func) in ((:logdensityof, :logpdf), (:densityof, :pdf))
     @eval begin

--- a/test/density_interface.jl
+++ b/test/density_interface.jl
@@ -11,9 +11,6 @@
             x = rand(d)
             ref_logd_at_x = logpdf(d, x)
             DensityInterface.test_density_interface(d, x, ref_logd_at_x)
-
-            # Stricter than required by test_density_interface:
-            @test logfuncdensity(logdensityof(d)) === d
         end
 
         for di_func in (logdensityof, densityof)


### PR DESCRIPTION
This is non-breaking and keeps support for DensityInterface v0.3.2.