### PR TITLE
Explicitly ignore derivatives of argument checks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.42"
+version = "0.25.43"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.41"
+version = "0.25.42"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/cholesky/lkjcholesky.jl
+++ b/src/cholesky/lkjcholesky.jl
@@ -41,12 +41,11 @@ end
 #  -----------------------------------------------------------------------------
 
 function LKJCholesky(d::Int, η::Real, _uplo::Union{Char,Symbol} = 'L'; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        if check_args
-            d > 0 || throw(ArgumentError("matrix dimension must be positive"))
-            η > 0 || throw(ArgumentError("shape parameter must be positive"))
-        end
-    end
+    @check_args(
+        LKJCholesky,
+        (d > 0, "matrix dimension must be positive"),
+        (η > 0, "shape parameter must be positive"),
+    )
     logc0 = lkj_logc0(d, η)
     uplo = _char_uplo(_uplo)
     T = Base.promote_eltype(η, logc0)

--- a/src/cholesky/lkjcholesky.jl
+++ b/src/cholesky/lkjcholesky.jl
@@ -43,8 +43,8 @@ end
 function LKJCholesky(d::Int, η::Real, _uplo::Union{Char,Symbol} = 'L'; check_args::Bool=true)
     @check_args(
         LKJCholesky,
-        (d > 0, "matrix dimension must be positive"),
-        (η > 0, "shape parameter must be positive"),
+        (d, d > 0, "matrix dimension must be positive"),
+        (η, η > 0, "shape parameter must be positive"),
     )
     logc0 = lkj_logc0(d, η)
     uplo = _char_uplo(_uplo)

--- a/src/cholesky/lkjcholesky.jl
+++ b/src/cholesky/lkjcholesky.jl
@@ -41,9 +41,11 @@ end
 #  -----------------------------------------------------------------------------
 
 function LKJCholesky(d::Int, η::Real, _uplo::Union{Char,Symbol} = 'L'; check_args::Bool=true)
-    if check_args
-        d > 0 || throw(ArgumentError("matrix dimension must be positive"))
-        η > 0 || throw(ArgumentError("shape parameter must be positive"))
+    ChainRulesCore.ignore_derivatives() do
+        if check_args
+            d > 0 || throw(ArgumentError("matrix dimension must be positive"))
+            η > 0 || throw(ArgumentError("shape parameter must be positive"))
+        end
     end
     logc0 = lkj_logc0(d, η)
     uplo = _char_uplo(_uplo)

--- a/src/edgeworth.jl
+++ b/src/edgeworth.jl
@@ -14,9 +14,7 @@ struct EdgeworthZ{D<:UnivariateDistribution} <: EdgeworthAbstract
     n::Float64
 
     function EdgeworthZ{D}(d::UnivariateDistribution, n::Real; check_args::Bool=true) where {D<:UnivariateDistribution}
-        ChainRulesCore.ignore_derivatives() do
-            check_args && @check_args(EdgeworthZ, n > zero(n))
-        end
+        @check_args(EdgeworthZ, n > zero(n))
         new{D}(d, n)
     end
 end
@@ -82,9 +80,7 @@ struct EdgeworthSum{D<:UnivariateDistribution} <: EdgeworthAbstract
     dist::D
     n::Float64
     function EdgeworthSum{D}(d::UnivariateDistribution, n::Real; check_args::Bool=true) where {D<:UnivariateDistribution}
-        ChainRulesCore.ignore_derivatives() do
-            check_args && @check_args(EdgeworthSum, n > zero(n))
-        end
+        @check_args(EdgeworthSum, n > zero(n))
         new{D}(d, n)
     end
 end

--- a/src/edgeworth.jl
+++ b/src/edgeworth.jl
@@ -14,7 +14,9 @@ struct EdgeworthZ{D<:UnivariateDistribution} <: EdgeworthAbstract
     n::Float64
 
     function EdgeworthZ{D}(d::UnivariateDistribution, n::Real; check_args::Bool=true) where {D<:UnivariateDistribution}
-        check_args && @check_args(EdgeworthZ, n > zero(n))
+        ChainRulesCore.ignore_derivatives() do
+            check_args && @check_args(EdgeworthZ, n > zero(n))
+        end
         new{D}(d, n)
     end
 end
@@ -80,7 +82,9 @@ struct EdgeworthSum{D<:UnivariateDistribution} <: EdgeworthAbstract
     dist::D
     n::Float64
     function EdgeworthSum{D}(d::UnivariateDistribution, n::Real; check_args::Bool=true) where {D<:UnivariateDistribution}
-        check_args && @check_args(EdgeworthSum, n > zero(n))
+        ChainRulesCore.ignore_derivatives() do
+            check_args && @check_args(EdgeworthSum, n > zero(n))
+        end
         new{D}(d, n)
     end
 end

--- a/src/edgeworth.jl
+++ b/src/edgeworth.jl
@@ -14,7 +14,7 @@ struct EdgeworthZ{D<:UnivariateDistribution} <: EdgeworthAbstract
     n::Float64
 
     function EdgeworthZ{D}(d::UnivariateDistribution, n::Real; check_args::Bool=true) where {D<:UnivariateDistribution}
-        @check_args(EdgeworthZ, n > zero(n))
+        @check_args EdgeworthZ (n, n > zero(n))
         new{D}(d, n)
     end
 end
@@ -80,7 +80,7 @@ struct EdgeworthSum{D<:UnivariateDistribution} <: EdgeworthAbstract
     dist::D
     n::Float64
     function EdgeworthSum{D}(d::UnivariateDistribution, n::Real; check_args::Bool=true) where {D<:UnivariateDistribution}
-        @check_args(EdgeworthSum, n > zero(n))
+        @check_args EdgeworthSum (n, n > zero(n))
         new{D}(d, n)
     end
 end
@@ -95,14 +95,15 @@ var(d::EdgeworthSum) = d.n*var(d.dist)
 struct EdgeworthMean{D<:UnivariateDistribution} <: EdgeworthAbstract
     dist::D
     n::Float64
-    function EdgeworthMean{D}(d::T, n::Real) where {D<:UnivariateDistribution,T<:UnivariateDistribution}
+    function EdgeworthMean{D}(d::UnivariateDistribution, n::Real; check_args::Bool=true) where {D<:UnivariateDistribution}
         # although n would usually be an integer, no methods are require this
-        n > zero(n) ||
-            error("n must be positive")
+        @check_args EdgeworthMean (n, n > zero(n), "n must be positive")
         new{D}(d, Float64(n))
     end
 end
-EdgeworthMean(d::UnivariateDistribution,n::Real) = EdgeworthMean{typeof(d)}(d,n)
+function EdgeworthMean(d::UnivariateDistribution, n::Real; check_args::Bool=true)
+    return EdgeworthMean{typeof(d)}(d, n; check_args=check_args)
+end
 
 mean(d::EdgeworthMean) = mean(d.dist)
 var(d::EdgeworthMean) = var(d.dist) / d.n

--- a/src/matrix/lkj.jl
+++ b/src/matrix/lkj.jl
@@ -33,12 +33,11 @@ end
 #  -----------------------------------------------------------------------------
 
 function LKJ(d::Integer, η::Real; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        if check_args
-            d > 0 || throw(ArgumentError("Matrix dimension must be positive."))
-            η > 0 || throw(ArgumentError("Shape parameter must be positive."))
-        end
-    end
+    @check_args(
+        LKJ,
+        (d > 0, "matrix dimension must be positive."),
+        (η > 0, "shape parameter must be positive."),
+    )
     logc0 = lkj_logc0(d, η)
     T = Base.promote_eltype(η, logc0)
     LKJ{T, typeof(d)}(d, T(η), T(logc0))
@@ -77,12 +76,11 @@ insupport(d::LKJ, R::AbstractMatrix) = isreal(R) && size(R) == size(d) && isone(
 mean(d::LKJ) = Matrix{partype(d)}(I, dim(d), dim(d))
 
 function mode(d::LKJ; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        if check_args
-            _, η = params(d)
-            η > 1 || throw(ArgumentError("mode is defined only when η > 1."))
-        end
-    end
+    @check_args(
+        LKJ,
+        @setup(_, η = params(d)),
+        (η > 1, "mode is defined only when η > 1."),
+    )
     return mean(d)
 end
 

--- a/src/matrix/lkj.jl
+++ b/src/matrix/lkj.jl
@@ -78,7 +78,7 @@ mean(d::LKJ) = Matrix{partype(d)}(I, dim(d), dim(d))
 function mode(d::LKJ; check_args::Bool=true)
     @check_args(
         LKJ,
-        @setup(_, η = params(d)),
+        @setup((_, η) = params(d)),
         (η > 1, "mode is defined only when η > 1."),
     )
     return mean(d)

--- a/src/matrix/lkj.jl
+++ b/src/matrix/lkj.jl
@@ -35,8 +35,8 @@ end
 function LKJ(d::Integer, η::Real; check_args::Bool=true)
     @check_args(
         LKJ,
-        (d > 0, "matrix dimension must be positive."),
-        (η > 0, "shape parameter must be positive."),
+        (d, d > 0, "matrix dimension must be positive."),
+        (η, η > 0, "shape parameter must be positive."),
     )
     logc0 = lkj_logc0(d, η)
     T = Base.promote_eltype(η, logc0)
@@ -79,7 +79,7 @@ function mode(d::LKJ; check_args::Bool=true)
     @check_args(
         LKJ,
         @setup((_, η) = params(d)),
-        (η > 1, "mode is defined only when η > 1."),
+        (η, η > 1, "mode is defined only when η > 1."),
     )
     return mean(d)
 end

--- a/src/matrix/lkj.jl
+++ b/src/matrix/lkj.jl
@@ -33,9 +33,11 @@ end
 #  -----------------------------------------------------------------------------
 
 function LKJ(d::Integer, η::Real; check_args::Bool=true)
-    if check_args
-        d > 0 || throw(ArgumentError("Matrix dimension must be positive."))
-        η > 0 || throw(ArgumentError("Shape parameter must be positive."))
+    ChainRulesCore.ignore_derivatives() do
+        if check_args
+            d > 0 || throw(ArgumentError("Matrix dimension must be positive."))
+            η > 0 || throw(ArgumentError("Shape parameter must be positive."))
+        end
     end
     logc0 = lkj_logc0(d, η)
     T = Base.promote_eltype(η, logc0)
@@ -75,9 +77,11 @@ insupport(d::LKJ, R::AbstractMatrix) = isreal(R) && size(R) == size(d) && isone(
 mean(d::LKJ) = Matrix{partype(d)}(I, dim(d), dim(d))
 
 function mode(d::LKJ; check_args::Bool=true)
-    p, η = params(d)
-    if check_args
-        η > 1 || throw(ArgumentError("mode is defined only when η > 1."))
+    ChainRulesCore.ignore_derivatives() do
+        if check_args
+            _, η = params(d)
+            η > 1 || throw(ArgumentError("mode is defined only when η > 1."))
+        end
     end
     return mean(d)
 end

--- a/src/multivariate/dirichlet.jl
+++ b/src/multivariate/dirichlet.jl
@@ -26,8 +26,10 @@ struct Dirichlet{T<:Real,Ts<:AbstractVector{T},S<:Real} <: ContinuousMultivariat
     lmnB::S
 
     function Dirichlet{T}(alpha::AbstractVector{T}; check_args::Bool=true) where T
-        if check_args && !all(x -> x > zero(x), alpha)
-            throw(ArgumentError("Dirichlet: alpha must be a positive vector."))
+        ChainRulesCore.ignore_derivatives() do
+            if check_args && !all(x -> x > zero(x), alpha)
+                throw(ArgumentError("Dirichlet: alpha must be a positive vector."))
+            end
         end
         alpha0 = sum(alpha)
         lmnB = sum(loggamma, alpha) - loggamma(alpha0)
@@ -39,7 +41,9 @@ function Dirichlet(alpha::AbstractVector{T}; check_args::Bool=true) where {T<:Re
     Dirichlet{T}(alpha; check_args=check_args)
 end
 function Dirichlet(d::Integer, alpha::Real; check_args::Bool=true)
-    check_args && @check_args(Dirichlet, d > zero(d) && alpha > zero(alpha))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Dirichlet, d > zero(d) && alpha > zero(alpha))
+    end
     return Dirichlet{typeof(alpha)}(Fill(alpha, d); check_args=false)
 end
 

--- a/src/multivariate/dirichlet.jl
+++ b/src/multivariate/dirichlet.jl
@@ -28,7 +28,7 @@ struct Dirichlet{T<:Real,Ts<:AbstractVector{T},S<:Real} <: ContinuousMultivariat
     function Dirichlet{T}(alpha::AbstractVector{T}; check_args::Bool=true) where T
         @check_args(
             Dirichlet,
-            (!all(x -> x > zero(x), alpha), "alpha must be a positive vector."),
+            (all(x -> x > zero(x), alpha), "alpha must be a positive vector."),
         )
         alpha0 = sum(alpha)
         lmnB = sum(loggamma, alpha) - loggamma(alpha0)

--- a/src/multivariate/dirichlet.jl
+++ b/src/multivariate/dirichlet.jl
@@ -28,7 +28,7 @@ struct Dirichlet{T<:Real,Ts<:AbstractVector{T},S<:Real} <: ContinuousMultivariat
     function Dirichlet{T}(alpha::AbstractVector{T}; check_args::Bool=true) where T
         @check_args(
             Dirichlet,
-            (all(x -> x > zero(x), alpha), "alpha must be a positive vector."),
+            (alpha, all(x -> x > zero(x), alpha), "alpha must be a positive vector."),
         )
         alpha0 = sum(alpha)
         lmnB = sum(loggamma, alpha) - loggamma(alpha0)
@@ -40,7 +40,7 @@ function Dirichlet(alpha::AbstractVector{T}; check_args::Bool=true) where {T<:Re
     Dirichlet{T}(alpha; check_args=check_args)
 end
 function Dirichlet(d::Integer, alpha::Real; check_args::Bool=true)
-    @check_args(Dirichlet, d > zero(d), alpha > zero(alpha))
+    @check_args Dirichlet (d, d > zero(d)) (alpha, alpha > zero(alpha))
     return Dirichlet{typeof(alpha)}(Fill(alpha, d); check_args=false)
 end
 

--- a/src/multivariate/dirichlet.jl
+++ b/src/multivariate/dirichlet.jl
@@ -26,11 +26,10 @@ struct Dirichlet{T<:Real,Ts<:AbstractVector{T},S<:Real} <: ContinuousMultivariat
     lmnB::S
 
     function Dirichlet{T}(alpha::AbstractVector{T}; check_args::Bool=true) where T
-        ChainRulesCore.ignore_derivatives() do
-            if check_args && !all(x -> x > zero(x), alpha)
-                throw(ArgumentError("Dirichlet: alpha must be a positive vector."))
-            end
-        end
+        @check_args(
+            Dirichlet,
+            (!all(x -> x > zero(x), alpha), "alpha must be a positive vector."),
+        )
         alpha0 = sum(alpha)
         lmnB = sum(loggamma, alpha) - loggamma(alpha0)
         new{T,typeof(alpha),typeof(lmnB)}(alpha, alpha0, lmnB)
@@ -41,9 +40,7 @@ function Dirichlet(alpha::AbstractVector{T}; check_args::Bool=true) where {T<:Re
     Dirichlet{T}(alpha; check_args=check_args)
 end
 function Dirichlet(d::Integer, alpha::Real; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Dirichlet, d > zero(d) && alpha > zero(alpha))
-    end
+    @check_args(Dirichlet, d > zero(d), alpha > zero(alpha))
     return Dirichlet{typeof(alpha)}(Fill(alpha, d); check_args=false)
 end
 

--- a/src/multivariate/multinomial.jl
+++ b/src/multivariate/multinomial.jl
@@ -26,21 +26,21 @@ struct Multinomial{T<:Real, TV<:AbstractVector{T}} <: DiscreteMultivariateDistri
 end
 
 function Multinomial(n::Integer, p::AbstractVector{T}; check_args::Bool=true) where {T<:Real}
-    if check_args
-        if n < 0
-            throw(ArgumentError("n must be a nonnegative integer."))
-        end
-        if !isprobvec(p)
-            throw(ArgumentError("p = $p is not a probability vector."))
+    ChainRulesCore.ignore_derivatives() do
+        if check_args
+            @check_args(Multinomial, n >= 0)
+            isprobvec(p) || throw(ArgumentError("p = $p is not a probability vector."))
         end
     end
     return Multinomial{T,typeof(p)}(n, p)
 end
 
 function Multinomial(n::Integer, k::Integer; check_args::Bool=true)
-    if check_args
-        @check_args(Multinomial, n >= 0)
-        @check_args(Multinomial, k >= 1)
+    ChainRulesCore.ignore_derivatives() do
+        if check_args
+            @check_args(Multinomial, n >= 0)
+            @check_args(Multinomial, k >= 1)
+        end
     end
     return Multinomial{Float64, Vector{Float64}}(round(Int, n), fill(1.0 / k, k))
 end

--- a/src/multivariate/multinomial.jl
+++ b/src/multivariate/multinomial.jl
@@ -28,14 +28,14 @@ end
 function Multinomial(n::Integer, p::AbstractVector{T}; check_args::Bool=true) where {T<:Real}
     @check_args(
         Multinomial,
-        n >= 0,
-        (isprobvec(p), "p is not a probability vector."),
+        (n, n >= 0),
+        (p, isprobvec(p), "p is not a probability vector."),
     )
     return Multinomial{T,typeof(p)}(n, p)
 end
 
 function Multinomial(n::Integer, k::Integer; check_args::Bool=true)
-    @check_args(Multinomial, n >= 0, k >= 1)
+    @check_args Multinomial (n, n >= 0) (k, k >= 1)
     return Multinomial{Float64, Vector{Float64}}(round(Int, n), fill(1.0 / k, k))
 end
 

--- a/src/multivariate/multinomial.jl
+++ b/src/multivariate/multinomial.jl
@@ -26,22 +26,16 @@ struct Multinomial{T<:Real, TV<:AbstractVector{T}} <: DiscreteMultivariateDistri
 end
 
 function Multinomial(n::Integer, p::AbstractVector{T}; check_args::Bool=true) where {T<:Real}
-    ChainRulesCore.ignore_derivatives() do
-        if check_args
-            @check_args(Multinomial, n >= 0)
-            isprobvec(p) || throw(ArgumentError("p = $p is not a probability vector."))
-        end
-    end
+    @check_args(
+        Multinomial,
+        n >= 0,
+        (isprobvec(p), "p is not a probability vector."),
+    )
     return Multinomial{T,typeof(p)}(n, p)
 end
 
 function Multinomial(n::Integer, k::Integer; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        if check_args
-            @check_args(Multinomial, n >= 0)
-            @check_args(Multinomial, k >= 1)
-        end
-    end
+    @check_args(Multinomial, n >= 0, k >= 1)
     return Multinomial{Float64, Vector{Float64}}(round(Int, n), fill(1.0 / k, k))
 end
 

--- a/src/univariate/continuous/arcsine.jl
+++ b/src/univariate/continuous/arcsine.jl
@@ -32,7 +32,7 @@ struct Arcsine{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Arcsine(a::T, b::T; check_args::Bool=true) where {T <: Real}
-    @check_args(Arcsine, a < b)
+    @check_args Arcsine a < b
     return Arcsine{T}(a, b)
 end
 

--- a/src/univariate/continuous/arcsine.jl
+++ b/src/univariate/continuous/arcsine.jl
@@ -32,7 +32,9 @@ struct Arcsine{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Arcsine(a::T, b::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(Arcsine, a < b)
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Arcsine, a < b)
+    end
     return Arcsine{T}(a, b)
 end
 

--- a/src/univariate/continuous/arcsine.jl
+++ b/src/univariate/continuous/arcsine.jl
@@ -32,9 +32,7 @@ struct Arcsine{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Arcsine(a::T, b::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Arcsine, a < b)
-    end
+    @check_args(Arcsine, a < b)
     return Arcsine{T}(a, b)
 end
 

--- a/src/univariate/continuous/beta.jl
+++ b/src/univariate/continuous/beta.jl
@@ -33,18 +33,14 @@ struct Beta{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Beta(α::T, β::T; check_args::Bool=true) where {T<:Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Beta, α > zero(α) && β > zero(β))
-    end
+    @check_args(Beta, α > zero(α), β > zero(β))
     return Beta{T}(α, β)
 end
 
 Beta(α::Real, β::Real; check_args::Bool=true) = Beta(promote(α, β)...; check_args=check_args)
 Beta(α::Integer, β::Integer; check_args::Bool=true) = Beta(float(α), float(β); check_args=check_args)
 function Beta(α::Real; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Beta, α > zero(α))
-    end
+    @check_args(Beta, α > zero(α))
     Beta(α, α; check_args=false)
 end
 Beta() = Beta{Float64}(1.0, 1.0)
@@ -71,11 +67,10 @@ mean(d::Beta) = ((α, β) = params(d); α / (α + β))
 
 function mode(d::Beta; check_args::Bool=true)
     α, β = params(d)
-    ChainRulesCore.ignore_derivatives() do
-        if check_args
-            (α > 1 && β > 1) || error("mode is defined only when α > 1 and β > 1.")
-        end
-    end
+    @check_args(
+        Beta,
+        (α > 1 && β > 1, "mode is defined only when α > 1 and β > 1."),
+    )
     return (α - 1) / (α + β - 2)
 end
 

--- a/src/univariate/continuous/beta.jl
+++ b/src/univariate/continuous/beta.jl
@@ -33,14 +33,14 @@ struct Beta{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Beta(α::T, β::T; check_args::Bool=true) where {T<:Real}
-    @check_args(Beta, α > zero(α), β > zero(β))
+    @check_args Beta (α, α > zero(α)) (β, β > zero(β))
     return Beta{T}(α, β)
 end
 
 Beta(α::Real, β::Real; check_args::Bool=true) = Beta(promote(α, β)...; check_args=check_args)
 Beta(α::Integer, β::Integer; check_args::Bool=true) = Beta(float(α), float(β); check_args=check_args)
 function Beta(α::Real; check_args::Bool=true)
-    @check_args(Beta, α > zero(α))
+    @check_args Beta (α, α > zero(α))
     Beta(α, α; check_args=false)
 end
 Beta() = Beta{Float64}(1.0, 1.0)
@@ -69,7 +69,8 @@ function mode(d::Beta; check_args::Bool=true)
     α, β = params(d)
     @check_args(
         Beta,
-        (α > 1 && β > 1, "mode is defined only when α > 1 and β > 1."),
+        (α, α > 1, "mode is defined only when α > 1."),
+        (β, β > 1, "mode is defined only when β > 1."),
     )
     return (α - 1) / (α + β - 2)
 end

--- a/src/univariate/continuous/beta.jl
+++ b/src/univariate/continuous/beta.jl
@@ -33,14 +33,18 @@ struct Beta{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Beta(α::T, β::T; check_args::Bool=true) where {T<:Real}
-    check_args && @check_args(Beta, α > zero(α) && β > zero(β))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Beta, α > zero(α) && β > zero(β))
+    end
     return Beta{T}(α, β)
 end
 
 Beta(α::Real, β::Real; check_args::Bool=true) = Beta(promote(α, β)...; check_args=check_args)
 Beta(α::Integer, β::Integer; check_args::Bool=true) = Beta(float(α), float(β); check_args=check_args)
 function Beta(α::Real; check_args::Bool=true)
-    check_args && @check_args(Beta, α > zero(α))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Beta, α > zero(α))
+    end
     Beta(α, α; check_args=false)
 end
 Beta() = Beta{Float64}(1.0, 1.0)
@@ -66,9 +70,11 @@ params(d::Beta) = (d.α, d.β)
 mean(d::Beta) = ((α, β) = params(d); α / (α + β))
 
 function mode(d::Beta; check_args::Bool=true)
-    (α, β) = params(d)
-    if check_args
-        (α > 1 && β > 1) || error("mode is defined only when α > 1 and β > 1.")
+    α, β = params(d)
+    ChainRulesCore.ignore_derivatives() do
+        if check_args
+            (α > 1 && β > 1) || error("mode is defined only when α > 1 and β > 1.")
+        end
     end
     return (α - 1) / (α + β - 2)
 end

--- a/src/univariate/continuous/betaprime.jl
+++ b/src/univariate/continuous/betaprime.jl
@@ -33,14 +33,14 @@ struct BetaPrime{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function BetaPrime(α::T, β::T; check_args::Bool=true) where {T<:Real}
-    @check_args(BetaPrime, α > zero(α), β > zero(β))
+    @check_args BetaPrime (α, α > zero(α)) (β, β > zero(β))
     return BetaPrime{T}(α, β)
 end
 
 BetaPrime(α::Real, β::Real; check_args::Bool=true) = BetaPrime(promote(α, β)...; check_args=check_args)
 BetaPrime(α::Integer, β::Integer; check_args::Bool=true) = BetaPrime(float(α), float(β); check_args=check_args)
 function BetaPrime(α::Real; check_args::Bool=true)
-    @check_args(BetaPrime, α > zero(α))
+    @check_args BetaPrime (α, α > zero(α))
     BetaPrime(α, α; check_args=false)
 end
 BetaPrime() = BetaPrime{Float64}(1.0, 1.0)

--- a/src/univariate/continuous/betaprime.jl
+++ b/src/univariate/continuous/betaprime.jl
@@ -33,18 +33,14 @@ struct BetaPrime{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function BetaPrime(α::T, β::T; check_args::Bool=true) where {T<:Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(BetaPrime, α > zero(α) && β > zero(β))
-    end
+    @check_args(BetaPrime, α > zero(α), β > zero(β))
     return BetaPrime{T}(α, β)
 end
 
 BetaPrime(α::Real, β::Real; check_args::Bool=true) = BetaPrime(promote(α, β)...; check_args=check_args)
 BetaPrime(α::Integer, β::Integer; check_args::Bool=true) = BetaPrime(float(α), float(β); check_args=check_args)
 function BetaPrime(α::Real; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(BetaPrime, α > zero(α))
-    end
+    @check_args(BetaPrime, α > zero(α))
     BetaPrime(α, α; check_args=false)
 end
 BetaPrime() = BetaPrime{Float64}(1.0, 1.0)

--- a/src/univariate/continuous/betaprime.jl
+++ b/src/univariate/continuous/betaprime.jl
@@ -33,14 +33,18 @@ struct BetaPrime{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function BetaPrime(α::T, β::T; check_args::Bool=true) where {T<:Real}
-    check_args && @check_args(BetaPrime, α > zero(α) && β > zero(β))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(BetaPrime, α > zero(α) && β > zero(β))
+    end
     return BetaPrime{T}(α, β)
 end
 
 BetaPrime(α::Real, β::Real; check_args::Bool=true) = BetaPrime(promote(α, β)...; check_args=check_args)
 BetaPrime(α::Integer, β::Integer; check_args::Bool=true) = BetaPrime(float(α), float(β); check_args=check_args)
 function BetaPrime(α::Real; check_args::Bool=true)
-    check_args && @check_args(BetaPrime, α > zero(α))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(BetaPrime, α > zero(α))
+    end
     BetaPrime(α, α; check_args=false)
 end
 BetaPrime() = BetaPrime{Float64}(1.0, 1.0)

--- a/src/univariate/continuous/biweight.jl
+++ b/src/univariate/continuous/biweight.jl
@@ -8,7 +8,7 @@ struct Biweight{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Biweight(μ::T, σ::T; check_args::Bool=true) where {T<:Real}
-    @check_args(Biweight, σ > zero(σ))
+    @check_args Biweight (σ, σ > zero(σ))
     return Biweight{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/biweight.jl
+++ b/src/univariate/continuous/biweight.jl
@@ -8,7 +8,9 @@ struct Biweight{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Biweight(μ::T, σ::T; check_args::Bool=true) where {T<:Real}
-    check_args && @check_args(Biweight, σ > zero(σ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Biweight, σ > zero(σ))
+    end
     return Biweight{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/biweight.jl
+++ b/src/univariate/continuous/biweight.jl
@@ -8,9 +8,7 @@ struct Biweight{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Biweight(μ::T, σ::T; check_args::Bool=true) where {T<:Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Biweight, σ > zero(σ))
-    end
+    @check_args(Biweight, σ > zero(σ))
     return Biweight{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/cauchy.jl
+++ b/src/univariate/continuous/cauchy.jl
@@ -29,9 +29,7 @@ struct Cauchy{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Cauchy(μ::T, σ::T; check_args::Bool=true) where {T<:Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Cauchy, σ > zero(σ))
-    end
+    @check_args(Cauchy, σ > zero(σ))
     return Cauchy{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/cauchy.jl
+++ b/src/univariate/continuous/cauchy.jl
@@ -29,7 +29,7 @@ struct Cauchy{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Cauchy(μ::T, σ::T; check_args::Bool=true) where {T<:Real}
-    @check_args(Cauchy, σ > zero(σ))
+    @check_args Cauchy (σ, σ > zero(σ))
     return Cauchy{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/cauchy.jl
+++ b/src/univariate/continuous/cauchy.jl
@@ -29,7 +29,9 @@ struct Cauchy{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Cauchy(μ::T, σ::T; check_args::Bool=true) where {T<:Real}
-    check_args && @check_args(Cauchy, σ > zero(σ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Cauchy, σ > zero(σ))
+    end
     return Cauchy{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/chi.jl
+++ b/src/univariate/continuous/chi.jl
@@ -27,9 +27,7 @@ struct Chi{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Chi(ν::Real; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Chi, ν > zero(ν))
-    end
+    @check_args(Chi, ν > zero(ν))
     return Chi{typeof(ν)}(ν)
 end
 
@@ -73,11 +71,10 @@ entropy(d::Chi{T}) where {T<:Real} = (ν = d.ν;
 
 function mode(d::Chi; check_args::Bool=true)
     ν = d.ν
-    ChainRulesCore.ignore_derivatives() do
-        if check_args
-            ν >= 1 || error("Chi distribution has no mode when ν < 1")
-        end
-    end
+    @check_args(
+        Chi,
+        (ν >= 1, "Chi distribution has no mode when ν < 1"),
+    )
     sqrt(ν - 1)
 end
 

--- a/src/univariate/continuous/chi.jl
+++ b/src/univariate/continuous/chi.jl
@@ -27,7 +27,9 @@ struct Chi{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Chi(ν::Real; check_args::Bool=true)
-    check_args && @check_args(Chi, ν > zero(ν))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Chi, ν > zero(ν))
+    end
     return Chi{typeof(ν)}(ν)
 end
 
@@ -71,8 +73,10 @@ entropy(d::Chi{T}) where {T<:Real} = (ν = d.ν;
 
 function mode(d::Chi; check_args::Bool=true)
     ν = d.ν
-    if check_args
-        ν >= 1 || error("Chi distribution has no mode when ν < 1")
+    ChainRulesCore.ignore_derivatives() do
+        if check_args
+            ν >= 1 || error("Chi distribution has no mode when ν < 1")
+        end
     end
     sqrt(ν - 1)
 end

--- a/src/univariate/continuous/chi.jl
+++ b/src/univariate/continuous/chi.jl
@@ -27,7 +27,7 @@ struct Chi{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Chi(ν::Real; check_args::Bool=true)
-    @check_args(Chi, ν > zero(ν))
+    @check_args Chi (ν, ν > zero(ν))
     return Chi{typeof(ν)}(ν)
 end
 
@@ -73,7 +73,7 @@ function mode(d::Chi; check_args::Bool=true)
     ν = d.ν
     @check_args(
         Chi,
-        (ν >= 1, "Chi distribution has no mode when ν < 1"),
+        (ν, ν >= 1, "Chi distribution has no mode when ν < 1"),
     )
     sqrt(ν - 1)
 end

--- a/src/univariate/continuous/chisq.jl
+++ b/src/univariate/continuous/chisq.jl
@@ -26,9 +26,7 @@ struct Chisq{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Chisq(ν::Real; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Chisq, ν > zero(ν))
-    end
+    @check_args(Chisq, ν > zero(ν))
     return Chisq{typeof(ν)}(ν)
 end
 

--- a/src/univariate/continuous/chisq.jl
+++ b/src/univariate/continuous/chisq.jl
@@ -26,7 +26,7 @@ struct Chisq{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Chisq(ν::Real; check_args::Bool=true)
-    @check_args(Chisq, ν > zero(ν))
+    @check_args Chisq (ν, ν > zero(ν))
     return Chisq{typeof(ν)}(ν)
 end
 

--- a/src/univariate/continuous/chisq.jl
+++ b/src/univariate/continuous/chisq.jl
@@ -26,7 +26,9 @@ struct Chisq{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Chisq(ν::Real; check_args::Bool=true)
-    check_args && @check_args(Chisq, ν > zero(ν))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Chisq, ν > zero(ν))
+    end
     return Chisq{typeof(ν)}(ν)
 end
 

--- a/src/univariate/continuous/cosine.jl
+++ b/src/univariate/continuous/cosine.jl
@@ -14,9 +14,7 @@ struct Cosine{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Cosine(μ::T, σ::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Cosine, σ > zero(σ))
-    end
+    @check_args(Cosine, σ > zero(σ))
     return Cosine{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/cosine.jl
+++ b/src/univariate/continuous/cosine.jl
@@ -14,7 +14,9 @@ struct Cosine{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Cosine(μ::T, σ::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(Cosine, σ > zero(σ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Cosine, σ > zero(σ))
+    end
     return Cosine{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/cosine.jl
+++ b/src/univariate/continuous/cosine.jl
@@ -14,7 +14,7 @@ struct Cosine{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Cosine(μ::T, σ::T; check_args::Bool=true) where {T <: Real}
-    @check_args(Cosine, σ > zero(σ))
+    @check_args Cosine (σ, σ > zero(σ))
     return Cosine{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/epanechnikov.jl
+++ b/src/univariate/continuous/epanechnikov.jl
@@ -8,7 +8,7 @@ struct Epanechnikov{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Epanechnikov(μ::T, σ::T; check_args::Bool=true) where {T<:Real}
-    @check_args(Epanechnikov, σ > zero(σ))
+    @check_args Epanechnikov (σ, σ > zero(σ))
     return Epanechnikov{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/epanechnikov.jl
+++ b/src/univariate/continuous/epanechnikov.jl
@@ -8,9 +8,7 @@ struct Epanechnikov{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Epanechnikov(μ::T, σ::T; check_args::Bool=true) where {T<:Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Epanechnikov, σ > zero(σ))
-    end
+    @check_args(Epanechnikov, σ > zero(σ))
     return Epanechnikov{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/epanechnikov.jl
+++ b/src/univariate/continuous/epanechnikov.jl
@@ -8,7 +8,9 @@ struct Epanechnikov{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Epanechnikov(μ::T, σ::T; check_args::Bool=true) where {T<:Real}
-    check_args && @check_args(Epanechnikov, σ > zero(σ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Epanechnikov, σ > zero(σ))
+    end
     return Epanechnikov{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/erlang.jl
+++ b/src/univariate/continuous/erlang.jl
@@ -21,12 +21,16 @@ struct Erlang{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Erlang(α::Real, θ::Real; check_args::Bool=true)
-    check_args && @check_args(Erlang, isinteger(α) && α >= zero(α))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Erlang, isinteger(α) && α >= zero(α))
+    end
     return Erlang{typeof(θ)}(α, θ)
 end
 
 function Erlang(α::Integer, θ::Real; check_args::Bool=true)
-    check_args && @check_args(Erlang, α >= zero(α))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Erlang, α >= zero(α))
+    end
     return Erlang{typeof(θ)}(α, θ)
 end
 
@@ -63,8 +67,10 @@ kurtosis(d::Erlang) = 6 / d.α
 
 function mode(d::Erlang; check_args::Bool=true)
     α, θ = params(d)
-    if check_args
-        α >= 1 || error("Erlang has no mode when α < 1")
+    ChainRulesCore.ignore_derivatives() do
+        if check_args
+            α >= 1 || error("Erlang has no mode when α < 1")
+        end
     end
     θ * (α - 1)
 end

--- a/src/univariate/continuous/erlang.jl
+++ b/src/univariate/continuous/erlang.jl
@@ -21,12 +21,12 @@ struct Erlang{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Erlang(α::Real, θ::Real; check_args::Bool=true)
-    @check_args(Erlang, isinteger(α), α >= zero(α))
+    @check_args Erlang (α, isinteger(α)) (α, α >= zero(α))
     return Erlang{typeof(θ)}(α, θ)
 end
 
 function Erlang(α::Integer, θ::Real; check_args::Bool=true)
-    @check_args(Erlang, α >= zero(α))
+    @check_args Erlang (α, α >= zero(α))
     return Erlang{typeof(θ)}(α, θ)
 end
 
@@ -65,7 +65,7 @@ function mode(d::Erlang; check_args::Bool=true)
     α, θ = params(d)
     @check_args(
         Erlang,
-        (α >= 1, "Erlang has no mode when α < 1"),
+        (α, α >= 1, "Erlang has no mode when α < 1"),
     )
     θ * (α - 1)
 end

--- a/src/univariate/continuous/erlang.jl
+++ b/src/univariate/continuous/erlang.jl
@@ -21,16 +21,12 @@ struct Erlang{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Erlang(α::Real, θ::Real; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Erlang, isinteger(α) && α >= zero(α))
-    end
+    @check_args(Erlang, isinteger(α), α >= zero(α))
     return Erlang{typeof(θ)}(α, θ)
 end
 
 function Erlang(α::Integer, θ::Real; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Erlang, α >= zero(α))
-    end
+    @check_args(Erlang, α >= zero(α))
     return Erlang{typeof(θ)}(α, θ)
 end
 
@@ -67,11 +63,10 @@ kurtosis(d::Erlang) = 6 / d.α
 
 function mode(d::Erlang; check_args::Bool=true)
     α, θ = params(d)
-    ChainRulesCore.ignore_derivatives() do
-        if check_args
-            α >= 1 || error("Erlang has no mode when α < 1")
-        end
-    end
+    @check_args(
+        Erlang,
+        (α >= 1, "Erlang has no mode when α < 1"),
+    )
     θ * (α - 1)
 end
 

--- a/src/univariate/continuous/exponential.jl
+++ b/src/univariate/continuous/exponential.jl
@@ -27,7 +27,9 @@ struct Exponential{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Exponential(θ::Real; check_args::Bool=true)
-    check_args && @check_args(Exponential, θ > zero(θ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Exponential, θ > zero(θ))
+    end
     return Exponential{typeof(θ)}(θ)
 end
 

--- a/src/univariate/continuous/exponential.jl
+++ b/src/univariate/continuous/exponential.jl
@@ -27,7 +27,7 @@ struct Exponential{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Exponential(θ::Real; check_args::Bool=true)
-    @check_args(Exponential, θ > zero(θ))
+    @check_args Exponential (θ, θ > zero(θ))
     return Exponential{typeof(θ)}(θ)
 end
 

--- a/src/univariate/continuous/exponential.jl
+++ b/src/univariate/continuous/exponential.jl
@@ -27,9 +27,7 @@ struct Exponential{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Exponential(θ::Real; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Exponential, θ > zero(θ))
-    end
+    @check_args(Exponential, θ > zero(θ))
     return Exponential{typeof(θ)}(θ)
 end
 

--- a/src/univariate/continuous/fdist.jl
+++ b/src/univariate/continuous/fdist.jl
@@ -27,7 +27,7 @@ struct FDist{T<:Real} <: ContinuousUnivariateDistribution
     ν2::T
 
     function FDist{T}(ν1::T, ν2::T; check_args::Bool=true) where T
-        @check_args(FDist, ν1 > zero(ν1), ν2 > zero(ν2))
+        @check_args FDist (ν1, ν1 > zero(ν1)) (ν2, ν2 > zero(ν2))
         new{T}(ν1, ν2)
     end
 end

--- a/src/univariate/continuous/fdist.jl
+++ b/src/univariate/continuous/fdist.jl
@@ -27,9 +27,7 @@ struct FDist{T<:Real} <: ContinuousUnivariateDistribution
     ν2::T
 
     function FDist{T}(ν1::T, ν2::T; check_args::Bool=true) where T
-        ChainRulesCore.ignore_derivatives() do
-            check_args && @check_args(FDist, ν1 > zero(ν1) && ν2 > zero(ν2))
-        end
+        @check_args(FDist, ν1 > zero(ν1), ν2 > zero(ν2))
         new{T}(ν1, ν2)
     end
 end

--- a/src/univariate/continuous/fdist.jl
+++ b/src/univariate/continuous/fdist.jl
@@ -27,7 +27,9 @@ struct FDist{T<:Real} <: ContinuousUnivariateDistribution
     ν2::T
 
     function FDist{T}(ν1::T, ν2::T; check_args::Bool=true) where T
-        check_args && @check_args(FDist, ν1 > zero(ν1) && ν2 > zero(ν2))
+        ChainRulesCore.ignore_derivatives() do
+            check_args && @check_args(FDist, ν1 > zero(ν1) && ν2 > zero(ν2))
+        end
         new{T}(ν1, ν2)
     end
 end

--- a/src/univariate/continuous/frechet.jl
+++ b/src/univariate/continuous/frechet.jl
@@ -30,9 +30,7 @@ struct Frechet{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Frechet(α::T, θ::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Frechet, α > zero(α) && θ > zero(θ))
-    end
+    @check_args(Frechet, α > zero(α), θ > zero(θ))
     return Frechet{T}(α, θ)
 end
 

--- a/src/univariate/continuous/frechet.jl
+++ b/src/univariate/continuous/frechet.jl
@@ -30,7 +30,9 @@ struct Frechet{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Frechet(α::T, θ::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(Frechet, α > zero(α) && θ > zero(θ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Frechet, α > zero(α) && θ > zero(θ))
+    end
     return Frechet{T}(α, θ)
 end
 

--- a/src/univariate/continuous/frechet.jl
+++ b/src/univariate/continuous/frechet.jl
@@ -30,7 +30,7 @@ struct Frechet{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Frechet(α::T, θ::T; check_args::Bool=true) where {T <: Real}
-    @check_args(Frechet, α > zero(α), θ > zero(θ))
+    @check_args Frechet (α, α > zero(α)) (θ, θ > zero(θ))
     return Frechet{T}(α, θ)
 end
 

--- a/src/univariate/continuous/gamma.jl
+++ b/src/univariate/continuous/gamma.jl
@@ -31,7 +31,7 @@ struct Gamma{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Gamma(α::T, θ::T; check_args::Bool=true) where {T <: Real}
-    @check_args(Gamma, α > zero(α), θ > zero(θ))
+    @check_args Gamma (α, α > zero(α)) (θ, θ > zero(θ))
     return Gamma{T}(α, θ)
 end
 

--- a/src/univariate/continuous/gamma.jl
+++ b/src/univariate/continuous/gamma.jl
@@ -31,7 +31,9 @@ struct Gamma{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Gamma(α::T, θ::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(Gamma, α > zero(α) && θ > zero(θ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Gamma, α > zero(α) && θ > zero(θ))
+    end
     return Gamma{T}(α, θ)
 end
 

--- a/src/univariate/continuous/gamma.jl
+++ b/src/univariate/continuous/gamma.jl
@@ -31,9 +31,7 @@ struct Gamma{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Gamma(α::T, θ::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Gamma, α > zero(α) && θ > zero(θ))
-    end
+    @check_args(Gamma, α > zero(α), θ > zero(θ))
     return Gamma{T}(α, θ)
 end
 

--- a/src/univariate/continuous/generalizedpareto.jl
+++ b/src/univariate/continuous/generalizedpareto.jl
@@ -38,7 +38,7 @@ struct GeneralizedPareto{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function GeneralizedPareto(μ::T, σ::T, ξ::T; check_args::Bool=true) where {T <: Real}
-    @check_args(GeneralizedPareto, σ > zero(σ))
+    @check_args GeneralizedPareto (σ, σ > zero(σ))
     return GeneralizedPareto{T}(μ, σ, ξ)
 end
 

--- a/src/univariate/continuous/generalizedpareto.jl
+++ b/src/univariate/continuous/generalizedpareto.jl
@@ -38,9 +38,7 @@ struct GeneralizedPareto{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function GeneralizedPareto(μ::T, σ::T, ξ::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(GeneralizedPareto, σ > zero(σ))
-    end
+    @check_args(GeneralizedPareto, σ > zero(σ))
     return GeneralizedPareto{T}(μ, σ, ξ)
 end
 

--- a/src/univariate/continuous/generalizedpareto.jl
+++ b/src/univariate/continuous/generalizedpareto.jl
@@ -38,7 +38,9 @@ struct GeneralizedPareto{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function GeneralizedPareto(μ::T, σ::T, ξ::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(GeneralizedPareto, σ > zero(σ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(GeneralizedPareto, σ > zero(σ))
+    end
     return GeneralizedPareto{T}(μ, σ, ξ)
 end
 

--- a/src/univariate/continuous/gumbel.jl
+++ b/src/univariate/continuous/gumbel.jl
@@ -29,7 +29,7 @@ struct Gumbel{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Gumbel(μ::T, θ::T; check_args::Bool=true) where {T <: Real}
-    @check_args(Gumbel, θ > zero(θ))
+    @check_args Gumbel (θ, θ > zero(θ))
     return Gumbel{T}(μ, θ)
 end
 

--- a/src/univariate/continuous/gumbel.jl
+++ b/src/univariate/continuous/gumbel.jl
@@ -29,7 +29,9 @@ struct Gumbel{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Gumbel(μ::T, θ::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(Gumbel, θ > zero(θ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Gumbel, θ > zero(θ))
+    end
     return Gumbel{T}(μ, θ)
 end
 

--- a/src/univariate/continuous/gumbel.jl
+++ b/src/univariate/continuous/gumbel.jl
@@ -29,9 +29,7 @@ struct Gumbel{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Gumbel(μ::T, θ::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Gumbel, θ > zero(θ))
-    end
+    @check_args(Gumbel, θ > zero(θ))
     return Gumbel{T}(μ, θ)
 end
 

--- a/src/univariate/continuous/inversegamma.jl
+++ b/src/univariate/continuous/inversegamma.jl
@@ -32,7 +32,9 @@ struct InverseGamma{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function InverseGamma(α::T, θ::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(InverseGamma, α > zero(α) && θ > zero(θ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(InverseGamma, α > zero(α) && θ > zero(θ))
+    end
     return InverseGamma{T}(α, θ)
 end
 

--- a/src/univariate/continuous/inversegamma.jl
+++ b/src/univariate/continuous/inversegamma.jl
@@ -32,7 +32,7 @@ struct InverseGamma{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function InverseGamma(α::T, θ::T; check_args::Bool=true) where {T <: Real}
-    @check_args(InverseGamma, α > zero(α), θ > zero(θ))
+    @check_args InverseGamma (α, α > zero(α)) (θ, θ > zero(θ))
     return InverseGamma{T}(α, θ)
 end
 

--- a/src/univariate/continuous/inversegamma.jl
+++ b/src/univariate/continuous/inversegamma.jl
@@ -32,9 +32,7 @@ struct InverseGamma{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function InverseGamma(α::T, θ::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(InverseGamma, α > zero(α) && θ > zero(θ))
-    end
+    @check_args(InverseGamma, α > zero(α), θ > zero(θ))
     return InverseGamma{T}(α, θ)
 end
 

--- a/src/univariate/continuous/inversegaussian.jl
+++ b/src/univariate/continuous/inversegaussian.jl
@@ -30,7 +30,7 @@ struct InverseGaussian{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function InverseGaussian(μ::T, λ::T; check_args::Bool=true) where {T<:Real}
-    check_args && @check_args(InverseGaussian, μ > zero(μ) && λ > zero(λ))
+    @check_args(InverseGaussian, μ > zero(μ), λ > zero(λ))
     return InverseGaussian{T}(μ, λ)
 end
 

--- a/src/univariate/continuous/inversegaussian.jl
+++ b/src/univariate/continuous/inversegaussian.jl
@@ -30,7 +30,7 @@ struct InverseGaussian{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function InverseGaussian(μ::T, λ::T; check_args::Bool=true) where {T<:Real}
-    @check_args(InverseGaussian, μ > zero(μ), λ > zero(λ))
+    @check_args InverseGaussian (μ, μ > zero(μ)) (λ, λ > zero(λ))
     return InverseGaussian{T}(μ, λ)
 end
 

--- a/src/univariate/continuous/laplace.jl
+++ b/src/univariate/continuous/laplace.jl
@@ -29,7 +29,9 @@ struct Laplace{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Laplace(μ::T, θ::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(Laplace, θ > zero(θ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Laplace, θ > zero(θ))
+    end
     return Laplace{T}(μ, θ)
 end
 

--- a/src/univariate/continuous/laplace.jl
+++ b/src/univariate/continuous/laplace.jl
@@ -29,7 +29,7 @@ struct Laplace{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Laplace(μ::T, θ::T; check_args::Bool=true) where {T <: Real}
-    @check_args(Laplace, θ > zero(θ))
+    @check_args Laplace (θ, θ > zero(θ))
     return Laplace{T}(μ, θ)
 end
 

--- a/src/univariate/continuous/laplace.jl
+++ b/src/univariate/continuous/laplace.jl
@@ -29,9 +29,7 @@ struct Laplace{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Laplace(μ::T, θ::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Laplace, θ > zero(θ))
-    end
+    @check_args(Laplace, θ > zero(θ))
     return Laplace{T}(μ, θ)
 end
 

--- a/src/univariate/continuous/levy.jl
+++ b/src/univariate/continuous/levy.jl
@@ -28,9 +28,7 @@ struct Levy{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Levy(μ::T, σ::T; check_args::Bool=true) where {T<:Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Levy, σ > zero(σ))
-    end
+    @check_args(Levy, σ > zero(σ))
     return Levy{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/levy.jl
+++ b/src/univariate/continuous/levy.jl
@@ -28,7 +28,9 @@ struct Levy{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Levy(μ::T, σ::T; check_args::Bool=true) where {T<:Real}
-    check_args && @check_args(Levy, σ > zero(σ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Levy, σ > zero(σ))
+    end
     return Levy{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/levy.jl
+++ b/src/univariate/continuous/levy.jl
@@ -28,7 +28,7 @@ struct Levy{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Levy(μ::T, σ::T; check_args::Bool=true) where {T<:Real}
-    @check_args(Levy, σ > zero(σ))
+    @check_args Levy (σ, σ > zero(σ))
     return Levy{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/logistic.jl
+++ b/src/univariate/continuous/logistic.jl
@@ -31,7 +31,7 @@ end
 
 
 function Logistic(μ::T, θ::T; check_args::Bool=true) where {T <: Real}
-    @check_args(Logistic, θ > zero(θ))
+    @check_args Logistic (θ, θ > zero(θ))
     return Logistic{T}(μ, θ)
 end
 

--- a/src/univariate/continuous/logistic.jl
+++ b/src/univariate/continuous/logistic.jl
@@ -31,9 +31,7 @@ end
 
 
 function Logistic(μ::T, θ::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Logistic, θ > zero(θ))
-    end
+    @check_args(Logistic, θ > zero(θ))
     return Logistic{T}(μ, θ)
 end
 

--- a/src/univariate/continuous/logistic.jl
+++ b/src/univariate/continuous/logistic.jl
@@ -31,7 +31,9 @@ end
 
 
 function Logistic(μ::T, θ::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(Logistic, θ > zero(θ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Logistic, θ > zero(θ))
+    end
     return Logistic{T}(μ, θ)
 end
 

--- a/src/univariate/continuous/logitnormal.jl
+++ b/src/univariate/continuous/logitnormal.jl
@@ -59,9 +59,7 @@ struct LogitNormal{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function LogitNormal(μ::T, σ::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(LogitNormal, σ > zero(σ))
-    end
+    @check_args(LogitNormal, σ > zero(σ))
     return LogitNormal{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/logitnormal.jl
+++ b/src/univariate/continuous/logitnormal.jl
@@ -59,7 +59,9 @@ struct LogitNormal{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function LogitNormal(μ::T, σ::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(LogitNormal, σ > zero(σ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(LogitNormal, σ > zero(σ))
+    end
     return LogitNormal{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/logitnormal.jl
+++ b/src/univariate/continuous/logitnormal.jl
@@ -59,7 +59,7 @@ struct LogitNormal{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function LogitNormal(μ::T, σ::T; check_args::Bool=true) where {T <: Real}
-    @check_args(LogitNormal, σ > zero(σ))
+    @check_args LogitNormal (σ, σ > zero(σ))
     return LogitNormal{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/lognormal.jl
+++ b/src/univariate/continuous/lognormal.jl
@@ -33,7 +33,7 @@ struct LogNormal{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function LogNormal(μ::T, σ::T; check_args::Bool=true) where {T <: Real}
-    @check_args(LogNormal, σ ≥ zero(σ))
+    @check_args LogNormal (σ, σ ≥ zero(σ))
     return LogNormal{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/lognormal.jl
+++ b/src/univariate/continuous/lognormal.jl
@@ -33,9 +33,7 @@ struct LogNormal{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function LogNormal(μ::T, σ::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(LogNormal, σ ≥ zero(σ))
-    end
+    @check_args(LogNormal, σ ≥ zero(σ))
     return LogNormal{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/lognormal.jl
+++ b/src/univariate/continuous/lognormal.jl
@@ -33,7 +33,9 @@ struct LogNormal{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function LogNormal(μ::T, σ::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(LogNormal, σ ≥ zero(σ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(LogNormal, σ ≥ zero(σ))
+    end
     return LogNormal{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/loguniform.jl
+++ b/src/univariate/continuous/loguniform.jl
@@ -17,7 +17,9 @@ struct LogUniform{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function LogUniform(a::T, b::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(LogUniform, 0 < a < b)
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(LogUniform, 0 < a < b)
+    end
     LogUniform{T}(a, b)
 end
 

--- a/src/univariate/continuous/loguniform.jl
+++ b/src/univariate/continuous/loguniform.jl
@@ -17,7 +17,7 @@ struct LogUniform{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function LogUniform(a::T, b::T; check_args::Bool=true) where {T <: Real}
-    @check_args(LogUniform, 0 < a < b)
+    @check_args LogUniform (0 < a < b)
     LogUniform{T}(a, b)
 end
 

--- a/src/univariate/continuous/loguniform.jl
+++ b/src/univariate/continuous/loguniform.jl
@@ -17,9 +17,7 @@ struct LogUniform{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function LogUniform(a::T, b::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(LogUniform, 0 < a < b)
-    end
+    @check_args(LogUniform, 0 < a < b)
     LogUniform{T}(a, b)
 end
 

--- a/src/univariate/continuous/noncentralbeta.jl
+++ b/src/univariate/continuous/noncentralbeta.jl
@@ -9,9 +9,7 @@ struct NoncentralBeta{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function NoncentralBeta(α::T, β::T, λ::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(NoncentralBeta, α > zero(α) && β > zero(β) && λ >= zero(λ))
-    end
+    @check_args(NoncentralBeta, α > zero(α), β > zero(β), λ >= zero(λ))
     return NoncentralBeta{T}(α, β, λ)
 end
 

--- a/src/univariate/continuous/noncentralbeta.jl
+++ b/src/univariate/continuous/noncentralbeta.jl
@@ -9,7 +9,9 @@ struct NoncentralBeta{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function NoncentralBeta(α::T, β::T, λ::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(NoncentralBeta, α > zero(α) && β > zero(β) && λ >= zero(λ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(NoncentralBeta, α > zero(α) && β > zero(β) && λ >= zero(λ))
+    end
     return NoncentralBeta{T}(α, β, λ)
 end
 

--- a/src/univariate/continuous/noncentralbeta.jl
+++ b/src/univariate/continuous/noncentralbeta.jl
@@ -9,7 +9,7 @@ struct NoncentralBeta{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function NoncentralBeta(α::T, β::T, λ::T; check_args::Bool=true) where {T <: Real}
-    @check_args(NoncentralBeta, α > zero(α), β > zero(β), λ >= zero(λ))
+    @check_args NoncentralBeta (α, α > zero(α)) (β, β > zero(β)) (λ, λ >= zero(λ))
     return NoncentralBeta{T}(α, β, λ)
 end
 

--- a/src/univariate/continuous/noncentralchisq.jl
+++ b/src/univariate/continuous/noncentralchisq.jl
@@ -30,9 +30,7 @@ struct NoncentralChisq{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function NoncentralChisq(ν::T, λ::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(NoncentralChisq, ν > zero(ν) && λ >= zero(λ))
-    end
+    @check_args(NoncentralChisq, ν > zero(ν), λ >= zero(λ))
     return NoncentralChisq{T}(ν, λ)
 end
 

--- a/src/univariate/continuous/noncentralchisq.jl
+++ b/src/univariate/continuous/noncentralchisq.jl
@@ -30,7 +30,7 @@ struct NoncentralChisq{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function NoncentralChisq(ν::T, λ::T; check_args::Bool=true) where {T <: Real}
-    @check_args(NoncentralChisq, ν > zero(ν), λ >= zero(λ))
+    @check_args NoncentralChisq (ν, ν > zero(ν)) (λ, λ >= zero(λ))
     return NoncentralChisq{T}(ν, λ)
 end
 

--- a/src/univariate/continuous/noncentralchisq.jl
+++ b/src/univariate/continuous/noncentralchisq.jl
@@ -30,7 +30,9 @@ struct NoncentralChisq{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function NoncentralChisq(ν::T, λ::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(NoncentralChisq, ν > zero(ν) && λ >= zero(λ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(NoncentralChisq, ν > zero(ν) && λ >= zero(λ))
+    end
     return NoncentralChisq{T}(ν, λ)
 end
 

--- a/src/univariate/continuous/noncentralf.jl
+++ b/src/univariate/continuous/noncentralf.jl
@@ -9,7 +9,9 @@ struct NoncentralF{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function NoncentralF(ν1::T, ν2::T, λ::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(NoncentralF, ν1 > zero(T) && ν2 > zero(T) && λ >= zero(T))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(NoncentralF, ν1 > zero(T) && ν2 > zero(T) && λ >= zero(T))
+    end
     return NoncentralF{T}(ν1, ν2, λ)
 end
 

--- a/src/univariate/continuous/noncentralf.jl
+++ b/src/univariate/continuous/noncentralf.jl
@@ -9,7 +9,7 @@ struct NoncentralF{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function NoncentralF(ν1::T, ν2::T, λ::T; check_args::Bool=true) where {T <: Real}
-    @check_args(NoncentralF, ν1 > zero(ν1), ν2 > zero(ν2), λ >= zero(λ))
+    @check_args NoncentralF (ν1, ν1 > zero(ν1)) (ν2, ν2 > zero(ν2)) (λ, λ >= zero(λ))
     return NoncentralF{T}(ν1, ν2, λ)
 end
 

--- a/src/univariate/continuous/noncentralf.jl
+++ b/src/univariate/continuous/noncentralf.jl
@@ -9,9 +9,7 @@ struct NoncentralF{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function NoncentralF(ν1::T, ν2::T, λ::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(NoncentralF, ν1 > zero(T) && ν2 > zero(T) && λ >= zero(T))
-    end
+    @check_args(NoncentralF, ν1 > zero(ν1), ν2 > zero(ν2), λ >= zero(λ))
     return NoncentralF{T}(ν1, ν2, λ)
 end
 

--- a/src/univariate/continuous/noncentralt.jl
+++ b/src/univariate/continuous/noncentralt.jl
@@ -8,9 +8,7 @@ struct NoncentralT{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function NoncentralT(ν::T, λ::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(NoncentralT, ν > zero(ν))
-    end
+    @check_args(NoncentralT, ν > zero(ν))
     return NoncentralT{T}(ν, λ)
 end
 

--- a/src/univariate/continuous/noncentralt.jl
+++ b/src/univariate/continuous/noncentralt.jl
@@ -8,7 +8,7 @@ struct NoncentralT{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function NoncentralT(ν::T, λ::T; check_args::Bool=true) where {T <: Real}
-    @check_args(NoncentralT, ν > zero(ν))
+    @check_args NoncentralT (ν, ν > zero(ν))
     return NoncentralT{T}(ν, λ)
 end
 

--- a/src/univariate/continuous/noncentralt.jl
+++ b/src/univariate/continuous/noncentralt.jl
@@ -8,7 +8,9 @@ struct NoncentralT{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function NoncentralT(ν::T, λ::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(NoncentralT, ν > zero(ν))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(NoncentralT, ν > zero(ν))
+    end
     return NoncentralT{T}(ν, λ)
 end
 

--- a/src/univariate/continuous/normal.jl
+++ b/src/univariate/continuous/normal.jl
@@ -34,7 +34,9 @@ struct Normal{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Normal(μ::T, σ::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(Normal, σ >= zero(σ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Normal, σ >= zero(σ))
+    end
     return Normal{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/normal.jl
+++ b/src/univariate/continuous/normal.jl
@@ -34,7 +34,7 @@ struct Normal{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Normal(μ::T, σ::T; check_args::Bool=true) where {T <: Real}
-    @check_args(Normal, σ >= zero(σ))
+    @check_args Normal (σ, σ >= zero(σ))
     return Normal{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/normal.jl
+++ b/src/univariate/continuous/normal.jl
@@ -34,9 +34,7 @@ struct Normal{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Normal(μ::T, σ::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Normal, σ >= zero(σ))
-    end
+    @check_args(Normal, σ >= zero(σ))
     return Normal{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/normalcanon.jl
+++ b/src/univariate/continuous/normalcanon.jl
@@ -12,7 +12,7 @@ struct NormalCanon{T<:Real} <: ContinuousUnivariateDistribution
     μ::T       # μ
 
     function NormalCanon{T}(η, λ; check_args::Bool=true) where T
-        @check_args(NormalCanon, λ > zero(λ))
+        @check_args NormalCanon (λ, λ > zero(λ))
         new{T}(η, λ, η / λ)
     end
 end

--- a/src/univariate/continuous/normalcanon.jl
+++ b/src/univariate/continuous/normalcanon.jl
@@ -12,7 +12,9 @@ struct NormalCanon{T<:Real} <: ContinuousUnivariateDistribution
     μ::T       # μ
 
     function NormalCanon{T}(η, λ; check_args::Bool=true) where T
-        check_args && @check_args(NormalCanon, λ > zero(λ))
+        ChainRulesCore.ignore_derivatives() do
+            check_args && @check_args(NormalCanon, λ > zero(λ))
+        end
         new{T}(η, λ, η / λ)
     end
 end

--- a/src/univariate/continuous/normalcanon.jl
+++ b/src/univariate/continuous/normalcanon.jl
@@ -12,9 +12,7 @@ struct NormalCanon{T<:Real} <: ContinuousUnivariateDistribution
     μ::T       # μ
 
     function NormalCanon{T}(η, λ; check_args::Bool=true) where T
-        ChainRulesCore.ignore_derivatives() do
-            check_args && @check_args(NormalCanon, λ > zero(λ))
-        end
+        @check_args(NormalCanon, λ > zero(λ))
         new{T}(η, λ, η / λ)
     end
 end

--- a/src/univariate/continuous/pareto.jl
+++ b/src/univariate/continuous/pareto.jl
@@ -28,7 +28,7 @@ struct Pareto{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Pareto(α::T, θ::T; check_args::Bool=true) where {T <: Real}
-    @check_args(Pareto, α > zero(α), θ > zero(θ))
+    @check_args Pareto (α, α > zero(α)) (θ, θ > zero(θ))
     return Pareto{T}(α, θ)
 end
 

--- a/src/univariate/continuous/pareto.jl
+++ b/src/univariate/continuous/pareto.jl
@@ -28,7 +28,9 @@ struct Pareto{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Pareto(α::T, θ::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(Pareto, α > zero(α) && θ > zero(θ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Pareto, α > zero(α) && θ > zero(θ))
+    end
     return Pareto{T}(α, θ)
 end
 

--- a/src/univariate/continuous/pareto.jl
+++ b/src/univariate/continuous/pareto.jl
@@ -28,9 +28,7 @@ struct Pareto{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Pareto(α::T, θ::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Pareto, α > zero(α) && θ > zero(θ))
-    end
+    @check_args(Pareto, α > zero(α), θ > zero(θ))
     return Pareto{T}(α, θ)
 end
 

--- a/src/univariate/continuous/pgeneralizedgaussian.jl
+++ b/src/univariate/continuous/pgeneralizedgaussian.jl
@@ -35,9 +35,7 @@ struct PGeneralizedGaussian{T1<:Real, T2<:Real, T3<:Real} <: ContinuousUnivariat
 end
 
 function PGeneralizedGaussian(μ::T1,α::T2,p::T3; check_args::Bool=true) where {T1<:Real, T2<:Real, T3<:Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(PGeneralizedGaussian, α > zero(α) && p > zero(p))
-    end
+    @check_args(PGeneralizedGaussian, α > zero(α), p > zero(p))
     return PGeneralizedGaussian{T1,T2,T3}(μ,α,p)
 end
 

--- a/src/univariate/continuous/pgeneralizedgaussian.jl
+++ b/src/univariate/continuous/pgeneralizedgaussian.jl
@@ -35,7 +35,7 @@ struct PGeneralizedGaussian{T1<:Real, T2<:Real, T3<:Real} <: ContinuousUnivariat
 end
 
 function PGeneralizedGaussian(μ::T1,α::T2,p::T3; check_args::Bool=true) where {T1<:Real, T2<:Real, T3<:Real}
-    @check_args(PGeneralizedGaussian, α > zero(α), p > zero(p))
+    @check_args PGeneralizedGaussian (α, α > zero(α)) (p, p > zero(p))
     return PGeneralizedGaussian{T1,T2,T3}(μ,α,p)
 end
 

--- a/src/univariate/continuous/pgeneralizedgaussian.jl
+++ b/src/univariate/continuous/pgeneralizedgaussian.jl
@@ -35,7 +35,9 @@ struct PGeneralizedGaussian{T1<:Real, T2<:Real, T3<:Real} <: ContinuousUnivariat
 end
 
 function PGeneralizedGaussian(μ::T1,α::T2,p::T3; check_args::Bool=true) where {T1<:Real, T2<:Real, T3<:Real}
-    check_args && @check_args(PGeneralizedGaussian, α > zero(α) && p > zero(p))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(PGeneralizedGaussian, α > zero(α) && p > zero(p))
+    end
     return PGeneralizedGaussian{T1,T2,T3}(μ,α,p)
 end
 

--- a/src/univariate/continuous/rayleigh.jl
+++ b/src/univariate/continuous/rayleigh.jl
@@ -29,9 +29,7 @@ struct Rayleigh{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Rayleigh(σ::Real; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Rayleigh, σ > zero(σ))
-    end
+    @check_args(Rayleigh, σ > zero(σ))
     return Rayleigh{typeof(σ)}(σ)
 end
 

--- a/src/univariate/continuous/rayleigh.jl
+++ b/src/univariate/continuous/rayleigh.jl
@@ -29,7 +29,9 @@ struct Rayleigh{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Rayleigh(σ::Real; check_args::Bool=true)
-    check_args && @check_args(Rayleigh, σ > zero(σ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Rayleigh, σ > zero(σ))
+    end
     return Rayleigh{typeof(σ)}(σ)
 end
 

--- a/src/univariate/continuous/rayleigh.jl
+++ b/src/univariate/continuous/rayleigh.jl
@@ -29,7 +29,7 @@ struct Rayleigh{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Rayleigh(σ::Real; check_args::Bool=true)
-    @check_args(Rayleigh, σ > zero(σ))
+    @check_args Rayleigh (σ, σ > zero(σ))
     return Rayleigh{typeof(σ)}(σ)
 end
 

--- a/src/univariate/continuous/rician.jl
+++ b/src/univariate/continuous/rician.jl
@@ -34,7 +34,9 @@ struct Rician{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Rician(ν::T, σ::T; check_args::Bool=true) where {T<:Real}
-    check_args && @check_args(Rician, ν ≥ zero(ν) && σ ≥ zero(σ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Rician, ν ≥ zero(ν) && σ ≥ zero(σ))
+    end
     return Rician{T}(ν, σ)
 end
 

--- a/src/univariate/continuous/rician.jl
+++ b/src/univariate/continuous/rician.jl
@@ -34,7 +34,7 @@ struct Rician{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Rician(ν::T, σ::T; check_args::Bool=true) where {T<:Real}
-    @check_args(Rician, ν ≥ zero(ν), σ ≥ zero(σ))
+    @check_args Rician (ν, ν ≥ zero(ν)) (σ, σ ≥ zero(σ))
     return Rician{T}(ν, σ)
 end
 

--- a/src/univariate/continuous/rician.jl
+++ b/src/univariate/continuous/rician.jl
@@ -34,9 +34,7 @@ struct Rician{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Rician(ν::T, σ::T; check_args::Bool=true) where {T<:Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Rician, ν ≥ zero(ν) && σ ≥ zero(σ))
-    end
+    @check_args(Rician, ν ≥ zero(ν), σ ≥ zero(σ))
     return Rician{T}(ν, σ)
 end
 

--- a/src/univariate/continuous/semicircle.jl
+++ b/src/univariate/continuous/semicircle.jl
@@ -25,7 +25,9 @@ end
 
 
 function Semicircle(r::Real; check_args::Bool=true)
-    check_args && @check_args(Semicircle, r > zero(r))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Semicircle, r > zero(r))
+    end
     return Semicircle{typeof(r)}(r)
 end
 

--- a/src/univariate/continuous/semicircle.jl
+++ b/src/univariate/continuous/semicircle.jl
@@ -25,9 +25,7 @@ end
 
 
 function Semicircle(r::Real; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Semicircle, r > zero(r))
-    end
+    @check_args(Semicircle, r > zero(r))
     return Semicircle{typeof(r)}(r)
 end
 

--- a/src/univariate/continuous/semicircle.jl
+++ b/src/univariate/continuous/semicircle.jl
@@ -25,7 +25,7 @@ end
 
 
 function Semicircle(r::Real; check_args::Bool=true)
-    @check_args(Semicircle, r > zero(r))
+    @check_args Semicircle (r, r > zero(r))
     return Semicircle{typeof(r)}(r)
 end
 

--- a/src/univariate/continuous/skewedexponentialpower.jl
+++ b/src/univariate/continuous/skewedexponentialpower.jl
@@ -38,13 +38,7 @@ struct SkewedExponentialPower{T <: Real} <: ContinuousUnivariateDistribution
 end
 
 function SkewedExponentialPower(µ::T, σ::T, p::T, α::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        if check_args
-            @check_args(SkewedExponentialPower, σ > zero(σ))
-            @check_args(SkewedExponentialPower, p > zero(p))
-            @check_args(SkewedExponentialPower, zero(α) < α < one(α))
-        end
-    end
+    @check_args(SkewedExponentialPower, σ > zero(σ), p > zero(p), zero(α) < α < one(α))
     return SkewedExponentialPower{T}(µ, σ, p, α)
 end
 

--- a/src/univariate/continuous/skewedexponentialpower.jl
+++ b/src/univariate/continuous/skewedexponentialpower.jl
@@ -38,10 +38,12 @@ struct SkewedExponentialPower{T <: Real} <: ContinuousUnivariateDistribution
 end
 
 function SkewedExponentialPower(µ::T, σ::T, p::T, α::T; check_args::Bool=true) where {T <: Real}
-    if check_args
-        @check_args(SkewedExponentialPower, σ > zero(σ))
-        @check_args(SkewedExponentialPower, p > zero(p))
-        @check_args(SkewedExponentialPower, zero(α) < α < one(α))
+    ChainRulesCore.ignore_derivatives() do
+        if check_args
+            @check_args(SkewedExponentialPower, σ > zero(σ))
+            @check_args(SkewedExponentialPower, p > zero(p))
+            @check_args(SkewedExponentialPower, zero(α) < α < one(α))
+        end
     end
     return SkewedExponentialPower{T}(µ, σ, p, α)
 end

--- a/src/univariate/continuous/skewedexponentialpower.jl
+++ b/src/univariate/continuous/skewedexponentialpower.jl
@@ -38,7 +38,7 @@ struct SkewedExponentialPower{T <: Real} <: ContinuousUnivariateDistribution
 end
 
 function SkewedExponentialPower(µ::T, σ::T, p::T, α::T; check_args::Bool=true) where {T <: Real}
-    @check_args(SkewedExponentialPower, σ > zero(σ), p > zero(p), zero(α) < α < one(α))
+    @check_args SkewedExponentialPower (σ, σ > zero(σ)) (p, p > zero(p)) (α, zero(α) < α < one(α))
     return SkewedExponentialPower{T}(µ, σ, p, α)
 end
 

--- a/src/univariate/continuous/skewnormal.jl
+++ b/src/univariate/continuous/skewnormal.jl
@@ -15,7 +15,9 @@ struct SkewNormal{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function SkewNormal(ξ::T, ω::T, α::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(SkewNormal, ω > zero(ω))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(SkewNormal, ω > zero(ω))
+    end
     return SkewNormal{T}(ξ, ω, α)
 end
 

--- a/src/univariate/continuous/skewnormal.jl
+++ b/src/univariate/continuous/skewnormal.jl
@@ -15,9 +15,7 @@ struct SkewNormal{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function SkewNormal(ξ::T, ω::T, α::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(SkewNormal, ω > zero(ω))
-    end
+    @check_args(SkewNormal, ω > zero(ω))
     return SkewNormal{T}(ξ, ω, α)
 end
 

--- a/src/univariate/continuous/skewnormal.jl
+++ b/src/univariate/continuous/skewnormal.jl
@@ -15,7 +15,7 @@ struct SkewNormal{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function SkewNormal(ξ::T, ω::T, α::T; check_args::Bool=true) where {T <: Real}
-    @check_args(SkewNormal, ω > zero(ω))
+    @check_args SkewNormal (ω, ω > zero(ω))
     return SkewNormal{T}(ξ, ω, α)
 end
 

--- a/src/univariate/continuous/studentizedrange.jl
+++ b/src/univariate/continuous/studentizedrange.jl
@@ -34,7 +34,7 @@ struct StudentizedRange{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function StudentizedRange(ν::T, k::T; check_args::Bool=true) where {T <: Real}
-    @check_args(StudentizedRange, ν > zero(ν), k > one(k))
+    @check_args StudentizedRange (ν, ν > zero(ν)) (k, k > one(k))
     return StudentizedRange{T}(ν, k)
 end
 

--- a/src/univariate/continuous/studentizedrange.jl
+++ b/src/univariate/continuous/studentizedrange.jl
@@ -34,9 +34,7 @@ struct StudentizedRange{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function StudentizedRange(ν::T, k::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(StudentizedRange, ν > zero(ν) && k > one(k))
-    end
+    @check_args(StudentizedRange, ν > zero(ν), k > one(k))
     return StudentizedRange{T}(ν, k)
 end
 

--- a/src/univariate/continuous/studentizedrange.jl
+++ b/src/univariate/continuous/studentizedrange.jl
@@ -34,7 +34,9 @@ struct StudentizedRange{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function StudentizedRange(ν::T, k::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(StudentizedRange, ν > zero(ν) && k > one(k))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(StudentizedRange, ν > zero(ν) && k > one(k))
+    end
     return StudentizedRange{T}(ν, k)
 end
 

--- a/src/univariate/continuous/symtriangular.jl
+++ b/src/univariate/continuous/symtriangular.jl
@@ -24,7 +24,7 @@ struct SymTriangularDist{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function SymTriangularDist(μ::T, σ::T; check_args::Bool=true) where {T <: Real}
-    @check_args(SymTriangularDist, σ > zero(σ))
+    @check_args SymTriangularDist (σ, σ > zero(σ))
     return SymTriangularDist{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/symtriangular.jl
+++ b/src/univariate/continuous/symtriangular.jl
@@ -24,7 +24,7 @@ struct SymTriangularDist{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function SymTriangularDist(μ::T, σ::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(SymTriangularDist, σ > zero(σ))
+    @check_args(SymTriangularDist, σ > zero(σ))
     return SymTriangularDist{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/tdist.jl
+++ b/src/univariate/continuous/tdist.jl
@@ -26,7 +26,7 @@ struct TDist{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function TDist(ν::Real; check_args::Bool=true)
-    @check_args(TDist, ν > zero(ν))
+    @check_args TDist (ν, ν > zero(ν))
     return TDist{typeof(ν)}(ν)
 end
 

--- a/src/univariate/continuous/tdist.jl
+++ b/src/univariate/continuous/tdist.jl
@@ -26,7 +26,9 @@ struct TDist{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function TDist(ν::Real; check_args::Bool=true)
-    check_args && @check_args(TDist, ν > zero(ν))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(TDist, ν > zero(ν))
+    end
     return TDist{typeof(ν)}(ν)
 end
 

--- a/src/univariate/continuous/tdist.jl
+++ b/src/univariate/continuous/tdist.jl
@@ -26,9 +26,7 @@ struct TDist{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function TDist(ν::Real; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(TDist, ν > zero(ν))
-    end
+    @check_args(TDist, ν > zero(ν))
     return TDist{typeof(ν)}(ν)
 end
 

--- a/src/univariate/continuous/triangular.jl
+++ b/src/univariate/continuous/triangular.jl
@@ -35,7 +35,7 @@ struct TriangularDist{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function TriangularDist(a::T, b::T, c::T; check_args::Bool=true) where {T <: Real}
-    @check_args(TriangularDist, a <= c <= b)
+    @check_args TriangularDist (a <= c <= b)
     return TriangularDist{T}(a, b, c)
 end
 

--- a/src/univariate/continuous/triangular.jl
+++ b/src/univariate/continuous/triangular.jl
@@ -35,9 +35,7 @@ struct TriangularDist{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function TriangularDist(a::T, b::T, c::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(TriangularDist, a <= c <= b)
-    end
+    @check_args(TriangularDist, a <= c <= b)
     return TriangularDist{T}(a, b, c)
 end
 

--- a/src/univariate/continuous/triangular.jl
+++ b/src/univariate/continuous/triangular.jl
@@ -35,7 +35,9 @@ struct TriangularDist{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function TriangularDist(a::T, b::T, c::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(TriangularDist, a <= c <= b)
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(TriangularDist, a <= c <= b)
+    end
     return TriangularDist{T}(a, b, c)
 end
 

--- a/src/univariate/continuous/triweight.jl
+++ b/src/univariate/continuous/triweight.jl
@@ -8,7 +8,7 @@ struct Triweight{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Triweight(μ::T, σ::T; check_args::Bool=true) where {T <: Real}
-    @check_args(Triweight, σ > zero(σ))
+    @check_args Triweight (σ, σ > zero(σ))
     return Triweight{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/triweight.jl
+++ b/src/univariate/continuous/triweight.jl
@@ -8,9 +8,7 @@ struct Triweight{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Triweight(μ::T, σ::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Triweight, σ > zero(σ))
-    end
+    @check_args(Triweight, σ > zero(σ))
     return Triweight{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/triweight.jl
+++ b/src/univariate/continuous/triweight.jl
@@ -8,7 +8,9 @@ struct Triweight{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Triweight(μ::T, σ::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(Triweight, σ > zero(σ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Triweight, σ > zero(σ))
+    end
     return Triweight{T}(μ, σ)
 end
 

--- a/src/univariate/continuous/uniform.jl
+++ b/src/univariate/continuous/uniform.jl
@@ -30,7 +30,9 @@ struct Uniform{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Uniform(a::T, b::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(Uniform, a < b)
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Uniform, a < b)
+    end
     return Uniform{T}(a, b)
 end
 

--- a/src/univariate/continuous/uniform.jl
+++ b/src/univariate/continuous/uniform.jl
@@ -30,7 +30,7 @@ struct Uniform{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Uniform(a::T, b::T; check_args::Bool=true) where {T <: Real}
-    @check_args(Uniform, a < b)
+    @check_args Uniform (a < b)
     return Uniform{T}(a, b)
 end
 
@@ -168,7 +168,7 @@ function ChainRulesCore.rrule(::typeof(logpdf), d::Uniform, x::Real)
     # Define pullback
     function logpdf_Uniform_pullback(Δ)
         Δa = Δ / diff
-        Δd = if insupport 
+        Δd = if insupport
             ChainRulesCore.Tangent{typeof(d)}(; a=Δa, b=-Δa)
         else
             ChainRulesCore.Tangent{typeof(d)}(; a=zero(Δa), b=zero(Δa))
@@ -178,4 +178,3 @@ function ChainRulesCore.rrule(::typeof(logpdf), d::Uniform, x::Real)
 
     return Ω, logpdf_Uniform_pullback
 end
-

--- a/src/univariate/continuous/uniform.jl
+++ b/src/univariate/continuous/uniform.jl
@@ -30,9 +30,7 @@ struct Uniform{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Uniform(a::T, b::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Uniform, a < b)
-    end
+    @check_args(Uniform, a < b)
     return Uniform{T}(a, b)
 end
 

--- a/src/univariate/continuous/vonmises.jl
+++ b/src/univariate/continuous/vonmises.jl
@@ -25,9 +25,7 @@ struct VonMises{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function VonMises(μ::T, κ::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(VonMises, κ > zero(κ))
-    end
+    @check_args(VonMises, κ > zero(κ))
     return VonMises{T}(μ, κ, besselix(zero(T), κ))
 end
 

--- a/src/univariate/continuous/vonmises.jl
+++ b/src/univariate/continuous/vonmises.jl
@@ -25,7 +25,9 @@ struct VonMises{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function VonMises(μ::T, κ::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(VonMises, κ > zero(κ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(VonMises, κ > zero(κ))
+    end
     return VonMises{T}(μ, κ, besselix(zero(T), κ))
 end
 

--- a/src/univariate/continuous/vonmises.jl
+++ b/src/univariate/continuous/vonmises.jl
@@ -25,7 +25,7 @@ struct VonMises{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function VonMises(μ::T, κ::T; check_args::Bool=true) where {T <: Real}
-    @check_args(VonMises, κ > zero(κ))
+    @check_args VonMises (κ, κ > zero(κ))
     return VonMises{T}(μ, κ, besselix(zero(T), κ))
 end
 

--- a/src/univariate/continuous/weibull.jl
+++ b/src/univariate/continuous/weibull.jl
@@ -33,7 +33,7 @@ struct Weibull{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Weibull(α::T, θ::T; check_args::Bool=true) where {T <: Real}
-    @check_args(Weibull, α > zero(α), θ > zero(θ))
+    @check_args Weibull (α, α > zero(α)) (θ, θ > zero(θ))
     return Weibull{T}(α, θ)
 end
 

--- a/src/univariate/continuous/weibull.jl
+++ b/src/univariate/continuous/weibull.jl
@@ -33,9 +33,7 @@ struct Weibull{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Weibull(α::T, θ::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Weibull, α > zero(α) && θ > zero(θ))
-    end
+    @check_args(Weibull, α > zero(α), θ > zero(θ))
     return Weibull{T}(α, θ)
 end
 

--- a/src/univariate/continuous/weibull.jl
+++ b/src/univariate/continuous/weibull.jl
@@ -33,7 +33,9 @@ struct Weibull{T<:Real} <: ContinuousUnivariateDistribution
 end
 
 function Weibull(α::T, θ::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(Weibull, α > zero(α) && θ > zero(θ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Weibull, α > zero(α) && θ > zero(θ))
+    end
     return Weibull{T}(α, θ)
 end
 

--- a/src/univariate/discrete/bernoulli.jl
+++ b/src/univariate/discrete/bernoulli.jl
@@ -31,7 +31,9 @@ struct Bernoulli{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function Bernoulli(p::Real; check_args::Bool=true)
-    check_args && @check_args(Bernoulli, zero(p) <= p <= one(p))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Bernoulli, zero(p) <= p <= one(p))
+    end
     return Bernoulli{typeof(p)}(p)
 end
 

--- a/src/univariate/discrete/bernoulli.jl
+++ b/src/univariate/discrete/bernoulli.jl
@@ -31,9 +31,7 @@ struct Bernoulli{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function Bernoulli(p::Real; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Bernoulli, zero(p) <= p <= one(p))
-    end
+    @check_args(Bernoulli, zero(p) <= p <= one(p))
     return Bernoulli{typeof(p)}(p)
 end
 

--- a/src/univariate/discrete/bernoulli.jl
+++ b/src/univariate/discrete/bernoulli.jl
@@ -31,7 +31,7 @@ struct Bernoulli{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function Bernoulli(p::Real; check_args::Bool=true)
-    @check_args(Bernoulli, zero(p) <= p <= one(p))
+    @check_args Bernoulli (p, zero(p) <= p <= one(p))
     return Bernoulli{typeof(p)}(p)
 end
 

--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -27,7 +27,7 @@ struct BetaBinomial{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function BetaBinomial(n::Integer, α::T, β::T; check_args::Bool=true) where {T <: Real}
-    @check_args(BetaBinomial, n >= zero(n), α >= zero(α), β >= zero(β))
+    @check_args BetaBinomial (n, n >= zero(n)) (α, α >= zero(α)) (β, β >= zero(β))
     return BetaBinomial{T}(n, α, β)
 end
 

--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -27,9 +27,7 @@ struct BetaBinomial{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function BetaBinomial(n::Integer, α::T, β::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(BetaBinomial, n >= zero(n) && α >= zero(α) && β >= zero(β))
-    end
+    @check_args(BetaBinomial, n >= zero(n), α >= zero(α), β >= zero(β))
     return BetaBinomial{T}(n, α, β)
 end
 

--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -27,7 +27,9 @@ struct BetaBinomial{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function BetaBinomial(n::Integer, α::T, β::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(BetaBinomial, n >= zero(n) && α >= zero(α) && β >= zero(β))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(BetaBinomial, n >= zero(n) && α >= zero(α) && β >= zero(β))
+    end
     return BetaBinomial{T}(n, α, β)
 end
 

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -30,16 +30,20 @@ struct Binomial{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function Binomial(n::Integer, p::Real; check_args::Bool=true)
-    if check_args
-        @check_args(Binomial, n >= zero(n))
-        @check_args(Binomial, zero(p) <= p <= one(p))
+    ChainRulesCore.ignore_derivatives() do
+        if check_args
+            @check_args(Binomial, n >= zero(n))
+            @check_args(Binomial, zero(p) <= p <= one(p))
+        end
     end
     return Binomial{typeof(p)}(n, p)
 end
 
 Binomial(n::Integer, p::Integer; check_args::Bool=true) = Binomial(n, float(p); check_args=check_args)
 function Binomial(n::Integer; check_args::Bool=true)
-    check_args && @check_args(Binomial, n >= zero(n))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Binomial, n >= zero(n))
+    end
     Binomial{Float64}(n, 0.5)
 end
 Binomial() = Binomial{Float64}(1, 0.5)

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -30,20 +30,13 @@ struct Binomial{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function Binomial(n::Integer, p::Real; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        if check_args
-            @check_args(Binomial, n >= zero(n))
-            @check_args(Binomial, zero(p) <= p <= one(p))
-        end
-    end
+    @check_args(Binomial, n >= zero(n), zero(p) <= p <= one(p))
     return Binomial{typeof(p)}(n, p)
 end
 
 Binomial(n::Integer, p::Integer; check_args::Bool=true) = Binomial(n, float(p); check_args=check_args)
 function Binomial(n::Integer; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Binomial, n >= zero(n))
-    end
+    @check_args(Binomial, n >= zero(n))
     Binomial{Float64}(n, 0.5)
 end
 Binomial() = Binomial{Float64}(1, 0.5)

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -30,13 +30,13 @@ struct Binomial{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function Binomial(n::Integer, p::Real; check_args::Bool=true)
-    @check_args(Binomial, n >= zero(n), zero(p) <= p <= one(p))
+    @check_args Binomial (n, n >= zero(n)) (p, zero(p) <= p <= one(p))
     return Binomial{typeof(p)}(n, p)
 end
 
 Binomial(n::Integer, p::Integer; check_args::Bool=true) = Binomial(n, float(p); check_args=check_args)
 function Binomial(n::Integer; check_args::Bool=true)
-    @check_args(Binomial, n >= zero(n))
+    @check_args Binomial (n, n >= zero(n))
     Binomial{Float64}(n, 0.5)
 end
 Binomial() = Binomial{Float64}(1, 0.5)

--- a/src/univariate/discrete/categorical.jl
+++ b/src/univariate/discrete/categorical.jl
@@ -27,7 +27,7 @@ External links:
 const Categorical{P<:Real,Ps<:AbstractVector{P}} = DiscreteNonParametric{Int,P,Base.OneTo{Int},Ps}
 
 function Categorical{P,Ps}(p::Ps; check_args::Bool=true) where {P<:Real, Ps<:AbstractVector{P}}
-    @check_args(Categorical, isprobvec(p))
+    @check_args Categorical (p, isprobvec(p), "vector p is not a probability vector")
     return Categorical{P,Ps}(Base.OneTo(length(p)), p; check_args=check_args)
 end
 
@@ -35,7 +35,7 @@ Categorical(p::AbstractVector{P}; check_args::Bool=true) where {P<:Real} =
     Categorical{P,typeof(p)}(p; check_args=check_args)
 
 function Categorical(k::Integer; check_args::Bool=true)
-    @check_args(Categorical, k >= 1)
+    @check_args Categorical (k, k >= 1, "at least one category is required")
     return Categorical{Float64,Vector{Float64}}(Base.OneTo(k), fill(1/k, k); check_args=false)
 end
 

--- a/src/univariate/discrete/categorical.jl
+++ b/src/univariate/discrete/categorical.jl
@@ -27,9 +27,7 @@ External links:
 const Categorical{P<:Real,Ps<:AbstractVector{P}} = DiscreteNonParametric{Int,P,Base.OneTo{Int},Ps}
 
 function Categorical{P,Ps}(p::Ps; check_args::Bool=true) where {P<:Real, Ps<:AbstractVector{P}}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Categorical, isprobvec(p))
-    end
+    @check_args(Categorical, isprobvec(p))
     return Categorical{P,Ps}(Base.OneTo(length(p)), p; check_args=check_args)
 end
 
@@ -37,9 +35,7 @@ Categorical(p::AbstractVector{P}; check_args::Bool=true) where {P<:Real} =
     Categorical{P,typeof(p)}(p; check_args=check_args)
 
 function Categorical(k::Integer; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Categorical, k >= 1)
-    end
+    @check_args(Categorical, k >= 1)
     return Categorical{Float64,Vector{Float64}}(Base.OneTo(k), fill(1/k, k); check_args=false)
 end
 

--- a/src/univariate/discrete/categorical.jl
+++ b/src/univariate/discrete/categorical.jl
@@ -27,7 +27,9 @@ External links:
 const Categorical{P<:Real,Ps<:AbstractVector{P}} = DiscreteNonParametric{Int,P,Base.OneTo{Int},Ps}
 
 function Categorical{P,Ps}(p::Ps; check_args::Bool=true) where {P<:Real, Ps<:AbstractVector{P}}
-    check_args && @check_args(Categorical, isprobvec(p))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Categorical, isprobvec(p))
+    end
     return Categorical{P,Ps}(Base.OneTo(length(p)), p; check_args=check_args)
 end
 
@@ -35,7 +37,9 @@ Categorical(p::AbstractVector{P}; check_args::Bool=true) where {P<:Real} =
     Categorical{P,typeof(p)}(p; check_args=check_args)
 
 function Categorical(k::Integer; check_args::Bool=true)
-    check_args && @check_args(Categorical, k >= 1)
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Categorical, k >= 1)
+    end
     return Categorical{Float64,Vector{Float64}}(Base.OneTo(k), fill(1/k, k); check_args=false)
 end
 

--- a/src/univariate/discrete/discretenonparametric.jl
+++ b/src/univariate/discrete/discretenonparametric.jl
@@ -21,17 +21,17 @@ struct DiscreteNonParametric{T<:Real,P<:Real,Ts<:AbstractVector{T},Ps<:AbstractV
     support::Ts
     p::Ps
 
-    function DiscreteNonParametric{T,P,Ts,Ps}(vs::Ts, ps::Ps; check_args::Bool=true) where {
+    function DiscreteNonParametric{T,P,Ts,Ps}(xs::Ts, ps::Ps; check_args::Bool=true) where {
             T<:Real,P<:Real,Ts<:AbstractVector{T},Ps<:AbstractVector{P}}
-        check_args || return new{T,P,Ts,Ps}(vs, ps)
+        check_args || return new{T,P,Ts,Ps}(xs, ps)
         @check_args(
             DiscreteNonParametric,
-            length(vs) == length(ps),
-            isprobvec(ps),
-            allunique(vs),
+            (length(xs) == length(ps), "length of support and probability vector must be equal"),
+            (ps, isprobvec(ps), "vector is not a probability vector"),
+            (xs, allunique(xs), "support must contain only unique elements"),
         )
-        sort_order = sortperm(vs)
-        new{T,P,Ts,Ps}(vs[sort_order], ps[sort_order])
+        sort_order = sortperm(xs)
+        new{T,P,Ts,Ps}(xs[sort_order], ps[sort_order])
     end
 end
 
@@ -272,7 +272,7 @@ end
 function suffstats(::Type{<:DiscreteNonParametric}, x::AbstractArray{T},
                    w::AbstractArray{W}; check_args::Bool=true) where {T<:Real,W<:Real}
 
-    @check_args(DiscreteNonParametric, length(x) == length(w))
+    @check_args DiscreteNonParametric (length(x) == length(w))
 
     N = length(x)
     N == 0 && return DiscreteNonParametricStats(T[], W[])

--- a/src/univariate/discrete/discretenonparametric.jl
+++ b/src/univariate/discrete/discretenonparametric.jl
@@ -24,9 +24,11 @@ struct DiscreteNonParametric{T<:Real,P<:Real,Ts<:AbstractVector{T},Ps<:AbstractV
     function DiscreteNonParametric{T,P,Ts,Ps}(vs::Ts, ps::Ps; check_args::Bool=true) where {
             T<:Real,P<:Real,Ts<:AbstractVector{T},Ps<:AbstractVector{P}}
         check_args || return new{T,P,Ts,Ps}(vs, ps)
-        @check_args(DiscreteNonParametric, length(vs) == length(ps))
-        @check_args(DiscreteNonParametric, isprobvec(ps))
-        @check_args(DiscreteNonParametric, allunique(vs))
+        ChainRulesCore.ignore_derivatives() do
+            @check_args(DiscreteNonParametric, length(vs) == length(ps))
+            @check_args(DiscreteNonParametric, isprobvec(ps))
+            @check_args(DiscreteNonParametric, allunique(vs))
+        end
         sort_order = sortperm(vs)
         new{T,P,Ts,Ps}(vs[sort_order], ps[sort_order])
     end

--- a/src/univariate/discrete/discretenonparametric.jl
+++ b/src/univariate/discrete/discretenonparametric.jl
@@ -24,11 +24,12 @@ struct DiscreteNonParametric{T<:Real,P<:Real,Ts<:AbstractVector{T},Ps<:AbstractV
     function DiscreteNonParametric{T,P,Ts,Ps}(vs::Ts, ps::Ps; check_args::Bool=true) where {
             T<:Real,P<:Real,Ts<:AbstractVector{T},Ps<:AbstractVector{P}}
         check_args || return new{T,P,Ts,Ps}(vs, ps)
-        ChainRulesCore.ignore_derivatives() do
-            @check_args(DiscreteNonParametric, length(vs) == length(ps))
-            @check_args(DiscreteNonParametric, isprobvec(ps))
-            @check_args(DiscreteNonParametric, allunique(vs))
-        end
+        @check_args(
+            DiscreteNonParametric,
+            length(vs) == length(ps),
+            isprobvec(ps),
+            allunique(vs),
+        )
         sort_order = sortperm(vs)
         new{T,P,Ts,Ps}(vs[sort_order], ps[sort_order])
     end
@@ -269,7 +270,7 @@ function suffstats(::Type{<:DiscreteNonParametric}, x::AbstractArray{T}) where {
 end
 
 function suffstats(::Type{<:DiscreteNonParametric}, x::AbstractArray{T},
-                   w::AbstractArray{W}) where {T<:Real,W<:Real}
+                   w::AbstractArray{W}; check_args::Bool=true) where {T<:Real,W<:Real}
 
     @check_args(DiscreteNonParametric, length(x) == length(w))
 

--- a/src/univariate/discrete/discreteuniform.jl
+++ b/src/univariate/discrete/discreteuniform.jl
@@ -27,7 +27,9 @@ struct DiscreteUniform <: DiscreteUnivariateDistribution
     pv::Float64 # individual probabilities
 
     function DiscreteUniform(a::Real, b::Real; check_args::Bool=true)
-        check_args && @check_args(DiscreteUniform, a <= b)
+        ChainRulesCore.ignore_derivatives() do
+            check_args && @check_args(DiscreteUniform, a <= b)
+        end
         new(a, b, 1 / (b - a + 1))
     end
     DiscreteUniform(b::Real; check_args::Bool=true) = DiscreteUniform(0, b; check_args=check_args)

--- a/src/univariate/discrete/discreteuniform.jl
+++ b/src/univariate/discrete/discreteuniform.jl
@@ -27,7 +27,7 @@ struct DiscreteUniform <: DiscreteUnivariateDistribution
     pv::Float64 # individual probabilities
 
     function DiscreteUniform(a::Real, b::Real; check_args::Bool=true)
-        @check_args(DiscreteUniform, a <= b)
+        @check_args DiscreteUniform (a <= b)
         new(a, b, 1 / (b - a + 1))
     end
     DiscreteUniform(b::Real; check_args::Bool=true) = DiscreteUniform(0, b; check_args=check_args)

--- a/src/univariate/discrete/discreteuniform.jl
+++ b/src/univariate/discrete/discreteuniform.jl
@@ -27,9 +27,7 @@ struct DiscreteUniform <: DiscreteUnivariateDistribution
     pv::Float64 # individual probabilities
 
     function DiscreteUniform(a::Real, b::Real; check_args::Bool=true)
-        ChainRulesCore.ignore_derivatives() do
-            check_args && @check_args(DiscreteUniform, a <= b)
-        end
+        @check_args(DiscreteUniform, a <= b)
         new(a, b, 1 / (b - a + 1))
     end
     DiscreteUniform(b::Real; check_args::Bool=true) = DiscreteUniform(0, b; check_args=check_args)

--- a/src/univariate/discrete/geometric.jl
+++ b/src/univariate/discrete/geometric.jl
@@ -30,9 +30,7 @@ struct Geometric{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function Geometric(p::Real; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Geometric, zero(p) < p < one(p))
-    end
+    @check_args(Geometric, zero(p) < p < one(p))
     return Geometric{typeof(p)}(p)
 end
 

--- a/src/univariate/discrete/geometric.jl
+++ b/src/univariate/discrete/geometric.jl
@@ -30,7 +30,9 @@ struct Geometric{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function Geometric(p::Real; check_args::Bool=true)
-    check_args && @check_args(Geometric, zero(p) < p < one(p))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Geometric, zero(p) < p < one(p))
+    end
     return Geometric{typeof(p)}(p)
 end
 

--- a/src/univariate/discrete/geometric.jl
+++ b/src/univariate/discrete/geometric.jl
@@ -30,7 +30,7 @@ struct Geometric{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function Geometric(p::Real; check_args::Bool=true)
-    @check_args(Geometric, zero(p) < p < one(p))
+    @check_args Geometric (p, zero(p) < p < one(p))
     return Geometric{typeof(p)}(p)
 end
 

--- a/src/univariate/discrete/hypergeometric.jl
+++ b/src/univariate/discrete/hypergeometric.jl
@@ -25,12 +25,12 @@ struct Hypergeometric <: DiscreteUnivariateDistribution
     n::Int      # sample size
 
     function Hypergeometric(ns::Real, nf::Real, n::Real; check_args::Bool=true)
-        ChainRulesCore.ignore_derivatives() do
-            if check_args
-                @check_args(Hypergeometric, ns >= zero(ns) && nf >= zero(nf))
-                @check_args(Hypergeometric, zero(n) <= n <= ns + nf)
-            end
-        end
+        @check_args(
+            Hypergeometric,
+            ns >= zero(ns),
+            nf >= zero(nf),
+            zero(n) <= n <= ns + nf,
+        )
         new(ns, nf, n)
     end
 end

--- a/src/univariate/discrete/hypergeometric.jl
+++ b/src/univariate/discrete/hypergeometric.jl
@@ -25,9 +25,11 @@ struct Hypergeometric <: DiscreteUnivariateDistribution
     n::Int      # sample size
 
     function Hypergeometric(ns::Real, nf::Real, n::Real; check_args::Bool=true)
-        if check_args
-            @check_args(Hypergeometric, ns >= zero(ns) && nf >= zero(nf))
-            @check_args(Hypergeometric, zero(n) <= n <= ns + nf)
+        ChainRulesCore.ignore_derivatives() do
+            if check_args
+                @check_args(Hypergeometric, ns >= zero(ns) && nf >= zero(nf))
+                @check_args(Hypergeometric, zero(n) <= n <= ns + nf)
+            end
         end
         new(ns, nf, n)
     end

--- a/src/univariate/discrete/hypergeometric.jl
+++ b/src/univariate/discrete/hypergeometric.jl
@@ -27,8 +27,8 @@ struct Hypergeometric <: DiscreteUnivariateDistribution
     function Hypergeometric(ns::Real, nf::Real, n::Real; check_args::Bool=true)
         @check_args(
             Hypergeometric,
-            ns >= zero(ns),
-            nf >= zero(nf),
+            (ns, ns >= zero(ns)),
+            (nf, nf >= zero(nf)),
             zero(n) <= n <= ns + nf,
         )
         new(ns, nf, n)

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -38,9 +38,11 @@ struct NegativeBinomial{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function NegativeBinomial(r::T, p::T; check_args::Bool=true) where {T <: Real}
-    if check_args
-        @check_args(NegativeBinomial, r > zero(r))
-        @check_args(NegativeBinomial, zero(p) < p <= one(p))
+    ChainRulesCore.ignore_derivatives() do
+        if check_args
+            @check_args(NegativeBinomial, r > zero(r))
+            @check_args(NegativeBinomial, zero(p) < p <= one(p))
+        end
     end
     return NegativeBinomial{T}(r, p)
 end

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -38,7 +38,7 @@ struct NegativeBinomial{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function NegativeBinomial(r::T, p::T; check_args::Bool=true) where {T <: Real}
-    @check_args(NegativeBinomial, r > zero(r), zero(p) < p <= one(p))
+    @check_args NegativeBinomial (r, r > zero(r)) (p, zero(p) < p <= one(p))
     return NegativeBinomial{T}(r, p)
 end
 

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -38,12 +38,7 @@ struct NegativeBinomial{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function NegativeBinomial(r::T, p::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        if check_args
-            @check_args(NegativeBinomial, r > zero(r))
-            @check_args(NegativeBinomial, zero(p) < p <= one(p))
-        end
-    end
+    @check_args(NegativeBinomial, r > zero(r), zero(p) < p <= one(p))
     return NegativeBinomial{T}(r, p)
 end
 

--- a/src/univariate/discrete/noncentralhypergeometric.jl
+++ b/src/univariate/discrete/noncentralhypergeometric.jl
@@ -40,10 +40,12 @@ struct FisherNoncentralHypergeometric{T<:Real} <: NoncentralHypergeometric{T}
     ω::T # odds ratio
 
     function FisherNoncentralHypergeometric{T}(ns::Real, nf::Real, n::Real, ω::T; check_args::Bool=true) where T
-        if check_args
-            @check_args(FisherNoncentralHypergeometric, ns >= zero(ns) && nf >= zero(nf))
-            @check_args(FisherNoncentralHypergeometric, zero(n) < n < ns + nf)
-            @check_args(FisherNoncentralHypergeometric, ω > zero(ω))
+        ChainRulesCore.ignore_derivatives() do
+            if check_args
+                @check_args(FisherNoncentralHypergeometric, ns >= zero(ns) && nf >= zero(nf))
+                @check_args(FisherNoncentralHypergeometric, zero(n) < n < ns + nf)
+                @check_args(FisherNoncentralHypergeometric, ω > zero(ω))
+            end
         end
         new{T}(ns, nf, n, ω)
     end
@@ -226,10 +228,12 @@ struct WalleniusNoncentralHypergeometric{T<:Real} <: NoncentralHypergeometric{T}
     ω::T # odds ratio
 
     function WalleniusNoncentralHypergeometric{T}(ns::Real, nf::Real, n::Real, ω::T; check_args::Bool=true) where T
-        if check_args
-            @check_args(WalleniusNoncentralHypergeometric, ns >= zero(ns) && nf >= zero(nf))
-            @check_args(WalleniusNoncentralHypergeometric, zero(n) < n < ns + nf)
-            @check_args(WalleniusNoncentralHypergeometric, ω > zero(ω))
+        ChainRulesCore.ignore_derivatives() do
+            if check_args
+                @check_args(WalleniusNoncentralHypergeometric, ns >= zero(ns) && nf >= zero(nf))
+                @check_args(WalleniusNoncentralHypergeometric, zero(n) < n < ns + nf)
+                @check_args(WalleniusNoncentralHypergeometric, ω > zero(ω))
+            end
         end
         new{T}(ns, nf, n, ω)
     end

--- a/src/univariate/discrete/noncentralhypergeometric.jl
+++ b/src/univariate/discrete/noncentralhypergeometric.jl
@@ -40,13 +40,13 @@ struct FisherNoncentralHypergeometric{T<:Real} <: NoncentralHypergeometric{T}
     ω::T # odds ratio
 
     function FisherNoncentralHypergeometric{T}(ns::Real, nf::Real, n::Real, ω::T; check_args::Bool=true) where T
-        ChainRulesCore.ignore_derivatives() do
-            if check_args
-                @check_args(FisherNoncentralHypergeometric, ns >= zero(ns) && nf >= zero(nf))
-                @check_args(FisherNoncentralHypergeometric, zero(n) < n < ns + nf)
-                @check_args(FisherNoncentralHypergeometric, ω > zero(ω))
-            end
-        end
+        @check_args(
+            FisherNoncentralHypergeometric,
+            ns >= zero(ns),
+            nf >= zero(nf),
+            zero(n) < n < ns + nf,
+            ω > zero(ω),
+        )
         new{T}(ns, nf, n, ω)
     end
 end
@@ -228,13 +228,13 @@ struct WalleniusNoncentralHypergeometric{T<:Real} <: NoncentralHypergeometric{T}
     ω::T # odds ratio
 
     function WalleniusNoncentralHypergeometric{T}(ns::Real, nf::Real, n::Real, ω::T; check_args::Bool=true) where T
-        ChainRulesCore.ignore_derivatives() do
-            if check_args
-                @check_args(WalleniusNoncentralHypergeometric, ns >= zero(ns) && nf >= zero(nf))
-                @check_args(WalleniusNoncentralHypergeometric, zero(n) < n < ns + nf)
-                @check_args(WalleniusNoncentralHypergeometric, ω > zero(ω))
-            end
-        end
+        @check_args(
+            WalleniusNoncentralHypergeometric,
+            ns >= zero(ns),
+            nf >= zero(nf),
+            zero(n) < n < ns + nf,
+            ω > zero(ω),
+        )
         new{T}(ns, nf, n, ω)
     end
 end

--- a/src/univariate/discrete/noncentralhypergeometric.jl
+++ b/src/univariate/discrete/noncentralhypergeometric.jl
@@ -42,10 +42,10 @@ struct FisherNoncentralHypergeometric{T<:Real} <: NoncentralHypergeometric{T}
     function FisherNoncentralHypergeometric{T}(ns::Real, nf::Real, n::Real, ω::T; check_args::Bool=true) where T
         @check_args(
             FisherNoncentralHypergeometric,
-            ns >= zero(ns),
-            nf >= zero(nf),
+            (ns, ns >= zero(ns)),
+            (nf, nf >= zero(nf)),
             zero(n) < n < ns + nf,
-            ω > zero(ω),
+            (ω, ω > zero(ω)),
         )
         new{T}(ns, nf, n, ω)
     end
@@ -230,10 +230,10 @@ struct WalleniusNoncentralHypergeometric{T<:Real} <: NoncentralHypergeometric{T}
     function WalleniusNoncentralHypergeometric{T}(ns::Real, nf::Real, n::Real, ω::T; check_args::Bool=true) where T
         @check_args(
             WalleniusNoncentralHypergeometric,
-            ns >= zero(ns),
-            nf >= zero(nf),
+            (ns, ns >= zero(ns)),
+            (nf, nf >= zero(nf)),
             zero(n) < n < ns + nf,
-            ω > zero(ω),
+            (ω, ω > zero(ω)),
         )
         new{T}(ns, nf, n, ω)
     end

--- a/src/univariate/discrete/poisson.jl
+++ b/src/univariate/discrete/poisson.jl
@@ -27,7 +27,9 @@ struct Poisson{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function Poisson(λ::Real; check_args::Bool=true)
-    check_args && @check_args(Poisson, λ >= zero(λ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Poisson, λ >= zero(λ))
+    end
     return Poisson{typeof(λ)}(λ)
 end
 

--- a/src/univariate/discrete/poisson.jl
+++ b/src/univariate/discrete/poisson.jl
@@ -27,9 +27,7 @@ struct Poisson{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function Poisson(λ::Real; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Poisson, λ >= zero(λ))
-    end
+    @check_args(Poisson, λ >= zero(λ))
     return Poisson{typeof(λ)}(λ)
 end
 

--- a/src/univariate/discrete/poisson.jl
+++ b/src/univariate/discrete/poisson.jl
@@ -27,7 +27,7 @@ struct Poisson{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function Poisson(λ::Real; check_args::Bool=true)
-    @check_args(Poisson, λ >= zero(λ))
+    @check_args Poisson (λ, λ >= zero(λ))
     return Poisson{typeof(λ)}(λ)
 end
 

--- a/src/univariate/discrete/poissonbinomial.jl
+++ b/src/univariate/discrete/poissonbinomial.jl
@@ -31,6 +31,7 @@ mutable struct PoissonBinomial{T<:Real,P<:AbstractVector{T}} <: DiscreteUnivaria
         @check_args(
             PoissonBinomial,
             (
+                p,
                 all(x -> zero(x) <= x <= one(x), p),
                 "p must be a vector of success probabilities",
             ),

--- a/src/univariate/discrete/poissonbinomial.jl
+++ b/src/univariate/discrete/poissonbinomial.jl
@@ -28,7 +28,9 @@ mutable struct PoissonBinomial{T<:Real,P<:AbstractVector{T}} <: DiscreteUnivaria
     pmf::Union{Nothing,Vector{T}} # lazy computation of the probability mass function
 
     function PoissonBinomial{T}(p::AbstractVector{T}; check_args::Bool=true) where {T <: Real}
-        check_args && @check_args(PoissonBinomial, all(x -> zero(x) <= x <= one(x), p))
+        ChainRulesCore.ignore_derivatives() do
+            check_args && @check_args(PoissonBinomial, all(x -> zero(x) <= x <= one(x), p))
+        end
         return new{T,typeof(p)}(p, nothing)
     end
 end

--- a/src/univariate/discrete/poissonbinomial.jl
+++ b/src/univariate/discrete/poissonbinomial.jl
@@ -28,9 +28,13 @@ mutable struct PoissonBinomial{T<:Real,P<:AbstractVector{T}} <: DiscreteUnivaria
     pmf::Union{Nothing,Vector{T}} # lazy computation of the probability mass function
 
     function PoissonBinomial{T}(p::AbstractVector{T}; check_args::Bool=true) where {T <: Real}
-        ChainRulesCore.ignore_derivatives() do
-            check_args && @check_args(PoissonBinomial, all(x -> zero(x) <= x <= one(x), p))
-        end
+        @check_args(
+            PoissonBinomial,
+            (
+                all(x -> zero(x) <= x <= one(x), p),
+                "p must be a vector of success probabilities",
+            ),
+        )
         return new{T,typeof(p)}(p, nothing)
     end
 end

--- a/src/univariate/discrete/skellam.jl
+++ b/src/univariate/discrete/skellam.jl
@@ -33,14 +33,18 @@ struct Skellam{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function Skellam(μ1::T, μ2::T; check_args::Bool=true) where {T <: Real}
-    check_args && @check_args(Skellam, μ1 > zero(μ1) && μ2 > zero(μ2))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Skellam, μ1 > zero(μ1) && μ2 > zero(μ2))
+    end
     return Skellam{T}(μ1, μ2)
 end
 
 Skellam(μ1::Real, μ2::Real; check_args::Bool=true) = Skellam(promote(μ1, μ2)...; check_args=check_args)
 Skellam(μ1::Integer, μ2::Integer; check_args::Bool=true) = Skellam(float(μ1), float(μ2); check_args=check_args)
 function Skellam(μ::Real; check_args::Bool=true)
-    check_args && @check_args(Skellam, μ > zero(μ))
+    ChainRulesCore.ignore_derivatives() do
+        check_args && @check_args(Skellam, μ > zero(μ))
+    end
     Skellam(μ, μ; check_args=false)
 end
 Skellam() = Skellam{Float64}(1.0, 1.0)

--- a/src/univariate/discrete/skellam.jl
+++ b/src/univariate/discrete/skellam.jl
@@ -33,14 +33,14 @@ struct Skellam{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function Skellam(μ1::T, μ2::T; check_args::Bool=true) where {T <: Real}
-    @check_args(Skellam, μ1 > zero(μ1), μ2 > zero(μ2))
+    @check_args Skellam (μ1, μ1 > zero(μ1)) (μ2, μ2 > zero(μ2))
     return Skellam{T}(μ1, μ2)
 end
 
 Skellam(μ1::Real, μ2::Real; check_args::Bool=true) = Skellam(promote(μ1, μ2)...; check_args=check_args)
 Skellam(μ1::Integer, μ2::Integer; check_args::Bool=true) = Skellam(float(μ1), float(μ2); check_args=check_args)
 function Skellam(μ::Real; check_args::Bool=true)
-    @check_args(Skellam, μ > zero(μ))
+    @check_args Skellam (μ, μ > zero(μ))
     Skellam(μ, μ; check_args=false)
 end
 Skellam() = Skellam{Float64}(1.0, 1.0)

--- a/src/univariate/discrete/skellam.jl
+++ b/src/univariate/discrete/skellam.jl
@@ -33,18 +33,14 @@ struct Skellam{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function Skellam(μ1::T, μ2::T; check_args::Bool=true) where {T <: Real}
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Skellam, μ1 > zero(μ1) && μ2 > zero(μ2))
-    end
+    @check_args(Skellam, μ1 > zero(μ1), μ2 > zero(μ2))
     return Skellam{T}(μ1, μ2)
 end
 
 Skellam(μ1::Real, μ2::Real; check_args::Bool=true) = Skellam(promote(μ1, μ2)...; check_args=check_args)
 Skellam(μ1::Integer, μ2::Integer; check_args::Bool=true) = Skellam(float(μ1), float(μ2); check_args=check_args)
 function Skellam(μ::Real; check_args::Bool=true)
-    ChainRulesCore.ignore_derivatives() do
-        check_args && @check_args(Skellam, μ > zero(μ))
-    end
+    @check_args(Skellam, μ > zero(μ))
     Skellam(μ, μ; check_args=false)
 end
 Skellam() = Skellam{Float64}(1.0, 1.0)

--- a/src/univariate/locationscale.jl
+++ b/src/univariate/locationscale.jl
@@ -38,7 +38,9 @@ struct AffineDistribution{T<:Real, S<:ValueSupport, D<:UnivariateDistribution{S}
     σ::T
     ρ::D
     function AffineDistribution{T,S,D}(μ::T, σ::T, ρ::D; check_args::Bool=true) where {T<:Real, S<:ValueSupport, D<:UnivariateDistribution{S}}
-        check_args && @check_args(AffineDistribution, σ > zero(σ))
+        ChainRulesCore.ignore_derivatives() do
+            check_args && @check_args(AffineDistribution, σ > zero(σ))
+        end
         new{T, S, D}(μ, σ, ρ)
     end
 end
@@ -58,8 +60,9 @@ end
 const LocationScale{T,S,D} = AffineDistribution{T,S,D}
 function LocationScale(μ::Real, σ::Real, ρ::UnivariateDistribution; check_args::Bool=true)
     Base.depwarn("`LocationScale` is deprecated, use `AffineDistribution` instead", :LocationScale)
-    if check_args && σ ≤ 0  # preparation for future PR where I remove σ > 0 check
-        throw(ArgumentError("σ must be strictly positive."))
+    ChainRulesCore.ignore_derivatives() do
+        # preparation for future PR where I remove σ > 0 check
+        check_args && @check_args(LocationScale, σ > zero(σ))
     end
     return AffineDistribution(μ, σ, ρ; check_args=false)
 end

--- a/src/univariate/locationscale.jl
+++ b/src/univariate/locationscale.jl
@@ -38,7 +38,7 @@ struct AffineDistribution{T<:Real, S<:ValueSupport, D<:UnivariateDistribution{S}
     σ::T
     ρ::D
     function AffineDistribution{T,S,D}(μ::T, σ::T, ρ::D; check_args::Bool=true) where {T<:Real, S<:ValueSupport, D<:UnivariateDistribution{S}}
-        @check_args(AffineDistribution, σ > zero(σ))
+        @check_args AffineDistribution (σ, σ > zero(σ))
         new{T, S, D}(μ, σ, ρ)
     end
 end
@@ -59,7 +59,7 @@ const LocationScale{T,S,D} = AffineDistribution{T,S,D}
 function LocationScale(μ::Real, σ::Real, ρ::UnivariateDistribution; check_args::Bool=true)
     Base.depwarn("`LocationScale` is deprecated, use `AffineDistribution` instead", :LocationScale)
     # preparation for future PR where I remove σ > 0 check
-    @check_args(LocationScale, σ > zero(σ))
+    @check_args LocationScale (σ, σ > zero(σ))
     return AffineDistribution(μ, σ, ρ; check_args=false)
 end
 

--- a/src/univariate/locationscale.jl
+++ b/src/univariate/locationscale.jl
@@ -38,9 +38,7 @@ struct AffineDistribution{T<:Real, S<:ValueSupport, D<:UnivariateDistribution{S}
     σ::T
     ρ::D
     function AffineDistribution{T,S,D}(μ::T, σ::T, ρ::D; check_args::Bool=true) where {T<:Real, S<:ValueSupport, D<:UnivariateDistribution{S}}
-        ChainRulesCore.ignore_derivatives() do
-            check_args && @check_args(AffineDistribution, σ > zero(σ))
-        end
+        @check_args(AffineDistribution, σ > zero(σ))
         new{T, S, D}(μ, σ, ρ)
     end
 end
@@ -60,10 +58,8 @@ end
 const LocationScale{T,S,D} = AffineDistribution{T,S,D}
 function LocationScale(μ::Real, σ::Real, ρ::UnivariateDistribution; check_args::Bool=true)
     Base.depwarn("`LocationScale` is deprecated, use `AffineDistribution` instead", :LocationScale)
-    ChainRulesCore.ignore_derivatives() do
-        # preparation for future PR where I remove σ > 0 check
-        check_args && @check_args(LocationScale, σ > zero(σ))
-    end
+    # preparation for future PR where I remove σ > 0 check
+    @check_args(LocationScale, σ > zero(σ))
     return AffineDistribution(μ, σ, ρ; check_args=false)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -13,10 +13,10 @@ end
         ...,
     )
 
-A convenience macro that generates AD-compatible checks of arguments for a distribution of
-type `D`.
+A convenience macro that generates checks of arguments for a distribution of type `D`.
 
-More concretely, it generates the following Julia code:
+The macro expects that a boolean variable of name `check_args` is defined and generates
+the following Julia code:
 ```julia
 Distributions.check_args(check_args) do
     \$(statements...)
@@ -91,7 +91,6 @@ function check_args(f::F, check::Bool) where {F}
 end
 
 ChainRulesCore.@non_differentiable check_args(::Any, ::Bool)
-
 
 ##### Utility functions
 

--- a/test/discretenonparametric.jl
+++ b/test/discretenonparametric.jl
@@ -18,7 +18,7 @@ d = DiscreteNonParametric([40., 80., 120., -60.], [.4, .3, .1,  .2])
 @test d ≈ DiscreteNonParametric([-60., 40., 80, 120], [.2, .4, .3, .1], check_args=false)
 
 # Invalid probability
-@test_throws ArgumentError DiscreteNonParametric([40., 80, 120, -60], [.5, .3, .1, .2])
+@test_throws DomainError DiscreteNonParametric([40., 80, 120, -60], [.5, .3, .1, .2])
 
 # Invalid probability, but no arg check
 DiscreteNonParametric([40., 80, 120, -60], [.5, .3, .1, .2], check_args=false)

--- a/test/lkjcholesky.jl
+++ b/test/lkjcholesky.jl
@@ -83,9 +83,9 @@ using FiniteDifferences
             @test d.logc0 == LKJ(p, η).logc0
         end
 
-        @test_throws ArgumentError LKJCholesky(0, 2)
-        @test_throws ArgumentError LKJCholesky(4, 0.0)
-        @test_throws ArgumentError LKJCholesky(4, -1)
+        @test_throws DomainError LKJCholesky(0, 2)
+        @test_throws DomainError LKJCholesky(4, 0.0)
+        @test_throws DomainError LKJCholesky(4, -1)
 
         for uplo in (:U, 'U')
             d = LKJCholesky(4, 2, uplo)

--- a/test/matrixvariates.jl
+++ b/test/matrixvariates.jl
@@ -413,7 +413,7 @@ end
 function test_special(dist::Type{LKJ})
     @testset "LKJ mode" begin
         @test mode(LKJ(5, 1.5)) == mean(LKJ(5, 1.5))
-        @test_throws ArgumentError mode( LKJ(5, 0.5) )
+        @test_throws DomainError mode( LKJ(5, 0.5) )
     end
     @testset "LKJ marginals" begin
         d = 4

--- a/test/multinomial.jl
+++ b/test/multinomial.jl
@@ -205,6 +205,6 @@ d = Multinomial(nt, p)
 @test_nowarn rand!(d, m)
 
 p_v = [0.1, 0.4, 0.3, 0.8]
-@test_throws ArgumentError Multinomial(10, p_v)
-@test_throws ArgumentError Multinomial(10, p_v; check_args=true)
+@test_throws DomainError Multinomial(10, p_v)
+@test_throws DomainError Multinomial(10, p_v; check_args=true)
 Multinomial(10, p_v; check_args=false) # should not warn

--- a/test/skewedexponentialpower.jl
+++ b/test/skewedexponentialpower.jl
@@ -3,7 +3,7 @@ using Distributions
 
 @testset "SkewedExponentialPower" begin
     @testset "α = 0.5" begin
-        @test_throws ArgumentError SkewedExponentialPower(0, 0, 0, 0)
+        @test_throws DomainError SkewedExponentialPower(0, 0, 0, 0)
         d1 = SkewedExponentialPower(0, 1, 1, 0.5f0)
         @test @inferred partype(d1) == Float32
         d2 = SkewedExponentialPower(0, 1, 1, 0.5)

--- a/test/skewnormal.jl
+++ b/test/skewnormal.jl
@@ -3,7 +3,7 @@ using Distributions
 import Distributions: normpdf, normcdf, normlogpdf, normlogcdf
 
 @testset "SkewNormal" begin
-    @test_throws ArgumentError SkewNormal(0.0, 0.0, 0.0)
+    @test_throws DomainError SkewNormal(0.0, 0.0, 0.0)
     d1 = SkewNormal(1, 2, 3)
     d2 = SkewNormal(1.0f0, 2, 3)
     @test partype(d1) == Float64

--- a/test/univariates.jl
+++ b/test/univariates.jl
@@ -202,17 +202,17 @@ end
 
 # #1471
 @testset "InverseGamma constructor (#1471)" begin
-    @test_throws ArgumentError InverseGamma(-1, 2)
+    @test_throws DomainError InverseGamma(-1, 2)
     InverseGamma(-1, 2; check_args=false) # no error
 end
 
 # #1479
 @testset "Inner and outer constructors" begin
-    @test_throws ArgumentError InverseGaussian(0.0, 0.0)
+    @test_throws DomainError InverseGaussian(0.0, 0.0)
     @test InverseGaussian(0.0, 0.0; check_args=false) isa InverseGaussian{Float64}
     @test InverseGaussian{Float64}(0.0, 0.0) isa InverseGaussian{Float64}
 
-    @test_throws ArgumentError Levy(0.0, 0.0)
+    @test_throws DomainError Levy(0.0, 0.0)
     @test Levy(0.0, 0.0; check_args=false) isa Levy{Float64}
     @test Levy{Float64}(0.0, 0.0) isa Levy{Float64}
 end


### PR DESCRIPTION
@willtebbutt noticed in https://github.com/JuliaGaussianProcesses/AbstractGPs.jl/issues/256#issuecomment-1006695214 that the seemingly simple argument checks cause a massive slowdown in AD, specifically with Zygote. Hence this PR ignores derivatives of such checks explicitly.

@willtebbutt's example with `Normal` shows that with this PR AD is very performant, there is basically no overhead compared with the primal and zero allocations, whereas on master it is roughly 60 times slower:

On master:
```julia
julia> using BenchmarkTools, Distributions, Zygote

julia> @benchmark Normal(randn(), rand() + 1)
BenchmarkTools.Trial: 10000 samples with 999 evaluations.
 Range (min … max):  7.032 ns … 42.774 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     7.482 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   7.749 ns ±  0.827 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

        ▄▅▇▇█▆▃▁
  ▁▂▂▄▆█████████▇▅▄▃▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▂▂▂▃▃▃▃▃▃▃▂▂▂▂▂▂▁▁ ▃
  7.03 ns        Histogram: frequency by time        9.44 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark Zygote._pullback($(Zygote.Context()), Normal, randn(), rand() + 1)
BenchmarkTools.Trial: 10000 samples with 198 evaluations.
 Range (min … max):  435.172 ns … 85.840 μs  ┊ GC (min … max):  0.00% … 98.94%
 Time  (median):     454.141 ns              ┊ GC (median):     0.00%
 Time  (mean ± σ):   628.774 ns ±  2.690 μs  ┊ GC (mean ± σ):  25.31% ±  5.91%

  ▃██▇▇▅▄▄▃▃▂▂▂▂▁▂▁▁▂▂▁                                        ▂
  ████████████████████████▇▆▅▆▅▆▆▆▆▆▆▇▄▅▆▆▄▄▁▅▄▆▄▃▅▄▅▆▅▄▃▄▄▄▄▄ █
  435 ns        Histogram: log(frequency) by time       797 ns <

 Memory estimate: 848 bytes, allocs estimate: 17.
```

This PR:
```julia
julia> using BenchmarkTools, Distributions, Zygote

julia> @benchmark Normal(randn(), rand() + 1)
BenchmarkTools.Trial: 10000 samples with 999 evaluations.
 Range (min … max):  6.989 ns … 40.634 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     7.468 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   7.734 ns ±  0.801 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

         ▃▆▇█▆▄▂
  ▁▁▁▂▄▆█████████▆▄▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▂▂▂▃▃▃▃▃▃▃▃▂▂▂▂▁▁▁ ▃
  6.99 ns        Histogram: frequency by time         9.4 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark Zygote._pullback($(Zygote.Context()), Normal, randn(), rand() + 1)
BenchmarkTools.Trial: 10000 samples with 999 evaluations.
 Range (min … max):  7.010 ns … 40.456 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     7.466 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   7.718 ns ±  0.789 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

        ▃▆███▆▃▁
  ▁▁▂▃▅█████████▆▅▃▃▂▂▂▁▂▁▁▁▂▁▁▁▁▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▁ ▃
  7.01 ns        Histogram: frequency by time        9.45 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```