### PR TITLE
Better documentation for LocationScale

### DIFF
--- a/docs/src/extends.md
+++ b/docs/src/extends.md
@@ -2,6 +2,8 @@
 
 Whereas this package already provides a large collection of common distributions out of box, there are still occasions where you want to create new distributions (*e.g* your application requires a special kind of distributions, or you want to contribute to this package).
 
+**Note:** if you only want to change the location and scale of a univariate distribution, see [`LocationScale`](@ref).
+
 Generally, you don't have to implement every API method listed in the documentation. This package provides a series of generic functions that turn a small number of internal methods into user-end API methods. What you need to do is to implement this small set of internal methods for your distributions.
 
 By default, `Discrete` sampleables have support of type `Int` while `Continuous` sampleables have support of type `Float64`. If this assumption does not hold for your new distribution or sampler, or its `ValueSupport` is neither `Discrete` nor `Continuous`, you should implement the `eltype` method in addition to the other methods listed below.

--- a/src/univariate/continuous/tdist.jl
+++ b/src/univariate/continuous/tdist.jl
@@ -15,6 +15,8 @@ params(d)     # Get the parameters, i.e. (ν,)
 dof(d)        # Get the degrees of freedom, i.e. ν
 ```
 
+To create a TDist with a different location and scale, see `LocationScale`.
+
 External links
 
 [Student's T distribution on Wikipedia](https://en.wikipedia.org/wiki/Student%27s_t-distribution)


### PR DESCRIPTION
In the Statistics-course I had last semester, I early on found that I have an issue with normalizing distributions, computing normalized test-statistics, only to rescale the test statistic.

To that end, I looked for a way to change the location and scale of a TDist. I even went as far as trying to define my own generalized `GTDist`, based on https://juliastats.org/Distributions.jl/stable/extends/. But I never succeded.

Lo and behold, there is a function that does exactly what I wanted all along. Or, more precisly, a type: `LocationScale`.

This PR aims to make `LocationScale` more discoverable, by
1) Adding a note about `LocationScale` in the "Create New Samplers and Distributions" section of the docs.
2) Adding a reference to `LocationScale` in the docstring for TDist.

I feel that 2) might be overkill. But as the same time, it was the only distribution that I found the need to scale, and I quickly encountered that need. I also think that overdocumenting is better that underdocumenting, as one can not expect every user to read the entire documentation.

I do not know which (if any) other distributions `LocationScale` is particularly relevant for, but the same pointer should be added if there are.

These are my suggestions on how to make `LocationScale` more discoverable, but others are of course very welcome.

