### PR TITLE
Make method ambiguities due to `pdf`, `logpdf`, and `rand!` less likely

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.34"
+version = "0.25.35"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -134,12 +134,6 @@ end
 ## sampling
 
 # multiple univariate with pre-allocated array
-# we use a function barrier since for some distributions `sampler(s)` is not type-stable:
-# https://github.com/JuliaStats/Distributions.jl/pull/1281
-function rand!(rng::AbstractRNG, s::Sampleable{Univariate}, A::AbstractArray{<:Real})
-    return _rand!(rng, sampler(s), A)
-end
-
 function _rand!(rng::AbstractRNG, sampler::Sampleable{Univariate}, A::AbstractArray{<:Real})
     for i in eachindex(A)
         @inbounds A[i] = rand(rng, sampler)


### PR DESCRIPTION
@oxinabox reported on Slack that https://github.com/JuliaStats/Distributions.jl/pull/1437 caused method ambiguity errors in an internal package. This PR reduces the amount of default fallback implementations and hence should make method ambiguity errors due to `pdf`, `logpdf` and `rand!` less likely.

Of course, I don't know if it would solve the issues that @oxinabox had but the PR would fix e.g. issues with implementations of `pdf(::MyMvNormal, x::AbstractVecOrMat)`, `logpdf(::MyMvNormal, x::AbstractVecOrMat)` or `rand!(::AbstractRNG, ::MyMvNormal, x::AbstractVecOrMat)` for custom multivariate normal distribution of type `MyMvNormal`. With the master branch, calling `pdf(::MyMvNormal, x::AbstractVector)`, `logpdf(::MyMvNormal, x::AbstractVector)` or `rand!(::MyMvNormal, x::AbstractVector)` would cause a method ambiguity error since the default fallback is less specific in the first argument but more specific in the second argument. With this PR, the issue would not occur since the default fallback is less specific in both arguments.