### PR TITLE
Remove dynamic call in `check_args` macro

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,8 +3,7 @@
 macro check_args(D, cond)
     quote
         if !($(esc(cond)))
-            throw(ArgumentError(string(
-                $(string(D)), ": the condition ", $(string(cond)), " is not satisfied.")))
+            throw(ArgumentError($(string(D, ": the condition ", cond, " is not satisfied."))))
         end
     end
 end


### PR DESCRIPTION
@oschulz This PR fixes your example in https://github.com/JuliaStats/Distributions.jl/issues/1067#issuecomment-1018545600 for me. More concretely, I get
```julia
julia> using Distributions, CUDA

julia> Mu = cu(rand(10));

julia> Sigma = cu(rand(10));

julia> D = Normal.(Mu, Sigma)
10-element CuArray{Normal{Float32}, 1, CUDA.Mem.DeviceBuffer}:
 Normal{Float32}(μ=0.521244f0, σ=0.21886574f0)
 Normal{Float32}(μ=0.71777487f0, σ=0.7293551f0)
 Normal{Float32}(μ=0.9532782f0, σ=0.64151007f0)
 Normal{Float32}(μ=0.053326122f0, σ=0.9042364f0)
 Normal{Float32}(μ=0.7432136f0, σ=0.8857779f0)
 Normal{Float32}(μ=0.12811048f0, σ=0.61526275f0)
 Normal{Float32}(μ=0.25544932f0, σ=0.8564379f0)
 Normal{Float32}(μ=0.71731555f0, σ=0.57268643f0)
 Normal{Float32}(μ=0.17898592f0, σ=0.40761828f0)
 Normal{Float32}(μ=0.71395373f0, σ=0.39995775f0)

julia> X = cu(rand(10));

julia> logpdf.(D, X)
10-element CuArray{Float32, 1, CUDA.Mem.DeviceBuffer}:
 -0.26363182
 -0.6177307
 -0.52780163
 -0.8318763
 -0.980844
 -0.451747
 -0.9199794
 -0.5523126
 -0.7440649
 -0.033901572
```

I don't know how to test this without GPUs though... Maybe we should add some GPU-specific tests and run them with buildkite (I got help with setting it up for OptimalTransport.jl a while ago, so I could add a similar setup here)?