### PR TITLE
Build docs better on local machine

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,7 @@ import Random: AbstractRNG, rand!
 makedocs(
     sitename = "Distributions.jl",
     modules  = [Distributions],
-    doctest  = false,
+    format   = Documenter.HTML(; prettyurls = get(ENV, "CI", nothing) == "true"),
     pages    = [
         "index.md",
         "starting.md",


### PR DESCRIPTION
By default, Documenter builds the docs with `prettyurls=true`. Locally, this makes the docs non-browsable. This PR adds the [recommended check](https://juliadocs.github.io/Documenter.jl/stable/man/guide/) of the `CI` variable to only turn on `prettyurls` when building the docs on CI.