### PR TITLE
Use `Number` instead of `Real` for `mgf` and `cf`

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -1,7 +1,7 @@
 module Distributions
 
 using StatsBase, PDMats, StatsFuns, Statistics
-using StatsFuns: logtwo, invsqrt2, invsqrt2π
+using StatsFuns: logtwo, invsqrt2, invsqrt2π, sqrt2
 
 import QuadGK: quadgk
 import Base: size, length, convert, show, getindex, rand, vec, inv

--- a/src/univariate/continuous/biweight.jl
+++ b/src/univariate/continuous/biweight.jl
@@ -58,13 +58,14 @@ function mgf(d::Biweight, t::Number)
     a = d.σ * t
     abs(real(a)) < 1 || throw(DomainError(t, "|σ ⋅ real(t)| has to be smaller than 1"))
     a2 = a^2
-    iszero(a) ? one(Base.promote_typeof(a, d.μ)) :
-    15exp(d.μ * t) * (-3cosh(a) + (a + 3/a) * sinh(a)) / (a2^2)
+    result = 15exp(d.μ * t) * (-3cosh(a) + (a + 3/a) * sinh(a)) / (a2^2)
+    return iszero(a) ? one(result) : result
+    
 end
 
 function cf(d::Biweight, t::Number)
     a = d.σ * t
     a2 = a^2
-    iszero(a) ? complex(one(Base.promote_typeof(a, d.μ))) :
-    -15cis(d.μ * t) * (3cos(a) + (a - 3/a) * sin(a)) / (a2^2)
+    result = -15cis(d.μ * t) * (3cos(a) + (a - 3/a) * sin(a)) / (a2^2)
+    return iszero(a) ? complex(one(result)) : result
 end

--- a/src/univariate/continuous/biweight.jl
+++ b/src/univariate/continuous/biweight.jl
@@ -54,16 +54,16 @@ end
 
 @quantile_newton Biweight
 
-function mgf(d::Biweight{T}, t::Number) where T<:Real
+function mgf(d::Biweight, t::Number)
     a = d.σ * t
     a2 = a^2
-    iszero(a) ? one(a) :
+    iszero(a) ? one(Base.promote_typeof(a, d.μ)) :
     15exp(d.μ * t) * (-3cosh(a) + (a + 3/a) * sinh(a)) / (a2^2)
 end
 
 function cf(d::Biweight{T}, t::Number) where T<:Real
     a = d.σ * t
     a2 = a^2
-    iszero(a) ? complex(one(a)) :
+    iszero(a) ? complex(one(Base.promote_typeof(a, d.μ))) :
     -15cis(d.μ * t) * (3cos(a) + (a - 3/a) * sin(a)) / (a2^2)
 end

--- a/src/univariate/continuous/biweight.jl
+++ b/src/univariate/continuous/biweight.jl
@@ -56,7 +56,7 @@ end
 
 function mgf(d::Biweight, t::Number)
     a = d.σ * t
-    abs(real(a)) < 1 || throw(DomainError("|σ real(t)| has to be smaller than 1"))
+    abs(real(a)) < 1 || throw(DomainError(t, "|σ ⋅ real(t)| has to be smaller than 1"))
     a2 = a^2
     iszero(a) ? one(Base.promote_typeof(a, d.μ)) :
     15exp(d.μ * t) * (-3cosh(a) + (a + 3/a) * sinh(a)) / (a2^2)

--- a/src/univariate/continuous/biweight.jl
+++ b/src/univariate/continuous/biweight.jl
@@ -56,6 +56,7 @@ end
 
 function mgf(d::Biweight, t::Number)
     a = d.σ * t
+    abs(real(a)) < 1 || throw(DomainError("|σ real(t)| has to be smaller than 1"))
     a2 = a^2
     iszero(a) ? one(Base.promote_typeof(a, d.μ)) :
     15exp(d.μ * t) * (-3cosh(a) + (a + 3/a) * sinh(a)) / (a2^2)

--- a/src/univariate/continuous/biweight.jl
+++ b/src/univariate/continuous/biweight.jl
@@ -61,7 +61,7 @@ function mgf(d::Biweight, t::Number)
     15exp(d.μ * t) * (-3cosh(a) + (a + 3/a) * sinh(a)) / (a2^2)
 end
 
-function cf(d::Biweight{T}, t::Number) where T<:Real
+function cf(d::Biweight, t::Number)
     a = d.σ * t
     a2 = a^2
     iszero(a) ? complex(one(Base.promote_typeof(a, d.μ))) :

--- a/src/univariate/continuous/biweight.jl
+++ b/src/univariate/continuous/biweight.jl
@@ -54,16 +54,16 @@ end
 
 @quantile_newton Biweight
 
-function mgf(d::Biweight{T}, t::Real) where T<:Real
-    a = d.σ*t
+function mgf(d::Biweight{T}, t::Number) where T<:Real
+    a = d.σ * t
     a2 = a^2
-    a == 0 ? one(T) :
+    iszero(a) ? one(a) :
     15exp(d.μ * t) * (-3cosh(a) + (a + 3/a) * sinh(a)) / (a2^2)
 end
 
-function cf(d::Biweight{T}, t::Real) where T<:Real
+function cf(d::Biweight{T}, t::Number) where T<:Real
     a = d.σ * t
     a2 = a^2
-    a == 0 ? one(T)+zero(T)*im :
+    iszero(a) ? complex(one(a)) :
     -15cis(d.μ * t) * (3cos(a) + (a - 3/a) * sin(a)) / (a2^2)
 end

--- a/src/univariate/continuous/cauchy.jl
+++ b/src/univariate/continuous/cauchy.jl
@@ -97,8 +97,8 @@ function cquantile(d::Cauchy, p::Real)
     μ + σ * tan(π * (1//2 - p))
 end
 
-mgf(d::Cauchy{T}, t::Real) where {T<:Real} = t == zero(t) ? one(T) : T(NaN)
-cf(d::Cauchy, t::Real) = exp(im * (t * d.μ) - d.σ * abs(t))
+mgf(d::Cauchy{T}, t::Number) where {T<:Real} = iszero(t) ? one(T) : T(NaN)
+cf(d::Cauchy, t::Number) = exp(im * (t * d.μ) - d.σ * abs(t))
 
 #### Affine transformations
 

--- a/src/univariate/continuous/cauchy.jl
+++ b/src/univariate/continuous/cauchy.jl
@@ -97,7 +97,10 @@ function cquantile(d::Cauchy, p::Real)
     μ + σ * tan(π * (1//2 - p))
 end
 
-mgf(d::Cauchy{T}, t::Number) where {T<:Real} = iszero(t) ? one(T) : T(NaN)
+function mgf(d::Cauchy, t::Number)
+    T = float(partype(d))
+    return iszero(t) ? one(T) : T(NaN)
+end
 cf(d::Cauchy, t::Number) = exp(im * (t * d.μ) - d.σ * abs(t))
 
 #### Affine transformations

--- a/src/univariate/continuous/chisq.jl
+++ b/src/univariate/continuous/chisq.jl
@@ -76,7 +76,7 @@ end
 @_delegate_statsfuns Chisq chisq ν
 
 function mgf(d::Chisq, t::Number)
-    real(t) < 0.5 || throw(DomainError("the real part of t has to be smaller than 0.5"))
+    real(t) < 0.5 || throw(DomainError(t, "the real part of t has to be smaller than 0.5"))
     return (1 - 2 * t)^(-d.ν/2)
 end
 

--- a/src/univariate/continuous/chisq.jl
+++ b/src/univariate/continuous/chisq.jl
@@ -75,7 +75,10 @@ end
 
 @_delegate_statsfuns Chisq chisq ν
 
-mgf(d::Chisq, t::Number) = (1 - 2 * t)^(-d.ν/2)
+function mgf(d::Chisq, t::Number)
+    real(t) < 0.5 || throw(DomainError("the real part of t has to be smaller than 0.5"))
+    return (1 - 2 * t)^(-d.ν/2)
+end
 
 cf(d::Chisq, t::Number) = (1 - 2 * im * t)^(-d.ν/2)
 

--- a/src/univariate/continuous/chisq.jl
+++ b/src/univariate/continuous/chisq.jl
@@ -75,9 +75,9 @@ end
 
 @_delegate_statsfuns Chisq chisq ν
 
-mgf(d::Chisq, t::Real) = (1 - 2 * t)^(-d.ν/2)
+mgf(d::Chisq, t::Number) = (1 - 2 * t)^(-d.ν/2)
 
-cf(d::Chisq, t::Real) = (1 - 2 * im * t)^(-d.ν/2)
+cf(d::Chisq, t::Number) = (1 - 2 * im * t)^(-d.ν/2)
 
 gradlogpdf(d::Chisq{T}, x::Real) where {T<:Real} =  x > 0 ? (d.ν/2 - 1) / x - 1//2 : zero(T)
 

--- a/src/univariate/continuous/epanechnikov.jl
+++ b/src/univariate/continuous/epanechnikov.jl
@@ -73,6 +73,6 @@ end
 
 function cf(d::Epanechnikov{T}, t::Number) where T<:Real
     a = d.σ * t
-    iszero(a) ? complex(one(promote_rule(typeof(a), typeof(d.μ)))) :
+    iszero(a) ? complex(one(Base.promote_typeof(a, d.μ))) :
     -3exp(im * d.μ * t) * (cos(a) - sin(a) / a) / a^2
 end

--- a/src/univariate/continuous/epanechnikov.jl
+++ b/src/univariate/continuous/epanechnikov.jl
@@ -65,14 +65,14 @@ end
 
 @quantile_newton Epanechnikov
 
-function mgf(d::Epanechnikov{T}, t::Real) where T<:Real
+function mgf(d::Epanechnikov{T}, t::Number) where T<:Real
     a = d.σ * t
-    a == 0 ? one(T) :
+    iszero(a) ? one(T) :
     3exp(d.μ * t) * (cosh(a) - sinh(a) / a) / a^2
 end
 
-function cf(d::Epanechnikov{T}, t::Real) where T<:Real
+function cf(d::Epanechnikov{T}, t::Number) where T<:Real
     a = d.σ * t
-    a == 0 ? one(T)+zero(T)*im :
+    iszero(a) ? complex(one(a)) :
     -3exp(im * d.μ * t) * (cos(a) - sin(a) / a) / a^2
 end

--- a/src/univariate/continuous/epanechnikov.jl
+++ b/src/univariate/continuous/epanechnikov.jl
@@ -67,7 +67,7 @@ end
 
 function mgf(d::Epanechnikov{T}, t::Number) where T<:Real
     a = d.σ * t
-    abs(real(a)) < 1 || throw(DomainError("|σ real(t)| has to be smaller than 1"))
+    abs(real(a)) < 1 || throw(DomainError(t, "|σ ⋅ real(t)| has to be smaller than 1"))
     iszero(a) ? one(Base.promote_typeof(a, d.μ)) :
     3exp(d.μ * t) * (cosh(a) - sinh(a) / a) / a^2
 end

--- a/src/univariate/continuous/epanechnikov.jl
+++ b/src/univariate/continuous/epanechnikov.jl
@@ -68,12 +68,12 @@ end
 function mgf(d::Epanechnikov{T}, t::Number) where T<:Real
     a = d.σ * t
     abs(real(a)) < 1 || throw(DomainError(t, "|σ ⋅ real(t)| has to be smaller than 1"))
-    iszero(a) ? one(Base.promote_typeof(a, d.μ)) :
-    3exp(d.μ * t) * (cosh(a) - sinh(a) / a) / a^2
+    result = 3exp(d.μ * t) * (cosh(a) - sinh(a) / a) / a^2
+    return iszero(a) ? one(result) : result
 end
 
 function cf(d::Epanechnikov{T}, t::Number) where T<:Real
     a = d.σ * t
-    iszero(a) ? complex(one(Base.promote_typeof(a, d.μ))) :
-    -3exp(im * d.μ * t) * (cos(a) - sin(a) / a) / a^2
+    result = -3exp(im * d.μ * t) * (cos(a) - sin(a) / a) / a^2
+    return iszero(a) ? complex(one(result)) : result
 end

--- a/src/univariate/continuous/epanechnikov.jl
+++ b/src/univariate/continuous/epanechnikov.jl
@@ -67,6 +67,7 @@ end
 
 function mgf(d::Epanechnikov{T}, t::Number) where T<:Real
     a = d.σ * t
+    abs(real(a)) < 1 || throw(DomainError("|σ real(t)| has to be smaller than 1"))
     iszero(a) ? one(Base.promote_typeof(a, d.μ)) :
     3exp(d.μ * t) * (cosh(a) - sinh(a) / a) / a^2
 end

--- a/src/univariate/continuous/epanechnikov.jl
+++ b/src/univariate/continuous/epanechnikov.jl
@@ -67,12 +67,12 @@ end
 
 function mgf(d::Epanechnikov{T}, t::Number) where T<:Real
     a = d.σ * t
-    iszero(a) ? one(T) :
+    iszero(a) ? one(Base.promote_typeof(a, d.μ)) :
     3exp(d.μ * t) * (cosh(a) - sinh(a) / a) / a^2
 end
 
 function cf(d::Epanechnikov{T}, t::Number) where T<:Real
     a = d.σ * t
-    iszero(a) ? complex(one(a)) :
+    iszero(a) ? complex(one(promote_rule(typeof(a), typeof(d.μ)))) :
     -3exp(im * d.μ * t) * (cos(a) - sin(a) / a) / a^2
 end

--- a/src/univariate/continuous/erlang.jl
+++ b/src/univariate/continuous/erlang.jl
@@ -76,7 +76,7 @@ function entropy(d::Erlang)
 end
 
 function mgf(d::Erlang, t::Number)
-    real(t) < inv(d.θ) || throw(DomainError("the real part of t should be smaller than θ⁻¹")) 
+    real(t) < inv(d.θ) || throw(DomainError(t, "the real part of t should be smaller than θ⁻¹")) 
     return (1 - t * d.θ)^(-d.α)
 end
 cf(d::Erlang, t::Number)  = (1 - im * t * d.θ)^(-d.α)

--- a/src/univariate/continuous/erlang.jl
+++ b/src/univariate/continuous/erlang.jl
@@ -75,8 +75,8 @@ function entropy(d::Erlang)
     α + loggamma(α) + (1 - α) * digamma(α) + log(θ)
 end
 
-mgf(d::Erlang, t::Real) = (1 - t * d.θ)^(-d.α)
-cf(d::Erlang, t::Real)  = (1 - im * t * d.θ)^(-d.α)
+mgf(d::Erlang, t::Number) = (1 - t * d.θ)^(-d.α)
+cf(d::Erlang, t::Number)  = (1 - im * t * d.θ)^(-d.α)
 
 
 #### Evaluation & Sampling

--- a/src/univariate/continuous/erlang.jl
+++ b/src/univariate/continuous/erlang.jl
@@ -75,7 +75,10 @@ function entropy(d::Erlang)
     α + loggamma(α) + (1 - α) * digamma(α) + log(θ)
 end
 
-mgf(d::Erlang, t::Number) = (1 - t * d.θ)^(-d.α)
+function mgf(d::Erlang, t::Number)
+    real(t) < inv(d.θ) || throw(DomainError("the real part of t should be smaller than θ⁻¹")) 
+    return (1 - t * d.θ)^(-d.α)
+end
 cf(d::Erlang, t::Number)  = (1 - im * t * d.θ)^(-d.α)
 
 

--- a/src/univariate/continuous/exponential.jl
+++ b/src/univariate/continuous/exponential.jl
@@ -93,7 +93,10 @@ invlogccdf(d::Exponential, lp::Real) = -xval(d, lp)
 
 gradlogpdf(d::Exponential{T}, x::Real) where {T<:Real} = x > 0 ? -rate(d) : zero(T)
 
-mgf(d::Exponential, t::Number) = 1/(1 - t * scale(d))
+function mgf(d::Exponential, t::Number)
+    real(t) < rate(d) || throw(DomainError("the real part of t should be smaller than λ"))
+    return 1/(1 - t * scale(d))
+end
 cf(d::Exponential, t::Number) = 1/(1 - t * im * scale(d))
 
 

--- a/src/univariate/continuous/exponential.jl
+++ b/src/univariate/continuous/exponential.jl
@@ -93,8 +93,8 @@ invlogccdf(d::Exponential, lp::Real) = -xval(d, lp)
 
 gradlogpdf(d::Exponential{T}, x::Real) where {T<:Real} = x > 0 ? -rate(d) : zero(T)
 
-mgf(d::Exponential, t::Real) = 1/(1 - t * scale(d))
-cf(d::Exponential, t::Real) = 1/(1 - t * im * scale(d))
+mgf(d::Exponential, t::Number) = 1/(1 - t * scale(d))
+cf(d::Exponential, t::Number) = 1/(1 - t * im * scale(d))
 
 
 #### Sampling

--- a/src/univariate/continuous/exponential.jl
+++ b/src/univariate/continuous/exponential.jl
@@ -94,7 +94,7 @@ invlogccdf(d::Exponential, lp::Real) = -xval(d, lp)
 gradlogpdf(d::Exponential{T}, x::Real) where {T<:Real} = x > 0 ? -rate(d) : zero(T)
 
 function mgf(d::Exponential, t::Number)
-    real(t) < rate(d) || throw(DomainError("the real part of t should be smaller than λ"))
+    real(t) < rate(d) || throw(DomainError(t, "the real part of t should be smaller than λ"))
     return 1/(1 - t * scale(d))
 end
 cf(d::Exponential, t::Number) = 1/(1 - t * im * scale(d))

--- a/src/univariate/continuous/gamma.jl
+++ b/src/univariate/continuous/gamma.jl
@@ -76,7 +76,7 @@ function entropy(d::Gamma)
 end
 
 function mgf(d::Gamma, t::Number)
-    real(t) < inv(d.θ) || throw(DomainError("the real part of t should smaller than θ⁻¹"))
+    real(t) < rate(d) || throw(DomainError(t, "the real part of t should smaller than θ⁻¹"))
     return (1 - t * d.θ)^(-d.α)
 end
 

--- a/src/univariate/continuous/gamma.jl
+++ b/src/univariate/continuous/gamma.jl
@@ -75,9 +75,9 @@ function entropy(d::Gamma)
     α + loggamma(α) + (1 - α) * digamma(α) + log(θ)
 end
 
-mgf(d::Gamma, t::Real) = (1 - t * d.θ)^(-d.α)
+mgf(d::Gamma, t::Number) = (1 - t * d.θ)^(-d.α)
 
-cf(d::Gamma, t::Real) = (1 - im * t * d.θ)^(-d.α)
+cf(d::Gamma, t::Number) = (1 - im * t * d.θ)^(-d.α)
 
 function kldivergence(p::Gamma, q::Gamma)
     # We use the parametrization with the scale θ

--- a/src/univariate/continuous/gamma.jl
+++ b/src/univariate/continuous/gamma.jl
@@ -75,7 +75,10 @@ function entropy(d::Gamma)
     α + loggamma(α) + (1 - α) * digamma(α) + log(θ)
 end
 
-mgf(d::Gamma, t::Number) = (1 - t * d.θ)^(-d.α)
+function mgf(d::Gamma, t::Number)
+    real(t) < inv(d.θ) || throw(DomainError("the real part of t should smaller than θ⁻¹"))
+    return (1 - t * d.θ)^(-d.α)
+end
 
 cf(d::Gamma, t::Number) = (1 - im * t * d.θ)^(-d.α)
 

--- a/src/univariate/continuous/inversegamma.jl
+++ b/src/univariate/continuous/inversegamma.jl
@@ -110,12 +110,13 @@ invlogccdf(d::InverseGamma, p::Real) = inv(invlogcdf(d.invd, p))
 
 function mgf(d::InverseGamma, t::Number)
     (a, b) = params(d)
+    # Where does this formula comes from?
+    # Wikipedia says (wrongly I think) that it is not defined
     iszero(t) ? one(Base.promote_typeof(a, b, t)) : 2(-b*t)^(0.5a) / gamma(a) * besselk(a, sqrt(-4*b*t))
 end
 
 function cf(d::InverseGamma, t::Number)
     (a, b) = params(d)
-    T = promote_rule(typeof(a), typeof(b))
     iszero(t) ? complex(one(Base.promote_typeof(a, b, t))) : 2(-im*b*t)^(0.5a) / gamma(a) * besselk(a, sqrt(-4*im*b*t))
 end
 

--- a/src/univariate/continuous/inversegamma.jl
+++ b/src/univariate/continuous/inversegamma.jl
@@ -112,12 +112,14 @@ function mgf(d::InverseGamma, t::Number)
     (a, b) = params(d)
     # Where does this formula comes from?
     # Wikipedia says (wrongly I think) that it is not defined
-    iszero(t) ? one(Base.promote_typeof(a, b, t)) : 2(-b*t)^(0.5a) / gamma(a) * besselk(a, sqrt(-4*b*t))
+    result = 2(-b*t)^(0.5a) / gamma(a) * besselk(a, sqrt(-4*b*t))
+    return iszero(t) ? one(result) : result
 end
 
 function cf(d::InverseGamma, t::Number)
     (a, b) = params(d)
-    iszero(t) ? complex(one(Base.promote_typeof(a, b, t))) : 2(-im*b*t)^(0.5a) / gamma(a) * besselk(a, sqrt(-4*im*b*t))
+    result = 2(-im*b*t)^(0.5a) / gamma(a) * besselk(a, sqrt(-4*im*b*t))
+    iszero(t) ? complex(one(result)) : result
 end
 
 

--- a/src/univariate/continuous/inversegamma.jl
+++ b/src/univariate/continuous/inversegamma.jl
@@ -108,14 +108,14 @@ cquantile(d::InverseGamma, p::Real) = inv(quantile(d.invd, p))
 invlogcdf(d::InverseGamma, p::Real) = inv(invlogccdf(d.invd, p))
 invlogccdf(d::InverseGamma, p::Real) = inv(invlogcdf(d.invd, p))
 
-function mgf(d::InverseGamma{T}, t::Real) where T<:Real
+function mgf(d::InverseGamma{T}, t::Number) where T<:Real
     (a, b) = params(d)
-    t == zero(t) ? one(T) : 2(-b*t)^(0.5a) / gamma(a) * besselk(a, sqrt(-4*b*t))
+    iszero(t) ? one(T) : 2(-b*t)^(0.5a) / gamma(a) * besselk(a, sqrt(-4*b*t))
 end
 
-function cf(d::InverseGamma{T}, t::Real) where T<:Real
+function cf(d::InverseGamma{T}, t::Number) where T<:Real
     (a, b) = params(d)
-    t == zero(t) ? one(T)+zero(T)*im : 2(-im*b*t)^(0.5a) / gamma(a) * besselk(a, sqrt(-4*im*b*t))
+    iszero(t) ? complex(one(a)) : 2(-im*b*t)^(0.5a) / gamma(a) * besselk(a, sqrt(-4*im*b*t))
 end
 
 

--- a/src/univariate/continuous/inversegamma.jl
+++ b/src/univariate/continuous/inversegamma.jl
@@ -108,14 +108,15 @@ cquantile(d::InverseGamma, p::Real) = inv(quantile(d.invd, p))
 invlogcdf(d::InverseGamma, p::Real) = inv(invlogccdf(d.invd, p))
 invlogccdf(d::InverseGamma, p::Real) = inv(invlogcdf(d.invd, p))
 
-function mgf(d::InverseGamma{T}, t::Number) where T<:Real
+function mgf(d::InverseGamma, t::Number)
     (a, b) = params(d)
-    iszero(t) ? one(T) : 2(-b*t)^(0.5a) / gamma(a) * besselk(a, sqrt(-4*b*t))
+    iszero(t) ? one(Base.promote_typeof(a, b, t)) : 2(-b*t)^(0.5a) / gamma(a) * besselk(a, sqrt(-4*b*t))
 end
 
-function cf(d::InverseGamma{T}, t::Number) where T<:Real
+function cf(d::InverseGamma, t::Number)
     (a, b) = params(d)
-    iszero(t) ? complex(one(a)) : 2(-im*b*t)^(0.5a) / gamma(a) * besselk(a, sqrt(-4*im*b*t))
+    T = promote_rule(typeof(a), typeof(b))
+    iszero(t) ? complex(one(Base.promote_typeof(a, b, t))) : 2(-im*b*t)^(0.5a) / gamma(a) * besselk(a, sqrt(-4*im*b*t))
 end
 
 

--- a/src/univariate/continuous/laplace.jl
+++ b/src/univariate/continuous/laplace.jl
@@ -96,8 +96,8 @@ function gradlogpdf(d::Laplace, x::Real)
 end
 
 function mgf(d::Laplace, t::Number)
-    abs(t) < 1 / d.θ || return Base.promote_typeof(t, d.θ, d.μ)(NaN)
     st = d.θ * t
+    abs(real(t)) < 1 / d.θ || throw(DomainError("the absolute value of the real part of t should be smaller than θ"))
     exp(t * d.μ) / ((1 - st) * (1 + st))
 end
 function cf(d::Laplace, t::Number)

--- a/src/univariate/continuous/laplace.jl
+++ b/src/univariate/continuous/laplace.jl
@@ -96,6 +96,7 @@ function gradlogpdf(d::Laplace, x::Real)
 end
 
 function mgf(d::Laplace, t::Number)
+    abs(t) < 1 / d.θ || return Base.promote_typeof(t, d.θ, d.μ)(NaN)
     st = d.θ * t
     exp(t * d.μ) / ((1 - st) * (1 + st))
 end

--- a/src/univariate/continuous/laplace.jl
+++ b/src/univariate/continuous/laplace.jl
@@ -97,7 +97,7 @@ end
 
 function mgf(d::Laplace, t::Number)
     st = d.θ * t
-    abs(real(t)) < 1 / d.θ || throw(DomainError("the absolute value of the real part of t should be smaller than θ"))
+    abs(real(t)) < 1 / d.θ || throw(DomainError(t, "the absolute value of the real part of t should be smaller than θ⁻¹"))
     exp(t * d.μ) / ((1 - st) * (1 + st))
 end
 function cf(d::Laplace, t::Number)

--- a/src/univariate/continuous/laplace.jl
+++ b/src/univariate/continuous/laplace.jl
@@ -95,11 +95,11 @@ function gradlogpdf(d::Laplace, x::Real)
     x > μ ? -g : g
 end
 
-function mgf(d::Laplace, t::Real)
+function mgf(d::Laplace, t::Number)
     st = d.θ * t
     exp(t * d.μ) / ((1 - st) * (1 + st))
 end
-function cf(d::Laplace, t::Real)
+function cf(d::Laplace, t::Number)
     st = d.θ * t
     cis(t * d.μ) / (1+st*st)
 end

--- a/src/univariate/continuous/levy.jl
+++ b/src/univariate/continuous/levy.jl
@@ -90,9 +90,9 @@ ccdf(d::Levy{T}, x::Real) where {T<:Real} =  x <= d.μ ? one(T) : erf(sqrt(d.σ 
 quantile(d::Levy, p::Real) = d.μ + d.σ / (2*erfcinv(p)^2)
 cquantile(d::Levy, p::Real) = d.μ + d.σ / (2*erfinv(p)^2)
 
-mgf(d::Levy{T}, t::Real) where {T<:Real} = t == zero(t) ? one(T) : T(NaN)
+mgf(d::Levy{T}, t::Number) where {T<:Real} = iszero(t) ? one(T) : T(NaN)
 
-function cf(d::Levy, t::Real)
+function cf(d::Levy, t::Number)
     μ, σ = params(d)
     exp(im * μ * t - sqrt(-2im * σ * t))
 end

--- a/src/univariate/continuous/levy.jl
+++ b/src/univariate/continuous/levy.jl
@@ -90,7 +90,10 @@ ccdf(d::Levy{T}, x::Real) where {T<:Real} =  x <= d.μ ? one(T) : erf(sqrt(d.σ 
 quantile(d::Levy, p::Real) = d.μ + d.σ / (2*erfcinv(p)^2)
 cquantile(d::Levy, p::Real) = d.μ + d.σ / (2*erfinv(p)^2)
 
-mgf(d::Levy{T}, t::Number) where {T<:Real} = iszero(t) ? one(T) : T(NaN)
+function mgf(d::Levy, t::Number)
+    T = float(partype(d))
+    iszero(t) ? one(T) : T(NaN)
+end
 
 function cf(d::Levy, t::Number)
     μ, σ = params(d)

--- a/src/univariate/continuous/logistic.jl
+++ b/src/univariate/continuous/logistic.jl
@@ -97,7 +97,7 @@ end
 
 mgf(d::Logistic, t::Number) = exp(t * d.μ) / sinc(d.θ * t)
 
-function cf(d::Logistic{T}, t::Number) where {T<:Real}
+function cf(d::Logistic, t::Number)
     a = (π * t) * d.θ
     iszero(a) ? complex(one(a)) : cis(t * d.μ) * (a / sinh(a))
 end

--- a/src/univariate/continuous/logistic.jl
+++ b/src/univariate/continuous/logistic.jl
@@ -95,9 +95,9 @@ function gradlogpdf(d::Logistic, x::Real)
     ((2e) / (1 + e) - 1) / d.θ
 end
 
-mgf(d::Logistic, t::Real) = exp(t * d.μ) / sinc(d.θ * t)
+mgf(d::Logistic, t::Number) = exp(t * d.μ) / sinc(d.θ * t)
 
-function cf(d::Logistic, t::Real)
+function cf(d::Logistic{T}, t::Number) where {T<:Real}
     a = (π * t) * d.θ
-    a == zero(a) ? complex(one(a)) : cis(t * d.μ) * (a / sinh(a))
+    iszero(a) ? complex(one(a)) : cis(t * d.μ) * (a / sinh(a))
 end

--- a/src/univariate/continuous/logistic.jl
+++ b/src/univariate/continuous/logistic.jl
@@ -95,9 +95,12 @@ function gradlogpdf(d::Logistic, x::Real)
     ((2e) / (1 + e) - 1) / d.θ
 end
 
-mgf(d::Logistic, t::Number) = exp(t * d.μ) / sinc(d.θ * t)
+function mgf(d::Logistic, t::Number)
+    abs(real(t)) < inv(d.θ) || throw(DomainError("the absolute value of the real part of t should be smaller than θ⁻¹"))
+    return exp(t * d.μ) / sinc(d.θ * t)
+end
 
 function cf(d::Logistic, t::Number)
     a = (π * t) * d.θ
-    iszero(a) ? complex(one(a)) : cis(t * d.μ) * (a / sinh(a))
+    return iszero(a) ? complex(one(a)) : cis(t * d.μ) * (a / sinh(a))
 end

--- a/src/univariate/continuous/logistic.jl
+++ b/src/univariate/continuous/logistic.jl
@@ -96,7 +96,7 @@ function gradlogpdf(d::Logistic, x::Real)
 end
 
 function mgf(d::Logistic, t::Number)
-    abs(real(t)) < inv(d.θ) || throw(DomainError("the absolute value of the real part of t should be smaller than θ⁻¹"))
+    abs(real(t)) < inv(d.θ) || throw(DomainError(t, "the absolute value of the real part of t should be smaller than θ⁻¹"))
     return exp(t * d.μ) / sinc(d.θ * t)
 end
 

--- a/src/univariate/continuous/noncentralchisq.jl
+++ b/src/univariate/continuous/noncentralchisq.jl
@@ -62,7 +62,8 @@ skewness(d::NoncentralChisq) = 2sqrt2*(d.ν + 3d.λ)/sqrt(d.ν + 2d.λ)^3
 kurtosis(d::NoncentralChisq) = 12(d.ν + 4d.λ)/(d.ν + 2d.λ)^2
 
 function mgf(d::NoncentralChisq, t::Number)
-    exp(d.λ * t/(1 - 2t))*(1 - 2t)^(-d.ν/2)
+    real(t) < 0.5 || throw(DomainError("real part of t should be smaller than 1/2"))
+    return exp(d.λ * t/(1 - 2t))*(1 - 2t)^(-d.ν/2)
 end
 
 function cf(d::NoncentralChisq, t::Number)

--- a/src/univariate/continuous/noncentralchisq.jl
+++ b/src/univariate/continuous/noncentralchisq.jl
@@ -61,11 +61,11 @@ var(d::NoncentralChisq) = 2(d.ν + 2d.λ)
 skewness(d::NoncentralChisq) = 2sqrt2*(d.ν + 3d.λ)/sqrt(d.ν + 2d.λ)^3
 kurtosis(d::NoncentralChisq) = 12(d.ν + 4d.λ)/(d.ν + 2d.λ)^2
 
-function mgf(d::NoncentralChisq, t::Real)
+function mgf(d::NoncentralChisq, t::Number)
     exp(d.λ * t/(1 - 2t))*(1 - 2t)^(-d.ν/2)
 end
 
-function cf(d::NoncentralChisq, t::Real)
+function cf(d::NoncentralChisq, t::Number)
     cis(d.λ * t/(1 - 2im*t))*(1 - 2im*t)^(-d.ν/2)
 end
 

--- a/src/univariate/continuous/noncentralchisq.jl
+++ b/src/univariate/continuous/noncentralchisq.jl
@@ -62,7 +62,7 @@ skewness(d::NoncentralChisq) = 2sqrt2*(d.ν + 3d.λ)/sqrt(d.ν + 2d.λ)^3
 kurtosis(d::NoncentralChisq) = 12(d.ν + 4d.λ)/(d.ν + 2d.λ)^2
 
 function mgf(d::NoncentralChisq, t::Number)
-    real(t) < 0.5 || throw(DomainError("real part of t should be smaller than 1/2"))
+    real(t) < 0.5 || throw(DomainError(t, "the real part of t should be smaller than 1/2"))
     return exp(d.λ * t/(1 - 2t))*(1 - 2t)^(-d.ν/2)
 end
 

--- a/src/univariate/continuous/normal.jl
+++ b/src/univariate/continuous/normal.jl
@@ -90,8 +90,8 @@ end
 
 gradlogpdf(d::Normal, x::Real) = (d.μ - x) / d.σ^2
 
-mgf(d::Normal, t::Real) = exp(t * d.μ + d.σ^2 / 2 * t^2)
-cf(d::Normal, t::Real) = exp(im * t * d.μ - d.σ^2 / 2 * t^2)
+mgf(d::Normal, t::Number) = exp(t * d.μ + d.σ^2 / 2 * t^2)
+cf(d::Normal, t::Number) = exp(im * t * d.μ - d.σ^2 / 2 * t^2)
 
 #### Affine transformations
 

--- a/src/univariate/continuous/skewnormal.jl
+++ b/src/univariate/continuous/skewnormal.jl
@@ -56,7 +56,7 @@ logpdf(d::SkewNormal, x::Real) = log(2) - log(d.ω) + normlogpdf((x-d.ξ) / d.ω
 
 mgf(d::SkewNormal, t::Number) = 2 * exp(d.ξ * t + (d.ω^2 * t^2)/2 ) * normcdf(d.ω * delta(d) * t)
 
-cf(d::SkewNormal, t::Number) = exp(im * t * d.ξ - (d.ω^2 * t^2)/2) * (1 + im * erfi((d.ω * delta(d) * t)/(sqrt(2))) )
+cf(d::SkewNormal, t::Number) = exp(im * t * d.ξ - (d.ω^2 * t^2)/2) * (1 + im * erfi((d.ω * delta(d) * t)/sqrttwo) )
 
 #### Sampling
 function rand(rng::AbstractRNG, d::SkewNormal)

--- a/src/univariate/continuous/skewnormal.jl
+++ b/src/univariate/continuous/skewnormal.jl
@@ -54,9 +54,9 @@ logpdf(d::SkewNormal, x::Real) = log(2) - log(d.ω) + normlogpdf((x-d.ξ) / d.ω
 #cdf requires Owen's T function.
 #cdf/quantile etc 
 
-mgf(d::SkewNormal, t::Number) = 2 * exp(d.ξ * t + (d.ω^2 * t^2)/2 ) * normcdf(d.ω * delta(d) * t)
+mgf(d::SkewNormal, t::Number) = 2 * exp(d.ξ * t + (d.ω^2 * t^2)/2) * normcdf(d.ω * delta(d) * t)
 
-cf(d::SkewNormal, t::Number) = exp(im * t * d.ξ - (d.ω^2 * t^2)/2) * (1 + im * erfi((d.ω * delta(d) * t)/sqrttwo) )
+cf(d::SkewNormal, t::Number) = exp(im * t * d.ξ - (d.ω^2 * t^2)/2) * (1 + im * erfi((d.ω * delta(d) * t)/sqrt2))
 
 #### Sampling
 function rand(rng::AbstractRNG, d::SkewNormal)

--- a/src/univariate/continuous/skewnormal.jl
+++ b/src/univariate/continuous/skewnormal.jl
@@ -54,9 +54,9 @@ logpdf(d::SkewNormal, x::Real) = log(2) - log(d.ω) + normlogpdf((x-d.ξ) / d.ω
 #cdf requires Owen's T function.
 #cdf/quantile etc 
 
-mgf(d::SkewNormal, t::Real) = 2 * exp(d.ξ * t + (d.ω^2 * t^2)/2 ) * normcdf(d.ω * delta(d) * t)
+mgf(d::SkewNormal, t::Number) = 2 * exp(d.ξ * t + (d.ω^2 * t^2)/2 ) * normcdf(d.ω * delta(d) * t)
 
-cf(d::SkewNormal, t::Real) = exp(im * t * d.ξ - (d.ω^2 * t^2)/2) * (1 + im * erfi((d.ω * delta(d) * t)/(sqrt(2))) )
+cf(d::SkewNormal, t::Number) = exp(im * t * d.ξ - (d.ω^2 * t^2)/2) * (1 + im * erfi((d.ω * delta(d) * t)/(sqrt(2))) )
 
 #### Sampling
 function rand(rng::AbstractRNG, d::SkewNormal)

--- a/src/univariate/continuous/tdist.jl
+++ b/src/univariate/continuous/tdist.jl
@@ -85,7 +85,7 @@ function cf(d::TDist{T}, t::Real) where {T<:Real}
     h = d.ν / 2 
     q = d.ν / 4
     c = complex(2(q * t^2)^q * besselk(h, sqrt(d.ν) * abs(t)) / gamma(h))
-    iszero(t) ? one(c) : c
+    iszero(t) ? complex(one(c)) : c
 end
 
 gradlogpdf(d::TDist{T}, x::Real) where {T<:Real} = isinf(d.ν) ? gradlogpdf(Normal(zero(T), one(T)), x) : -((d.ν + 1) * x) / (x^2 + d.ν)

--- a/src/univariate/continuous/tdist.jl
+++ b/src/univariate/continuous/tdist.jl
@@ -80,12 +80,12 @@ end
 
 rand(rng::AbstractRNG, d::TDist) = randn(rng) / ( isinf(d.ν) ? 1 : sqrt(rand(rng, Chisq(d.ν))/d.ν) )
 
-function cf(d::TDist{T}, t::Real) where T <: Real
+function cf(d::TDist{T}, t::Real) where {T<:Real}
     isinf(d.ν) && return cf(Normal(zero(T), one(T)), t)
-    t == 0 && return complex(1)
-    h = d.ν/2
-    q = d.ν/4
-    complex(2(q*t^2)^q * besselk(h, sqrt(d.ν) * abs(t)) / gamma(h))
+    h = d.ν / 2 
+    q = d.ν / 4
+    c = complex(2(q * t^2)^q * besselk(h, sqrt(d.ν) * abs(t)) / gamma(h))
+    iszero(t) ? one(c) : c
 end
 
 gradlogpdf(d::TDist{T}, x::Real) where {T<:Real} = isinf(d.ν) ? gradlogpdf(Normal(zero(T), one(T)), x) : -((d.ν + 1) * x) / (x^2 + d.ν)

--- a/src/univariate/continuous/triangular.jl
+++ b/src/univariate/continuous/triangular.jl
@@ -118,7 +118,7 @@ function quantile(d::TriangularDist, p::Real)
               b - sqrt(b_m_a * (b - c) * (1 - p))
 end
 
-function mgf(d::TriangularDist{T}, t::Number) where T<:Real
+function mgf(d::TriangularDist, t::Number)
     (a, b, c) = params(d)
     if iszero(t)
         return one(Base.promote_typeof(a, b, c, t))

--- a/src/univariate/continuous/triangular.jl
+++ b/src/univariate/continuous/triangular.jl
@@ -119,22 +119,21 @@ function quantile(d::TriangularDist, p::Real)
 end
 
 function mgf(d::TriangularDist{T}, t::Number) where T<:Real
+    (a, b, c) = params(d)
     if iszero(t)
-        return one(T)
+        return one(Base.promote_typeof(a, b, c, t))
     else
-        (a, b, c) = params(d)
         u = (b - c) * exp(a * t) - (b - a) * exp(c * t) + (c - a) * exp(b * t)
         v = (b - a) * (c - a) * (b - c) * t^2
         return 2u / v
     end
 end
 
-function cf(d::TriangularDist{T}, t::Number) where T<:Real
-    # Is this correct?
+function cf(d::TriangularDist, t::Number)
+    (a, b, c) = params(d)
     if iszero(t)
-        return one(Complex{T})
+        return complex(one(Base.promote_typeof(a, b, c, t)))
     else
-        (a, b, c) = params(d)
         u = (b - c) * cis(a * t) - (b - a) * cis(c * t) + (c - a) * cis(b * t)
         v = (b - a) * (c - a) * (b - c) * t^2
         return -2u / v

--- a/src/univariate/continuous/triangular.jl
+++ b/src/univariate/continuous/triangular.jl
@@ -129,7 +129,7 @@ function cf(d::TriangularDist, t::Number)
     (a, b, c) = params(d)
     u = (b - c) * cis(a * t) - (b - a) * cis(c * t) + (c - a) * cis(b * t)
     v = (b - a) * (c - a) * (b - c) * t^2
-    return iszero(t) ? one(u) : -2u / v
+    return iszero(t) ? complex(one(u)) : -2u / v
 end
 
 

--- a/src/univariate/continuous/triangular.jl
+++ b/src/univariate/continuous/triangular.jl
@@ -120,24 +120,16 @@ end
 
 function mgf(d::TriangularDist, t::Number)
     (a, b, c) = params(d)
-    if iszero(t)
-        return one(Base.promote_typeof(a, b, c, t))
-    else
-        u = (b - c) * exp(a * t) - (b - a) * exp(c * t) + (c - a) * exp(b * t)
-        v = (b - a) * (c - a) * (b - c) * t^2
-        return 2u / v
-    end
+    u = (b - c) * exp(a * t) - (b - a) * exp(c * t) + (c - a) * exp(b * t)
+    v = (b - a) * (c - a) * (b - c) * t^2
+    return iszero(t) ? one(u) : 2u / v
 end
 
 function cf(d::TriangularDist, t::Number)
     (a, b, c) = params(d)
-    if iszero(t)
-        return complex(one(Base.promote_typeof(a, b, c, t)))
-    else
-        u = (b - c) * cis(a * t) - (b - a) * cis(c * t) + (c - a) * cis(b * t)
-        v = (b - a) * (c - a) * (b - c) * t^2
-        return -2u / v
-    end
+    u = (b - c) * cis(a * t) - (b - a) * cis(c * t) + (c - a) * cis(b * t)
+    v = (b - a) * (c - a) * (b - c) * t^2
+    return iszero(t) ? one(u) : -2u / v
 end
 
 

--- a/src/univariate/continuous/triangular.jl
+++ b/src/univariate/continuous/triangular.jl
@@ -118,8 +118,8 @@ function quantile(d::TriangularDist, p::Real)
               b - sqrt(b_m_a * (b - c) * (1 - p))
 end
 
-function mgf(d::TriangularDist{T}, t::Real) where T<:Real
-    if t == zero(t)
+function mgf(d::TriangularDist{T}, t::Number) where T<:Real
+    if iszero(t)
         return one(T)
     else
         (a, b, c) = params(d)
@@ -129,9 +129,9 @@ function mgf(d::TriangularDist{T}, t::Real) where T<:Real
     end
 end
 
-function cf(d::TriangularDist{T}, t::Real) where T<:Real
+function cf(d::TriangularDist{T}, t::Number) where T<:Real
     # Is this correct?
-    if t == zero(t)
+    if iszero(t)
         return one(Complex{T})
     else
         (a, b, c) = params(d)

--- a/src/univariate/continuous/triweight.jl
+++ b/src/univariate/continuous/triweight.jl
@@ -62,20 +62,14 @@ end
 function mgf(d::Triweight, t::Number)
     a = d.σ * t
     a2 = a * a
-    if iszero(t)
-        return one(Base.promote_typeof(a, d.μ))
-    else
-        abs(real(a)) < 1 || throw(DomainError(t, "|σ ⋅ real(t)| should be smaller than 1"))
-        return 105 * exp(d.μ * t) * ((15/a2 + 1) * cosh(a) - (15/a2 - 6) / a * sinh(a)) / (a2 * a2)
-    end
+    abs(real(a)) < 1 || throw(DomainError(t, "|σ ⋅ real(t)| should be smaller than 1"))
+    result = 105 * exp(d.μ * t) * ((15/a2 + 1) * cosh(a) - (15/a2 - 6) / a * sinh(a)) / (a2 * a2)
+    return iszero(t) ? one(result) : result
 end
 
 function cf(d::Triweight, t::Number)
     a = d.σ * t
     a2 = a * a
-    if iszero(t)
-        return complex(one(Base.promote_typeof(a, d.μ)))
-    else
-        return 105 * cis(d.μ * t) * ((1 - 15/a2) * cos(a) + (15/a2 - 6) / a * sin(a)) / (a2 * a2)
-    end
+    result = 105 * cis(d.μ * t) * ((1 - 15/a2) * cos(a) + (15/a2 - 6) / a * sin(a)) / (a2 * a2)
+    return iszero(t) ? one(result) : result
 end

--- a/src/univariate/continuous/triweight.jl
+++ b/src/univariate/continuous/triweight.jl
@@ -65,7 +65,7 @@ function mgf(d::Triweight, t::Number)
     if iszero(t)
         return one(Base.promote_typeof(a, d.μ))
     else
-        abs(real(a)) < 1 || throw(DomainError("|σ real(t)| should be smaller than 1"))
+        abs(real(a)) < 1 || throw(DomainError(t, "|σ ⋅ real(t)| should be smaller than 1"))
         return 105 * exp(d.μ * t) * ((15/a2 + 1) * cosh(a) - (15/a2 - 6) / a * sinh(a)) / (a2 * a2)
     end
 end

--- a/src/univariate/continuous/triweight.jl
+++ b/src/univariate/continuous/triweight.jl
@@ -59,14 +59,22 @@ end
 
 @quantile_newton Triweight
 
-function mgf(d::Triweight{T}, t::Number) where T<:Real
-    a = d.σ*t
-    a2 = a*a
-    iszero(t) ? one(T) : 105*exp(d.μ*t)*((15/a2+1)*cosh(a)-(15/a2-6)/a*sinh(a))/(a2*a2)
+function mgf(d::Triweight, t::Number)
+    a = d.σ * t
+    a2 = a * a
+    if iszero(t)
+        return one(Base.promote_typeof(a, d.μ))
+    else
+        return 105 * exp(d.μ * t) * ((15/a2 + 1) * cosh(a) - (15/a2 - 6) / a * sinh(a)) / (a2 * a2)
+    end
 end
 
-function cf(d::Triweight{T}, t::Number) where T<:Real
-    a = d.σ*t
-    a2 = a*a
-    iszero(t) ? complex(one(a)) : 105*cis(d.μ*t)*((1-15/a2)*cos(a)+(15/a2-6)/a*sin(a))/(a2*a2)
+function cf(d::Triweight, t::Number)
+    a = d.σ * t
+    a2 = a * a
+    if iszero(t)
+        return complex(one(Base.promote_typeof(a, d.μ)))
+    else
+        return 105 * cis(d.μ * t) * ((1 - 15/a2) * cos(a) + (15/a2 - 6) / a * sin(a)) / (a2 * a2)
+    end
 end

--- a/src/univariate/continuous/triweight.jl
+++ b/src/univariate/continuous/triweight.jl
@@ -71,5 +71,5 @@ function cf(d::Triweight, t::Number)
     a = d.σ * t
     a2 = a * a
     result = 105 * cis(d.μ * t) * ((1 - 15/a2) * cos(a) + (15/a2 - 6) / a * sin(a)) / (a2 * a2)
-    return iszero(t) ? one(result) : result
+    return iszero(t) ? complex(one(result)) : result
 end

--- a/src/univariate/continuous/triweight.jl
+++ b/src/univariate/continuous/triweight.jl
@@ -65,6 +65,7 @@ function mgf(d::Triweight, t::Number)
     if iszero(t)
         return one(Base.promote_typeof(a, d.μ))
     else
+        abs(real(a)) < 1 || throw(DomainError("|σ real(t)| should be smaller than 1"))
         return 105 * exp(d.μ * t) * ((15/a2 + 1) * cosh(a) - (15/a2 - 6) / a * sinh(a)) / (a2 * a2)
     end
 end

--- a/src/univariate/continuous/triweight.jl
+++ b/src/univariate/continuous/triweight.jl
@@ -59,14 +59,14 @@ end
 
 @quantile_newton Triweight
 
-function mgf(d::Triweight{T}, t::Float64) where T<:Real
+function mgf(d::Triweight{T}, t::Number) where T<:Real
     a = d.σ*t
     a2 = a*a
-    a == 0 ? one(T) : 105*exp(d.μ*t)*((15/a2+1)*cosh(a)-(15/a2-6)/a*sinh(a))/(a2*a2)
+    iszero(t) ? one(T) : 105*exp(d.μ*t)*((15/a2+1)*cosh(a)-(15/a2-6)/a*sinh(a))/(a2*a2)
 end
 
-function cf(d::Triweight{T}, t::Float64) where T<:Real
+function cf(d::Triweight{T}, t::Number) where T<:Real
     a = d.σ*t
     a2 = a*a
-    a == 0 ? complex(one(T)) : 105*cis(d.μ*t)*((1-15/a2)*cos(a)+(15/a2-6)/a*sin(a))/(a2*a2)
+    iszero(t) ? complex(one(a)) : 105*cis(d.μ*t)*((1-15/a2)*cos(a)+(15/a2-6)/a*sin(a))/(a2*a2)
 end

--- a/src/univariate/continuous/uniform.jl
+++ b/src/univariate/continuous/uniform.jl
@@ -93,20 +93,20 @@ quantile(d::Uniform, p::Real) = d.a + p * (d.b - d.a)
 cquantile(d::Uniform, p::Real) = d.b + p * (d.a - d.b)
 
 
-function mgf(d::Uniform, t::Real)
+function mgf(d::Uniform, t::Number)
     (a, b) = params(d)
     u = (b - a) * t / 2
-    u == zero(u) && return one(u)
+    iszero(u) && return one(u)
     v = (a + b) * t / 2
-    exp(v) * (sinh(u) / u)
+    return exp(v) * (sinh(u) / u)
 end
 
-function cf(d::Uniform, t::Real)
+function cf(d::Uniform, t::Number)
     (a, b) = params(d)
     u = (b - a) * t / 2
-    u == zero(u) && return complex(one(u))
+    iszero(u) && return complex(one(u))
     v = (a + b) * t / 2
-    cis(v) * (sin(u) / u)
+    return cis(v) * (sin(u) / u)
 end
 
 #### Affine transformations

--- a/src/univariate/continuous/uniform.jl
+++ b/src/univariate/continuous/uniform.jl
@@ -97,6 +97,7 @@ function mgf(d::Uniform, t::Number)
     (a, b) = params(d)
     u = (b - a) * t / 2
     iszero(u) && return one(float(typeof(u)))
+    abs(real(u)) < 1 || throw(DomainError("|(b-a) real(t) / 2| should be smaller than 1"))
     v = (a + b) * t / 2
     return exp(v) * (sinh(u) / u)
 end

--- a/src/univariate/continuous/uniform.jl
+++ b/src/univariate/continuous/uniform.jl
@@ -97,7 +97,7 @@ function mgf(d::Uniform, t::Number)
     (a, b) = params(d)
     u = (b - a) * t / 2
     iszero(u) && return one(float(typeof(u)))
-    abs(real(u)) < 1 || throw(DomainError("|(b-a) real(t) / 2| should be smaller than 1"))
+    abs(real(u)) < 1 || throw(DomainError(t, "|(b - a) ⋅ real(t) / 2| should be smaller than 1"))
     v = (a + b) * t / 2
     return exp(v) * (sinh(u) / u)
 end

--- a/src/univariate/continuous/uniform.jl
+++ b/src/univariate/continuous/uniform.jl
@@ -96,7 +96,7 @@ cquantile(d::Uniform, p::Real) = d.b + p * (d.a - d.b)
 function mgf(d::Uniform, t::Number)
     (a, b) = params(d)
     u = (b - a) * t / 2
-    iszero(u) && return one(u)
+    iszero(u) && return one(float(typeof(u)))
     v = (a + b) * t / 2
     return exp(v) * (sinh(u) / u)
 end
@@ -104,7 +104,7 @@ end
 function cf(d::Uniform, t::Number)
     (a, b) = params(d)
     u = (b - a) * t / 2
-    iszero(u) && return complex(one(u))
+    iszero(u) && return complex(one(float(typeof(u))))
     v = (a + b) * t / 2
     return cis(v) * (sin(u) / u)
 end

--- a/src/univariate/discrete/bernoulli.jl
+++ b/src/univariate/discrete/bernoulli.jl
@@ -102,8 +102,8 @@ function cquantile(d::Bernoulli{T}, p::Real) where T<:Real
     0 <= p <= 1 ? (p >= succprob(d) ? zero(T) : one(T)) : T(NaN)
 end
 
-mgf(d::Bernoulli, t::Real) = failprob(d) + succprob(d) * exp(t)
-cf(d::Bernoulli, t::Real) = failprob(d) + succprob(d) * cis(t)
+mgf(d::Bernoulli, t::Number) = failprob(d) + succprob(d) * exp(t)
+cf(d::Bernoulli, t::Number) = failprob(d) + succprob(d) * cis(t)
 
 
 #### Sampling

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -125,12 +125,12 @@ function rand(rng::AbstractRNG, d::Binomial)
     p <= 0.5 ? y : n-y
 end
 
-function mgf(d::Binomial, t::Real)
+function mgf(d::Binomial, t::Number)
     n, p = params(d)
     (one(p) - p + p * exp(t)) ^ n
 end
 
-function cf(d::Binomial, t::Real)
+function cf(d::Binomial, t::Number)
     n, p = params(d)
     (one(p) - p + p * cis(t)) ^ n
 end

--- a/src/univariate/discrete/dirac.jl
+++ b/src/univariate/discrete/dirac.jl
@@ -49,8 +49,8 @@ logccdf(d::Dirac, x::Real) = x < d.value ? 0.0 : isnan(x) ? NaN : -Inf
 
 quantile(d::Dirac{T}, p::Real) where {T} = 0 <= p <= 1 ? d.value : T(NaN)
 
-mgf(d::Dirac, t) = exp(t * d.value)
-cf(d::Dirac, t) = cis(t * d.value)
+mgf(d::Dirac, t::Number) = exp(t * d.value)
+cf(d::Dirac, t::Number) = cis(t * d.value)
 
 #### Sampling
 

--- a/src/univariate/discrete/discretenonparametric.jl
+++ b/src/univariate/discrete/discretenonparametric.jl
@@ -213,18 +213,18 @@ function modes(d::DiscreteNonParametric)
     return modes(x, Weights(p, one(eltype(p))))
 end
 
-function mgf(d::DiscreteNonParametric, t::Real)
+function mgf(d::DiscreteNonParametric{T}, t::Number)
     x, p = params(d)
-    s = zero(Float64)
+    s = zero(t)
     for i in 1:length(x)
         s += p[i] * exp(t*x[i])
     end
     s
 end
 
-function cf(d::DiscreteNonParametric, t::Real)
+function cf(d::DiscreteNonParametric, t::Number)
     x, p = params(d)
-    s = zero(Complex{Float64})
+    s = complex(zero(t))
     for i in 1:length(x)
        s += p[i] * cis(t*x[i])
     end

--- a/src/univariate/discrete/discretenonparametric.jl
+++ b/src/univariate/discrete/discretenonparametric.jl
@@ -213,22 +213,20 @@ function modes(d::DiscreteNonParametric)
     return modes(x, Weights(p, one(eltype(p))))
 end
 
-function mgf(d::DiscreteNonParametric{T}, t::Number)
-    x, p = params(d)
-    s = zero(t)
-    for i in 1:length(x)
-        s += p[i] * exp(t*x[i])
-    end
-    s
+function mgf(d::DiscreteNonParametric, t::Number)
+    xs, ps = params(d)
+    s = sum(Broadcast.instantiate(Broadcast.broadcasted(ps, xs) do p, x
+        return p * exp(t * x)
+    end))
+    return s
 end
 
 function cf(d::DiscreteNonParametric, t::Number)
-    x, p = params(d)
-    s = complex(zero(t))
-    for i in 1:length(x)
-       s += p[i] * cis(t*x[i])
-    end
-    s
+    xs, ps = params(d)
+    s = sum(Broadcast.instantiate(Broadcast.broadcasted(ps, xs) do p, x
+        return p * cis(t * x)
+    end))
+    return s
 end
 
 # Sufficient statistics

--- a/src/univariate/discrete/discreteuniform.jl
+++ b/src/univariate/discrete/discreteuniform.jl
@@ -87,14 +87,14 @@ end
 
 quantile(d::DiscreteUniform, p::Real) = iszero(p) ? d.a : d.a - 1 + ceil(Int, p * span(d))
 
-function mgf(d::DiscreteUniform, t::Real)
+function mgf(d::DiscreteUniform, t::Number)
     a, b = d.a, d.b
     u = b - a + 1
     result = (exp(t*a) * expm1(t*u)) / (u*expm1(t))
     return iszero(t) ? one(result) : result
 end
 
-function cf(d::DiscreteUniform, t::Real)
+function cf(d::DiscreteUniform, t::Number)
     a, b = d.a, d.b
     u = b - a + 1
     result = (im*cos(t*(a+b)/2) + sin(t*(a-b-1)/2)) / (u*sin(t/2))

--- a/src/univariate/discrete/discreteuniform.jl
+++ b/src/univariate/discrete/discreteuniform.jl
@@ -98,7 +98,7 @@ function cf(d::DiscreteUniform, t::Number)
     a, b = d.a, d.b
     u = b - a + 1
     result = (im*cos(t*(a+b)/2) + sin(t*(a-b-1)/2)) / (u*sin(t/2))
-    return iszero(t) ? one(result) : result
+    return iszero(t) ? complex(one(result)) : result
 end
 
 

--- a/src/univariate/discrete/geometric.jl
+++ b/src/univariate/discrete/geometric.jl
@@ -109,12 +109,12 @@ function invlogccdf(d::Geometric{T}, lp::Real) where T<:Real
     max(ceil(lp/log1p(-d.p)) - 1, zero(T))
 end
 
-function mgf(d::Geometric, t::Real)
+function mgf(d::Geometric, t::Number)
     p = succprob(d)
     p / (expm1(-t) + p)
 end
 
-function cf(d::Geometric, t::Real)
+function cf(d::Geometric, t::Number)
     p = succprob(d)
     # replace with expm1 when complex version available
     p / (exp(-t*im) - 1 + p)

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -117,6 +117,5 @@ end
 
 function cf(d::NegativeBinomial, t::Number)
     r, p = params(d)
-    real(t) < -log1p(-p) || return Base.promote_typeof(p, t)(NaN)
     return (p / (1 - (1 - p) * exp(t)))^r
 end

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -109,12 +109,12 @@ invlogccdf(d::NegativeBinomial, lq::Real) = convert(Int, nbinominvlogccdf(d.r, d
 ## sampling
 rand(rng::AbstractRNG, d::NegativeBinomial) = rand(rng, Poisson(rand(rng, Gamma(d.r, (1 - d.p)/d.p))))
 
-function mgf(d::NegativeBinomial, t::Real)
+function mgf(d::NegativeBinomial, t::Number)
     r, p = params(d)
     return ((1 - p) * exp(t))^r / (1 - p * exp(t))^r
 end
 
-function cf(d::NegativeBinomial, t::Real)
+function cf(d::NegativeBinomial, t::LineNumberNode)
     r, p = params(d)
     return (((1 - p) * cis(t)) / (1 - p * cis(t)))^r
 end

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -117,5 +117,5 @@ end
 
 function cf(d::NegativeBinomial, t::Number)
     r, p = params(d)
-    return (p / (1 - (1 - p) * exp(t)))^r
+    return complex(p / (1 - (1 - p) * exp(t)))^r
 end

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -111,7 +111,7 @@ rand(rng::AbstractRNG, d::NegativeBinomial) = rand(rng, Poisson(rand(rng, Gamma(
 
 function mgf(d::NegativeBinomial, t::Number)
     r, p = params(d)
-    real(t) < -log1p(-p) || throw(DomainError("the real part of t should be smaller than -log(1-p)"))
+    real(t) < -log1p(-p) || throw(DomainError(t, "the real part of t should be smaller than -log(1-p)"))
     return (p / (1 - (1 - p) * exp(t)))^r
 end
 

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -111,7 +111,7 @@ rand(rng::AbstractRNG, d::NegativeBinomial) = rand(rng, Poisson(rand(rng, Gamma(
 
 function mgf(d::NegativeBinomial, t::Number)
     r, p = params(d)
-    real(t) < -log1p(-p) || return Base.promote_typeof(p, t)(NaN)
+    real(t) < -log1p(-p) || throw(DomainError("the real part of t should be smaller than -log(1-p)"))
     return (p / (1 - (1 - p) * exp(t)))^r
 end
 

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -111,10 +111,12 @@ rand(rng::AbstractRNG, d::NegativeBinomial) = rand(rng, Poisson(rand(rng, Gamma(
 
 function mgf(d::NegativeBinomial, t::Number)
     r, p = params(d)
-    return ((1 - p) * exp(t))^r / (1 - p * exp(t))^r
+    real(t) < -log1p(-p) || return Base.promote_typeof(p, t)(NaN)
+    return (p / (1 - (1 - p) * exp(t)))^r
 end
 
 function cf(d::NegativeBinomial, t::Number)
     r, p = params(d)
-    return (((1 - p) * cis(t)) / (1 - p * cis(t)))^r
+    real(t) < -log1p(-p) || return Base.promote_typeof(p, t)(NaN)
+    return (p / (1 - (1 - p) * exp(t)))^r
 end

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -114,7 +114,7 @@ function mgf(d::NegativeBinomial, t::Number)
     return ((1 - p) * exp(t))^r / (1 - p * exp(t))^r
 end
 
-function cf(d::NegativeBinomial, t::LineNumberNode)
+function cf(d::NegativeBinomial, t::Number)
     r, p = params(d)
     return (((1 - p) * cis(t)) / (1 - p * cis(t)))^r
 end

--- a/src/univariate/discrete/poisson.jl
+++ b/src/univariate/discrete/poisson.jl
@@ -96,12 +96,12 @@ end
 
 @_delegate_statsfuns Poisson pois λ
 
-function mgf(d::Poisson, t::Real)
+function mgf(d::Poisson, t::Number)
     λ = rate(d)
     return exp(λ * (exp(t) - 1))
 end
 
-function cf(d::Poisson, t::Real)
+function cf(d::Poisson, t::Number)
     λ = rate(d)
     return exp(λ * (cis(t) - 1))
 end

--- a/src/univariate/discrete/poissonbinomial.jl
+++ b/src/univariate/discrete/poissonbinomial.jl
@@ -116,14 +116,14 @@ modes(d::PoissonBinomial) = modes(DiscreteNonParametric(support(d), d.pmf))
 
 quantile(d::PoissonBinomial, x::Float64) = quantile(Categorical(d.pmf), x) - 1
 
-function mgf(d::PoissonBinomial, t::Real)
+function mgf(d::PoissonBinomial, t::Number)
     expm1_t = expm1(t)
     mapreduce(*, succprob(d)) do p
         1 + p * expm1_t
     end
 end
 
-function cf(d::PoissonBinomial, t::Real)
+function cf(d::PoissonBinomial, t::Number)
     cis_t = cis(t)
     mapreduce(*, succprob(d)) do p
         1 - p + p * cis_t

--- a/src/univariate/discrete/skellam.jl
+++ b/src/univariate/discrete/skellam.jl
@@ -80,12 +80,12 @@ function logpdf(d::Skellam, x::Real)
     end
 end
 
-function mgf(d::Skellam, t::Real)
+function mgf(d::Skellam, t::Number)
     μ1, μ2 = params(d)
     exp(μ1 * (exp(t) - 1) + μ2 * (exp(-t) - 1))
 end
 
-function cf(d::Skellam, t::Real)
+function cf(d::Skellam, t::Number)
     μ1, μ2 = params(d)
     exp(μ1 * (cis(t) - 1) + μ2 * (cis(-t) - 1))
 end

--- a/src/univariate/locationscale.jl
+++ b/src/univariate/locationscale.jl
@@ -109,7 +109,7 @@ ismesokurtic(d::AffineDistribution) = ismesokurtic(d.ρ)
 entropy(d::ContinuousAffineDistribution) = entropy(d.ρ) + log(d.σ)
 entropy(d::DiscreteAffineDistribution) = entropy(d.ρ)
 
-mgf(d::AffineDistribution,t::Real) = exp(d.μ*t) * mgf(d.ρ,d.σ*t)
+mgf(d::AffineDistribution, t::Number) = exp(d.μ * t) * mgf(d.ρ, d.σ * t)
 
 #### Evaluation & Sampling
 

--- a/test/truncate.jl
+++ b/test/truncate.jl
@@ -96,10 +96,10 @@ function verify_and_test(d::UnivariateDistribution, dct::Dict, n_tsamples::Int)
     @test isapprox(quantile(d, Float64(0.7)), quantile(d, Float32(0.7)))
 
     try
-        m = mgf(d,0.0)
-        @test m == 1.0
-        m = mgf(d,Dual(0.0))
-        @test m == 1.0
+        m = mgf(d, 0.0)
+        @test isone(m)
+        m = mgf(d, Dual(0.0))
+        @test isone(m)
     catch e
         isa(e, MethodError) || throw(e)
     end

--- a/test/univariates.jl
+++ b/test/univariates.jl
@@ -119,17 +119,19 @@ function verify_and_test(D::Union{Type,Function}, d::UnivariateDistribution, dct
     end
 
     try
-        m = mgf(d,0.0)
-        @test m == 1.0
-    catch e
+        m = mgf(d, 0.0)
+        @test isone(m)
+        m = mgf(d, complex(0))
+        @test isone(m)
+    catch e # only rethrow if it's not a MethodError i.e. it's defined
         isa(e, MethodError) || throw(e)
     end
     try
-        c = cf(d,0.0)
-        @test c == 1.0
+        c = cf(d, 0.0)
+        @test isone(c)
         # test some extra values: should all be well-defined
-        for t in (0.1,-0.1,1.0,-1.0)
-            @test !isnan(cf(d,t))
+        for t in (0.1, -0.1, 1.0, -1.0)
+            @test !isnan(cf(d, t))
         end
     catch e
         isa(e, MethodError) || throw(e)

--- a/test/univariates.jl
+++ b/test/univariates.jl
@@ -119,16 +119,22 @@ function verify_and_test(D::Union{Type,Function}, d::UnivariateDistribution, dct
     end
 
     try
-        m = mgf(d, 0.0)
-        @test isone(m)
-        m = mgf(d, complex(0))
-        @test isone(m)
+        for T in (Float64, Float32, Rational, Int, Complex{Float64}, Complex{Float32})
+            m = mgf(d, zero(T))
+            @test isone(m)
+            @inferred mgf(d, zero(T))
+            @inferred mgf(d, one(T))
+        end
     catch e # only rethrow if it's not a MethodError i.e. it's defined
         isa(e, MethodError) || throw(e)
     end
     try
-        c = cf(d, 0.0)
-        @test isone(c)
+        for T in (Float64, Float32, Rational, Int, Complex{Float64}, Complex{Float32})
+            m = cf(d, zero(T))
+            @test isone(m)
+            @inferred cf(d, zero(T))
+            @inferred cf(d, one(T))
+        end
         # test some extra values: should all be well-defined
         for t in (0.1, -0.1, 1.0, -1.0)
             @test !isnan(cf(d, t))

--- a/test/univariates.jl
+++ b/test/univariates.jl
@@ -126,7 +126,7 @@ function verify_and_test(D::Union{Type,Function}, d::UnivariateDistribution, dct
             @inferred mgf(d, one(T))
         end
     catch e # only rethrow if it's not a MethodError i.e. it's defined
-        isa(e, MethodError) || throw(e)
+        isa(e, Union{MethodError,DomainError}) || throw(e)
     end
     try
         for T in (Float64, Float32, Rational, Int, Complex{Float64}, Complex{Float32})


### PR DESCRIPTION
As pointed out in #1502 , `mgf` and `cf` should be allowed to take `Complex` numbers and the second argument should be therefore relaxed.
All functions are also made type-stable.
**Breaking?**, when the argument for the `mgf` is given outside of the domain definition a `DomainError` is thrown.