### PR TITLE
Change suffstats to take Type{<:MvNormal} instead of Type{MvNormal}

### DIFF
--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -369,7 +369,7 @@ struct MvNormalStats <: SufficientStats
     tw::Float64         # total sample weight
 end
 
-function suffstats(D::Type{MvNormal}, x::AbstractMatrix{Float64})
+function suffstats(::Type{<:MvNormal}, x::AbstractMatrix{Float64})
     d = size(x, 1)
     n = size(x, 2)
     s = vec(sum(x, dims=2))
@@ -379,7 +379,7 @@ function suffstats(D::Type{MvNormal}, x::AbstractMatrix{Float64})
     MvNormalStats(s, m, s2, Float64(n))
 end
 
-function suffstats(D::Type{MvNormal}, x::AbstractMatrix{Float64}, w::AbstractVector)
+function suffstats(::Type{<:MvNormal}, x::AbstractMatrix{Float64}, w::AbstractVector)
     d = size(x, 1)
     n = size(x, 2)
     length(w) == n || throw(DimensionMismatch("Inconsistent argument dimensions."))

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -191,6 +191,26 @@ function _gauss_mle(x::AbstractMatrix{<:Real}, w::AbstractVector{<:Real})
     return mu, C
 end
 
+@testset "MvNormal suffstats" begin
+    x = randn(3, 200)
+    stat = suffstats(MvNormal, x)
+
+    @test isa(suffstats(MvNormal, x), Distributions.MvNormalStats)
+    @test suffstats(MvNormal{Float64}, x).s2 == stat.s2
+    @test suffstats(FullNormal, x).s2 == stat.s2
+    @test suffstats(DiagNormal, x).s2 == stat.s2
+    @test suffstats(IsoNormal, x).s2 == stat.s2
+
+    w = rand(200)
+    wstat = suffstats(MvNormal, x, w)
+
+    @test isa(wstat, Distributions.MvNormalStats)
+    @test suffstats(MvNormal{Float64}, x, w).s2 == wstat.s2
+    @test suffstats(FullNormal, x, w).s2 == wstat.s2
+    @test suffstats(DiagNormal, x, w).s2 == wstat.s2
+    @test suffstats(IsoNormal, x, w).s2 == wstat.s2
+end
+
 @testset "MvNormal MLE" begin
     x = randn(3, 200) .+ randn(3) * 2.
     w = rand(200)


### PR DESCRIPTION
I was hit by the fact it's only possible to calculate `suffstats` for `Type{MvNormal}` rather than `Type{<:MvNormal}`. That is, currently,

```julia
x = randn(2, 10)
suffstats(MvNormal, x)
```

runs fine, while e.g.

```julia
suffstats(FullNormal, x)
```

errs with `ERROR: suffstats is not implemented for (FullNormal, Matrix{Float64}).`. This PR fixes this by simply changing `suffstats` to take a `Type{<:MvNormal}` instead, which should fix the problem. I believe this addresses the problem also brought up in #809, where the closing PR #884 seems to have missed `suffstats` for `MvNormal`.

I added a few tests also, I've only recently picked up Julia, however, so I wasn't sure about the most idiomatic way of testing this. I'm happy to make changes if this could be done better.