### PR TITLE
Add fast path for `loglikelihood` of `Uniform`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.41"
+version = "0.25.42"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/test/uniform.jl
+++ b/test/uniform.jl
@@ -6,6 +6,19 @@ using Test
     # affine transformations
     test_affine_transformations(Uniform, rand(), 4 + rand())
 
+    @testset "loglikelihood" begin
+        dist = Uniform(rand(), 2 + rand())
+        for dims in ((10,), (2, 5), (1, 2, 3, 1))
+            # all values in support
+            x = rand(dist, dims...)
+            @test @inferred(loglikelihood(dist, x)) ≈ sum(logpdf.(dist, x))
+
+            # one value not in support
+            x[rand(1:length(x))] = -1
+            @test @inferred(loglikelihood(dist, x)) == -Inf
+        end
+    end
+
     @testset "ChainRules" begin
         # run test suite for values in the support
         dist = Uniform(- 1 - rand(), 1 + rand())
@@ -13,6 +26,11 @@ using Test
         for x in (rand(), -rand())
             test_frule(logpdf, dist ⊢ tangent, x)
             test_rrule(logpdf, dist ⊢ tangent, x)
+        end
+        for dim in ((10,), (2, 5), (1, 2, 3, 1))
+            x = 2 .* rand(dim...) .- 1
+            test_frule(loglikelihood, dist ⊢ tangent, x)
+            test_rrule(loglikelihood, dist ⊢ tangent, x)
         end
 
         # check manually that otherwise derivatives are zero (FiniteDifferences returns NaN)
@@ -29,6 +47,26 @@ using Test
 
             # rrule
             Ω, pullback = @inferred(ChainRulesTestUtils.rrule(logpdf, dist, x))
+            @test Ω == -Inf
+            @test @inferred(pullback(randn())) == (
+                ChainRulesTestUtils.NoTangent(),
+                ChainRulesTestUtils.Tangent{Uniform{Float64}}(; a=0.0, b=0.0),
+                ChainRulesTestUtils.ZeroTangent(),
+            )
+        end
+        for x in (vcat(-2, rand(dist, 9)), vcat(rand(dist, 9), 2))
+            # frule
+            @test @inferred(
+                ChainRulesTestUtils.frule(
+                    (ChainRulesTestUtils.NoTangent(), tangent, randn()),
+                    loglikelihood,
+                    dist,
+                    x,
+                ),
+            ) == (-Inf, 0.0)
+
+            # rrule
+            Ω, pullback = @inferred(ChainRulesTestUtils.rrule(loglikelihood, dist, x))
             @test Ω == -Inf
             @test @inferred(pullback(randn())) == (
                 ChainRulesTestUtils.NoTangent(),


### PR DESCRIPTION
On master:
```julia
julia> using Distributions, BenchmarkTools

julia> a = rand();

julia> b = a + rand();

julia> x = rand(Uniform(a, b), 10_000);

julia> @btime loglikelihood($(Uniform(a, b)), $x);
  77.560 μs (1 allocation: 16 bytes)
```
With this PR:
```julia
julia> using Distributions, BenchmarkTools

julia> a = rand();

julia> b = a + rand();

julia> x = rand(Uniform(a, b), 10_000);

julia> @btime loglikelihood($(Uniform(a, b)), $x);
  8.064 μs (1 allocation: 16 bytes)
```