### PR TITLE
Fix deprecations and test errors on Julia 1.7

### DIFF
--- a/test/density_interface.jl
+++ b/test/density_interface.jl
@@ -4,7 +4,7 @@
     d_uv_continous = Normal(-1.5, 2.3)
     d_uv_discrete = Poisson(4.7)
     d_mv = MvNormal([2.3 0.4; 0.4 1.2])
-    d_av = Distributions.MatrixReshaped(MvNormal(rand(10)), 2, 5)
+    d_av = reshape(MvNormal(Diagonal(rand(10))), 2, 5)
 
     @testset "Distribution" begin
         for d in (d_uv_continous, d_uv_discrete, d_mv, d_av)

--- a/test/locationscale.jl
+++ b/test/locationscale.jl
@@ -102,8 +102,8 @@ function test_location_scale(
 
             @test cdf(d, x) ≈ cdf(dref, x)
             @test logcdf(d, x) ≈ logcdf(dref, x)
-            @test ccdf(d, x) ≈ ccdf(dref, x) atol=1e-15
-            @test logccdf(d, x) ≈ logccdf(dref, x) atol=1e-15
+            @test ccdf(d, x) ≈ ccdf(dref, x) atol=1e-14
+            @test logccdf(d, x) ≈ logccdf(dref, x) atol=1e-14
 
             @test quantile(d,0.1) ≈ quantile(dref,0.1)
             @test quantile(d,0.5) ≈ quantile(dref,0.5)

--- a/test/matrixreshaped.jl
+++ b/test/matrixreshaped.jl
@@ -16,9 +16,9 @@ function test_matrixreshaped(rng, d1, sizes)
         end
     end
     @testset "MatrixReshaped constructor errors" begin
-        @test_throws ArgumentError MatrixReshaped(d1, length(d1), 2)
-        @test_throws ArgumentError MatrixReshaped(d1, length(d1))
-        @test_throws ArgumentError MatrixReshaped(d1, -length(d1), -1)
+        @test_deprecated(@test_throws ArgumentError MatrixReshaped(d1, length(d1), 2))
+        @test_deprecated(@test_throws ArgumentError MatrixReshaped(d1, length(d1)))
+        @test_deprecated(@test_throws ArgumentError MatrixReshaped(d1, -length(d1), -1))
     end
     @testset "MatrixReshaped size" begin
         for (d, s) in zip(d1s[1:end-1], sizes[1:end-1])

--- a/test/matrixvariates.jl
+++ b/test/matrixvariates.jl
@@ -52,13 +52,14 @@ test_draw(d::MatrixDistribution) = test_draw(d, rand(d))
 #  Check that sample quantities are close to population quantities
 #  --------------------------------------------------
 
-function test_draws(d::MatrixDistribution, draws::AbstractArray)
-    @test isapprox(mean(draws), mean(d), atol = 0.1)
-    @test isapprox(cov(hcat(vec.(draws)...)'), cov(d) , atol = 0.1)
+function test_draws(d::MatrixDistribution, draws::AbstractArray{<:AbstractMatrix})
+    @test mean(draws) ≈ mean(d) rtol = 0.01
+    draws_matrix = mapreduce(vec, hcat, draws)
+    @test cov(draws_matrix; dims=2) ≈ cov(d) rtol = 0.1
     nothing
 end
 
-function test_draws(d::LKJ, draws::AbstractArray)
+function test_draws(d::LKJ, draws::AbstractArray{<:AbstractMatrix})
     @test isapprox(mean(draws), mean(d), atol = 0.1)
     @test isapprox(var(draws), var(d) , atol = 0.1)
     nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,7 +79,6 @@ include("testutils.jl")
 
 for t in tests
     @testset "Test $t" begin
-        Random.seed!(345679)
         include("$t.jl")
     end
 end


### PR DESCRIPTION
This PR fixes deprecations in the tests and the test failures on Julia 1.7.

Since to me it seemed more reasonable to specify relative tolerances in the failing test (the order of magnitude of the resulting norms of matrices is unknown), I replaced the absolute tolerances with relative ones. I checked locally that smaller tolerances lead to (random) test failures.