### PR TITLE
Special case Inf and -Inf in truncated

### DIFF
--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -26,10 +26,17 @@ function truncated(d::UnivariateDistribution, l::T, u::T) where {T <: Real}
     else
         logcdf(d, l)
     end
+    _T = typeof(loglcdf)
+    if isfinite(loglcdf) && l == -Inf
+        loglcdf = convert(_T, -Inf)
+    end
     lcdf = exp(loglcdf)
 
     # (log)ucdf = (log) P(X ≤ u) where X ~ d
     logucdf = logcdf(d, u)
+    if isfinite(logucdf) && l == Inf
+        loglcdf = zero(_T)
+    end
     ucdf = exp(logucdf)
 
     # (log)tp = (log) P(l ≤ X ≤ u) where X ∼ d

--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -34,8 +34,8 @@ function truncated(d::UnivariateDistribution, l::T, u::T) where {T <: Real}
 
     # (log)ucdf = (log) P(X ≤ u) where X ~ d
     logucdf = logcdf(d, u)
-    if isfinite(logucdf) && l == Inf
-        loglcdf = zero(_T)
+    if isfinite(logucdf) && u == Inf
+        logucdf = zero(_T)
     end
     ucdf = exp(logucdf)
 

--- a/src/univariate/continuous/normal.jl
+++ b/src/univariate/continuous/normal.jl
@@ -155,10 +155,14 @@ end
 
 function logcdf(d::Normal, x::Real)
     # The Inf cases are useful for ForwardDiff.Dual to avoid NaN derivatives
-    if x == Inf
-        return zero(promote_type(typeof(d.μ), typeof(d.σ), typeof(x)))
-    elseif x == -Inf
-        return convert(promote_type(typeof(d.μ), typeof(d.σ), typeof(x)), -Inf)
+    finited = isfinite(d.μ) && isfinite(d.σ)
+    if !isfinite(x) && !isnan(x) && finited
+        T = typeof(log(one(promote_type(typeof(d.μ), typeof(d.σ), typeof(x)))))
+        if x == Inf
+            return zero(T)
+        else
+            return convert(T, -Inf)
+        end
     elseif iszero(d.σ) && x == d.μ
         z = zval(Normal(zero(d.μ), d.σ), one(x))
     else

--- a/src/univariate/continuous/normal.jl
+++ b/src/univariate/continuous/normal.jl
@@ -154,16 +154,7 @@ function _normlogcdf(z::Real)
 end
 
 function logcdf(d::Normal, x::Real)
-    # The Inf cases are useful for ForwardDiff.Dual to avoid NaN derivatives
-    finited = isfinite(d.μ) && isfinite(d.σ)
-    if !isfinite(x) && !isnan(x) && finited
-        T = typeof(log(one(promote_type(typeof(d.μ), typeof(d.σ), typeof(x)))))
-        if x == Inf
-            return zero(T)
-        else
-            return convert(T, -Inf)
-        end
-    elseif iszero(d.σ) && x == d.μ
+    if iszero(d.σ) && x == d.μ
         z = zval(Normal(zero(d.μ), d.σ), one(x))
     else
         z = zval(d, x)

--- a/src/univariate/continuous/normal.jl
+++ b/src/univariate/continuous/normal.jl
@@ -154,7 +154,12 @@ function _normlogcdf(z::Real)
 end
 
 function logcdf(d::Normal, x::Real)
-    if iszero(d.σ) && x == d.μ
+    # The Inf cases are useful for ForwardDiff.Dual to avoid NaN derivatives
+    if x == Inf
+        return zero(promote_type(typeof(d.μ), typeof(d.σ), typeof(x)))
+    elseif x == -Inf
+        return convert(promote_type(typeof(d.μ), typeof(d.σ), typeof(x)), -Inf)
+    elseif iszero(d.σ) && x == d.μ
         z = zval(Normal(zero(d.μ), d.σ), one(x))
     else
         z = zval(d, x)


### PR DESCRIPTION
This PR fixes a problem that showed up recently but I didn't track down exactly why it shows up now. Currently, the following code produces a `NaN` in the derivative of the log of the normalisation constant of a `Truncated`.
```julia
using ForwardDiff, Distributions

d = truncated(Normal(ForwardDiff.Dual(0.0, 1.0), ForwardDiff.Dual(1.0, 0.0)), 0, Inf)
d.logtp.partials[1] # NaN
```
Since the `logpdf` of a `truncated` subtracts `logtp`, the derivative is always going to be `NaN` at the end. This is clearly wrong and is only an artefact of how ForwardDiff/DiffRules behaviour is undefined for `Inf` values. For example, `x.partials[1]` is `NaN` in:
```julia
x = ForwardDiff.Dual(Inf, 0.0) / ForwardDiff.Dual(0.1, 0.0)
```
causing the `zval`, `(Inf - d.μ) / d.σ`, to give `NaN` in the derivative. This however seems to be the case even in previous versions of ForwardDiff and I haven't tracked down which change in `Distributions.truncated` made this ForwardDiff behaviour significant in the above example.

However, this PR feels like a half fix because:
1. It's not clear which change caused the above issue,
2. There are other similar functions that may need a special case for `Inf` and `-Inf` but I don't need them so I didn't fix their Dual support, and
3. It feels like ForwardDiff or DiffRules should be the place to fix this or special case `Inf` and `-Inf` but that will require a more significant effort.

That said, this PR gets the job done so I am opening it for now to get feedback.