### PR TITLE
Fix Wishart and MvNormal bugs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.31"
+version = "0.25.32"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -242,7 +242,8 @@ end
 function _rand_params(::Type{Wishart}, elty, n::Int, p::Int)
     n == p || throw(ArgumentError("dims must be equal for Wishart"))
     ν = elty(n - 1 + abs(10 * randn()))
-    X = 2 .* rand(elty, n, n) .- 1
+    X = rand(elty, n, n)
+    X .= 2 .* X .- 1
     S = X * X'
     return ν, S
 end

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -69,7 +69,7 @@ Wishart(df::Real, S::Cholesky) = Wishart(df, PDMat(S))
 #  REPL display
 #  -----------------------------------------------------------------------------
 
-show(io::IO, d::Wishart) = show_multline(io, d, [(:df, d.df), (:S, Matrix(d.S))])
+show(io::IO, d::Wishart) = show_multline(io, d, [(:df, d.df), (:S, d.S)])
 
 #  -----------------------------------------------------------------------------
 #  Conversion
@@ -107,45 +107,45 @@ params(d::Wishart) = (d.df, d.S)
 mean(d::Wishart) = d.df * Matrix(d.S)
 
 function mode(d::Wishart)
-    r = d.df - dim(d) - 1.0
-    r > 0.0 || throw(ArgumentError("mode is only defined when df > p + 1"))
+    r = d.df - dim(d) - 1
+    r > 0 || throw(ArgumentError("mode is only defined when df > p + 1"))
     return Matrix(d.S) * r
 end
 
 function meanlogdet(d::Wishart)
-    d.singular && return -Inf
+    logdet_S = logdet(d.S)
     p = dim(d)
-    df = d.df
-    v = logdet(d.S) + p * logtwo
-    for i = 1:p
-        v += digamma(0.5 * (df - (i - 1)))
+    v = logdet_S + p * oftype(logdet_S, logtwo)
+    df = oftype(logdet_S, d.df)
+    for i in 0:(p - 1)
+        v += digamma((df - i) / 2)
     end
-    return v
+    return d.singular ? oftype(v, -Inf) : v
 end
 
 function entropy(d::Wishart)
     d.singular && throw(ArgumentError("entropy not defined for singular Wishart."))
     p = dim(d)
     df = d.df
-    -d.logc0 - 0.5 * (df - p - 1) * meanlogdet(d) + 0.5 * df * p
+    return -d.logc0 - ((df - p - 1) * meanlogdet(d) - df * p) / 2
 end
 
 #  Gupta/Nagar (1999) Theorem 3.3.15.i
 function cov(d::Wishart, i::Integer, j::Integer, k::Integer, l::Integer)
-    S = Matrix(d.S)
-    d.df * (S[i, k] * S[j, l] + S[i, l] * S[j, k])
+    S = d.S
+    return d.df * (S[i, k] * S[j, l] + S[i, l] * S[j, k])
 end
 
 function var(d::Wishart, i::Integer, j::Integer)
-    S = Matrix(d.S)
-    d.df * (S[i, i] * S[j, j] + S[i, j] ^ 2)
+    S = d.S
+    return d.df * (S[i, i] * S[j, j] + S[i, j] ^ 2)
 end
 
 #  -----------------------------------------------------------------------------
 #  Evaluation
 #  -----------------------------------------------------------------------------
 
-function wishart_logc0(df::Real, S::AbstractPDMat, rnk::Integer)
+function wishart_logc0(df::T, S::AbstractPDMat{T}, rnk::Integer) where {T<:Real}
     p = dim(S)
     if df <= p - 1
         return singular_wishart_logc0(p, df, S, rnk)
@@ -163,30 +163,28 @@ function logkernel(d::Wishart, X::AbstractMatrix)
 end
 
 #  Singular Wishart pdf: Theorem 6 in Uhlig (1994 AoS)
-function singular_wishart_logc0(p::Integer, df::Real, S::AbstractPDMat, rnk::Integer)
-    h_df = df / 2
-    -h_df * (logdet(S) + p * typeof(df)(logtwo)) - logmvgamma(rnk, h_df) + (rnk*(rnk - p) / 2)*typeof(df)(logπ)
+function singular_wishart_logc0(p::Integer, df::T, S::AbstractPDMat{T}, rnk::Integer) where {T<:Real}
+    logdet_S = logdet(S)
+    h_df = oftype(logdet_S, df) / 2
+    return -h_df * (logdet_S + p * oftype(logdet_S, logtwo)) - logmvgamma(rnk, h_df) + ((rnk * (rnk - p)) // 2) * oftype(logdet_S, logπ)
 end
 
 function singular_wishart_logkernel(d::Wishart, X::AbstractMatrix)
-    df = d.df
     p = dim(d)
     r = rank(d)
     L = eigvals(Hermitian(X), (p - r + 1):p)
-    0.5 * ((df - (p + 1)) * sum(log.(L)) - tr(d.S \ X))
+    return ((d.df - (p + 1)) * sum(log, L) - tr(d.S \ X)) / 2
 end
 
 #  Nonsingular Wishart pdf
-function nonsingular_wishart_logc0(p::Integer, df::Real, S::AbstractPDMat)
-    h_df = df / 2
-    -h_df * (logdet(S) + p * typeof(df)(logtwo)) - logmvgamma(p, h_df)
+function nonsingular_wishart_logc0(p::Integer, df::T, S::AbstractPDMat{T}) where {T<:Real}
+    logdet_S = logdet(S)
+    h_df = oftype(logdet_S, df) / 2
+    return -h_df * (logdet_S + p * oftype(logdet_S, logtwo)) - logmvgamma(p, h_df)
 end
 
 function nonsingular_wishart_logkernel(d::Wishart, X::AbstractMatrix)
-    df = d.df
-    p = dim(d)
-    Xcf = cholesky(X)
-    0.5 * ((df - (p + 1)) * logdet(Xcf) - tr(d.S \ X))
+    return ((d.df - (dim(d) + 1)) * logdet(cholesky(X)) - tr(d.S \ X)) / 2
 end
 
 #  -----------------------------------------------------------------------------
@@ -195,16 +193,18 @@ end
 
 function _rand!(rng::AbstractRNG, d::Wishart, A::AbstractMatrix)
     if d.singular
-        A .= zero(eltype(A))
-        A[:, 1:rank(d)] = randn(rng, dim(d), rank(d))
+        axes2 = axes(A, 2)
+        r = rank(d)
+        randn!(rng, view(A, :, axes2[1:r]))
+        fill!(view(A, :, axes2[(r + 1):end]), zero(eltype(A)))
     else
-        _wishart_genA!(rng, dim(d), d.df, A)
+        _wishart_genA!(rng, A, d.df)
     end
     unwhiten!(d.S, A)
     A .= A * A'
 end
 
-function _wishart_genA!(rng::AbstractRNG, p::Int, df::Real, A::AbstractMatrix)
+function _wishart_genA!(rng::AbstractRNG, A::AbstractMatrix, df::Real)
     # Generate the matrix A in the Bartlett decomposition
     #
     #   A is a lower triangular matrix, with
@@ -212,13 +212,19 @@ function _wishart_genA!(rng::AbstractRNG, p::Int, df::Real, A::AbstractMatrix)
     #       A(i, j) ~ sqrt of Chisq(df - i + 1) when i == j
     #               ~ Normal()                  when i > j
     #
-    A .= zero(eltype(A))
-    for i = 1:p
-        @inbounds A[i,i] = rand(rng, Chi(df - i + 1.0))
+    T = eltype(A)
+    z = zero(T)
+    axes1 = axes(A, 1)
+    @inbounds for (j, jdx) in enumerate(axes(A, 2)), (i, idx) in enumerate(axes1)
+        A[idx, jdx] = if i < j
+            z
+        elseif i > j
+            randn(rng, T)
+        else
+            rand(rng, Chi(df - i + 1))
+        end
     end
-    for j in 1:p-1, i in j+1:p
-        @inbounds A[i,j] = randn(rng)
-    end
+    return A
 end
 
 #  -----------------------------------------------------------------------------
@@ -229,13 +235,14 @@ function _univariate(d::Wishart)
     check_univariate(d)
     df, S = params(d)
     α = df / 2
-    β = 2Matrix(S)[1]
+    β = 2 * first(S)
     return Gamma(α, β)
 end
 
 function _rand_params(::Type{Wishart}, elty, n::Int, p::Int)
     n == p || throw(ArgumentError("dims must be equal for Wishart"))
-    ν = elty( n - 1 + abs(10randn()) )
-    S = (X = 2rand(elty, n, n) .- 1; X * X')
+    ν = elty(n - 1 + abs(10 * randn()))
+    X = 2 .* rand(elty, n, n) .- 1
+    S = X * X'
     return ν, S
 end

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -94,11 +94,13 @@ rand(::AbstractRNG, ::Distributions.AbstractMvNormal)
 
 function entropy(d::AbstractMvNormal)
     ldcd = logdetcov(d)
-    T = typeof(ldcd)
-    (length(d) * (T(log2π) + one(T)) + ldcd)/2
+    return (length(d) * (oftype(ldcd, log2π) + 1) + ldcd) / 2
 end
 
-mvnormal_c0(g::AbstractMvNormal) = -(length(g) * convert(eltype(g), log2π) + logdetcov(g))/2
+function mvnormal_c0(d::AbstractMvNormal)
+    ldcd = logdetcov(d)
+    return - (length(d) * oftype(ldcd, log2π) + ldcd) / 2
+end
 
 function kldivergence(p::AbstractMvNormal, q::AbstractMvNormal)
     # This is the generic implementation for AbstractMvNormal, you might need to specialize for your type

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -284,4 +284,9 @@ end
     @test rand(d) isa Vector{Float64}
     @test rand(d, 10) isa Matrix{Float64}
     @test rand(d, (3, 2)) isa Matrix{Vector{Float64}}
+
+    # evaluation of `logpdf`
+    # (bug fixed by https://github.com/JuliaStats/Distributions.jl/pull/1429)
+    x = rand(d)
+    @test logpdf(d, x) ≈ logpdf(Normal(), x[1]) + logpdf(Normal(), x[2])
 end


### PR DESCRIPTION
Fix some bugs in the implementation of `Wishart`. Some of them were uncovered by the recent release of PDMats and cause test failures (see e.g. https://github.com/JuliaStats/Distributions.jl/pull/1428#issuecomment-973238410).

Mostly, this PR fixes many undesired and incorrect promotions and `Float64` literals. Additionally, since `AbstractPDMat <: AbstractMatrix` many explicit calls `Matrix(pdmat)` can be removed which are expensive/allocating e.g. for `ScalMat` and `PDiagMat`.

*Edit:* A similar problem existed for `MvNormal` and caused test errors e.g. in https://github.com/TuringLang/DynamicPPL.jl/pull/309.