### PR TITLE
Revert deprecations of `truncated`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.42"
+version = "0.25.43"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -65,14 +65,6 @@ end
 truncated(d::UnivariateDistribution, ::Nothing, ::Nothing) = d
 function truncated(d::UnivariateDistribution, l::T, u::T) where {T <: Real}
     l <= u || error("the lower bound must be less or equal than the upper bound")
-    l == -Inf && Base.depwarn(
-        "`truncated(d, -Inf, u)` is deprecated. Please use `truncated(d; upper=u)` instead.",
-        :truncated,
-    )
-    u == Inf && Base.depwarn(
-        "`truncated(d, l, Inf)` is deprecated. Please use `truncated(d; lower=l)` instead.",
-        :truncated,
-    )
 
     # (log)lcdf = (log) P(X < l) where X ~ d
     loglcdf = if value_support(typeof(d)) === Discrete

--- a/test/truncate.jl
+++ b/test/truncate.jl
@@ -131,13 +131,16 @@ for (μ, lower, upper) in [(0, -1, 1), (1, 2, 4)]
     @test d.upper == upper
     @test truncated(Normal(μ, 1); lower=lower, upper=upper) === d
 end
-@test truncated(Normal(); lower=1) == Distributions.Truncated(Normal(), 1.0, Inf)
-@test truncated(Normal(); lower=-2) == Distributions.Truncated(Normal(), -2.0, Inf)
-@test truncated(Normal(); upper=1) == Distributions.Truncated(Normal(), -Inf, 1.0)
-@test truncated(Normal(); upper=2) == Distributions.Truncated(Normal(), -Inf, 2.0)
+for bound in (-2, 1)
+    d = Distributions.Truncated(Normal(), Float64(bound), Inf)
+    @test truncated(Normal(); lower=bound) == d
+    @test truncated(Normal(); lower=bound, upper=Inf) == d
+
+    d = Distributions.Truncated(Normal(), -Inf, Float64(bound))
+    @test truncated(Normal(); upper=bound) == d
+    @test truncated(Normal(); lower=-Inf, upper=bound) == d
+end
 @test truncated(Normal()) === Normal()
-@test_deprecated truncated(Normal(), -Inf, 2)
-@test_deprecated truncated(Normal(), 2, Inf)
 
 ## main
 

--- a/test/truncated_exponential.jl
+++ b/test/truncated_exponential.jl
@@ -5,14 +5,18 @@ using Distributions, Random, Test
     l = 1.2
     r = 2.7
     @test mean(d) ≈ mean(truncated(d; lower=-3.0)) # non-binding truncation
+    @test mean(d) ≈ mean(truncated(d; lower=-3.0, upper=Inf))
     @test mean(truncated(d; lower=l)) ≈ mean(d) + l
+    @test mean(truncated(d; lower=l, upper=Inf)) ≈ mean(d) + l
     # test values below calculated using symbolic integration in Maxima
     @test mean(truncated(d, 0, r)) ≈ 0.9653092084094841
     @test mean(truncated(d, l, r)) ≈ 1.82703493969601
 
     # all the fun corner cases and numerical quirks
     @test mean(truncated(Exponential(1.0); upper=0)) == 0                   # degenerate
+    @test mean(truncated(Exponential(1.0); lower=-Inf, upper=0)) == 0
     @test mean(truncated(Exponential(1.0); upper=0+eps())) ≈ 0 atol = eps() # near-degenerate
+    @test mean(truncated(Exponential(1.0); lower=-Inf, upper=0+eps())) ≈ 0 atol=eps()
     @test mean(truncated(Exponential(1.0), 1.0, 1.0+eps())) ≈ 1.0 # near-degenerate
     @test mean(truncated(Exponential(1e308), 1.0, 1.0+eps())) ≈ 1.0 # near-degenerate
 end

--- a/test/truncated_uniform.jl
+++ b/test/truncated_uniform.jl
@@ -5,8 +5,11 @@ using Distributions, Test
     u = Uniform(1, 2)
     @test truncated(u) === u
     @test truncated(u; lower=0) == u
+    @test truncated(u; lower=0, upper=Inf) == u
     @test truncated(u; upper=2.1) == u
+    @test truncated(u; lower=-Inf, upper=2.1) == u
     @test truncated(u; lower=1.1) == Uniform(1.1, 2)
+    @test truncated(u; lower=1.1, upper=Inf) == Uniform(1.1, 2)
     @test truncated(u, 1.1, 2.1) == Uniform(1.1, 2)
     @test truncated(u, 1.1, 1.9) == Uniform(1.1, 1.9)
 end

--- a/test/truncnormal.jl
+++ b/test/truncnormal.jl
@@ -8,13 +8,19 @@ rng = MersenneTwister(123)
     @test mean(truncated(Normal(-2,3),50,70)) ≈ 50.171943499898757645751683644632860837133138152489
     @test mean(truncated(Normal(0,2),-100,0)) ≈ -1.59576912160573071175978423973752747390343452465973
     @test mean(truncated(Normal(0,1))) == 0
+    @test mean(truncated(Normal(0,1); lower=-Inf, upper=Inf)) == 0
     @test mean(truncated(Normal(0,1); lower=0)) ≈ +√(2/π)
+    @test mean(truncated(Normal(0,1); lower=0, upper=Inf)) ≈ +√(2/π)
     @test mean(truncated(Normal(0,1); upper=0)) ≈ -√(2/π)
+    @test mean(truncated(Normal(0,1); lower=-Inf, upper=0)) ≈ -√(2/π)
     @test var(truncated(Normal(0,1),50,70)) ≈ 0.00039904318680389954790992722653605933053648912703600
     @test var(truncated(Normal(-2,3); lower=50, upper=70)) ≈ 0.029373438107168350377591231295634273607812172191712
     @test var(truncated(Normal(0,1))) == 1
+    @test var(truncated(Normal(0,1); lower=-Inf, upper=Inf)) == 1
     @test var(truncated(Normal(0,1); lower=0)) ≈ 1 - 2/π
+    @test var(truncated(Normal(0,1); lower=0, upper=Inf)) ≈ 1 - 2/π
     @test var(truncated(Normal(0,1); upper=0)) ≈ 1 - 2/π
+    @test var(truncated(Normal(0,1); lower=-Inf, upper=0)) ≈ 1 - 2/π
     # https://github.com/JuliaStats/Distributions.jl/issues/827
     @test mean(truncated(Normal(1000000,1),0,1000)) ≈ 999.999998998998999001005011019018990904720462367106
     @test var(truncated(Normal(),999000,1e6)) ≥ 0


### PR DESCRIPTION
Removes the deprecations introduced in https://github.com/JuliaStats/Distributions.jl/pull/1489 and adds back some tests, as suggested in https://github.com/JuliaStats/Distributions.jl/pull/1489#issuecomment-1024919526.

Motivation for this PR (copied from https://github.com/JuliaStats/Distributions.jl/pull/1489#issuecomment-1024918778):
> On a second thought, maybe we should revert the deprecations (but keep everything else as is). It seems unnecessary to disallow these choices explicitly, as eg in an optimization algorithm you might converge to infinity. Of course, it should still be recommended to use nothing or kwargs if the infinite/non-existing bound is fixed.

cc: @sethaxen 