### PR TITLE
Remove documentation for LocationScale

### DIFF
--- a/docs/src/univariate.md
+++ b/docs/src/univariate.md
@@ -298,15 +298,6 @@ plotdensity((0, 20), Levy, (0, 1)) # hide
 ```
 
 ```@docs
-LocationScale
-```
-```@example plotdensity
-plotdensity(
-    (-2, 5), LocationScale(2, 1, Normal(0, 1)); title="LocationScale(2, 1, Normal(0, 1))",
-) # hide
-```
-
-```@docs
 Logistic
 ```
 ```@example plotdensity


### PR DESCRIPTION
https://github.com/JuliaStats/Distributions.jl/pull/1453 broke the documentation of LocationScale: https://juliastats.org/Distributions.jl/latest/univariate/ This is quite unfortunate since [I explicitly asked whether it still shows up](https://github.com/JuliaStats/Distributions.jl/pull/1453#issuecomment-997017439).

This PR removes the deprecated `LocationScale` from the documentation.

cc: @ParadaCarleton 