### PR TITLE
Fix and optimize `convert`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.49"
+version = "0.25.50"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.50"
+version = "0.25.51"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/cholesky/lkjcholesky.jl
+++ b/src/cholesky/lkjcholesky.jl
@@ -72,6 +72,8 @@ Base.show(io::IO, d::LKJCholesky) = show(io, d, (:d, :η, :uplo))
 function Base.convert(::Type{LKJCholesky{T}}, d::LKJCholesky) where T <: Real
     return LKJCholesky{T}(d.d, T(d.η), d.uplo, T(d.logc0))
 end
+Base.convert(::Type{LKJCholesky{T}}, d::LKJCholesky{T}) where T <: Real = d
+
 function convert(::Type{LKJCholesky{T}}, d::Integer, η::Real, uplo::Char, logc0::Real) where T <: Real
     return LKJCholesky{T}(Int(d), T(η), uplo, T(logc0))
 end

--- a/src/matrix/inversewishart.jl
+++ b/src/matrix/inversewishart.jl
@@ -60,6 +60,8 @@ function convert(::Type{InverseWishart{T}}, d::InverseWishart) where T<:Real
     P = convert(AbstractArray{T}, d.Ψ)
     InverseWishart{T, typeof(P)}(T(d.df), P, T(d.logc0))
 end
+Base.convert(::Type{InverseWishart{T}}, d::InverseWishart{T}) where {T<:Real} = d
+
 function convert(::Type{InverseWishart{T}}, df, Ψ::AbstractPDMat, logc0) where T<:Real
     P = convert(AbstractArray{T}, Ψ)
     InverseWishart{T, typeof(P)}(T(df), P, T(logc0))

--- a/src/matrix/lkj.jl
+++ b/src/matrix/lkj.jl
@@ -56,6 +56,7 @@ show(io::IO, d::LKJ) = show_multline(io, d, [(:d, d.d), (:η, d.η)])
 function convert(::Type{LKJ{T}}, d::LKJ) where T <: Real
     LKJ{T, typeof(d.d)}(d.d, T(d.η), T(d.logc0))
 end
+Base.convert(::Type{LKJ{T}}, d::LKJ{T}) where {T<:Real} = d
 
 function convert(::Type{LKJ{T}}, d::Integer, η, logc0) where T <: Real
     LKJ{T, typeof(d)}(d, T(η), T(logc0))

--- a/src/matrix/matrixbeta.jl
+++ b/src/matrix/matrixbeta.jl
@@ -60,6 +60,7 @@ function convert(::Type{MatrixBeta{T}}, d::MatrixBeta) where T <: Real
     W2 = convert(Wishart{T}, d.W2)
     MatrixBeta{T, typeof(W1)}(W1, W2, T(d.logc0))
 end
+Base.convert(::Type{MatrixBeta{T}}, d::MatrixBeta{T}) where {T<:Real} = d
 
 function convert(::Type{MatrixBeta{T}}, W1::Wishart, W2::Wishart, logc0) where T <: Real
     WW1 = convert(Wishart{T}, W1)

--- a/src/matrix/matrixfdist.jl
+++ b/src/matrix/matrixfdist.jl
@@ -67,6 +67,7 @@ function convert(::Type{MatrixFDist{T}}, d::MatrixFDist) where T <: Real
     W = convert(Wishart{T}, d.W)
     MatrixFDist{T, typeof(W)}(W, T(d.n2), T(d.logc0))
 end
+Base.convert(::Type{MatrixFDist{T}}, d::MatrixFDist{T}) where {T<:Real} = d
 
 function convert(::Type{MatrixFDist{T}}, W::Wishart, n2, logc0) where T <: Real
     WW = convert(Wishart{T}, W)

--- a/src/matrix/matrixnormal.jl
+++ b/src/matrix/matrixnormal.jl
@@ -67,6 +67,7 @@ function convert(::Type{MatrixNormal{T}}, d::MatrixNormal) where T <: Real
     VV = convert(AbstractArray{T}, d.V)
     MatrixNormal{T, typeof(MM), typeof(UU), typeof(VV)}(MM, UU, VV, T(d.logc0))
 end
+Base.convert(::Type{MatrixNormal{T}}, d::MatrixNormal{T}) where {T<:Real} = d
 
 function convert(::Type{MatrixNormal{T}}, M::AbstractMatrix, U::AbstractPDMat, V::AbstractPDMat, logc0) where T <: Real
     MM = convert(AbstractArray{T}, M)

--- a/src/matrix/matrixtdist.jl
+++ b/src/matrix/matrixtdist.jl
@@ -85,6 +85,7 @@ function convert(::Type{MatrixTDist{T}}, d::MatrixTDist) where T <: Real
     ΩΩ = convert(AbstractArray{T}, d.Ω)
     MatrixTDist{T, typeof(MM), typeof(ΣΣ), typeof(ΩΩ)}(T(d.ν), MM, ΣΣ, ΩΩ, T(d.logc0))
 end
+Base.convert(::Type{MatrixTDist{T}}, d::MatrixTDist{T}) where {T<:Real} = d
 
 function convert(::Type{MatrixTDist{T}}, ν, M::AbstractMatrix, Σ::AbstractPDMat, Ω::AbstractPDMat, logc0) where T <: Real
     MM = convert(AbstractArray{T}, M)

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -79,6 +79,8 @@ function convert(::Type{Wishart{T}}, d::Wishart) where T<:Real
     P = convert(AbstractArray{T}, d.S)
     Wishart{T, typeof(P), typeof(d.rank)}(T(d.df), P, T(d.logc0), d.rank, d.singular)
 end
+Base.convert(::Type{Wishart{T}}, d::Wishart{T}) where {T<:Real} = d
+
 function convert(::Type{Wishart{T}}, df, S::AbstractPDMat, logc0, rnk, singular) where T<:Real
     P = convert(AbstractArray{T}, S)
     Wishart{T, typeof(P), typeof(rnk)}(T(df), P, T(logc0), rnk, singular)

--- a/src/multivariate/mvlognormal.jl
+++ b/src/multivariate/mvlognormal.jl
@@ -182,6 +182,8 @@ Base.eltype(::Type{<:MvLogNormal{T}}) where {T} = T
 function convert(::Type{MvLogNormal{T}}, d::MvLogNormal) where T<:Real
     MvLogNormal(convert(MvNormal{T}, d.normal))
 end
+Base.convert(::Type{MvLogNormal{T}}, d::MvLogNormal{T}) where {T<:Real} = d
+
 function convert(::Type{MvLogNormal{T}}, pars...) where T<:Real
     MvLogNormal(convert(MvNormal{T}, MvNormal(pars...)))
 end

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -228,6 +228,8 @@ Base.eltype(::Type{<:MvNormal{T}}) where {T} = T
 function convert(::Type{MvNormal{T}}, d::MvNormal) where T<:Real
     MvNormal(convert(AbstractArray{T}, d.μ), convert(AbstractArray{T}, d.Σ))
 end
+Base.convert(::Type{MvNormal{T}}, d::MvNormal{T}) where {T<:Real} = d
+
 function convert(::Type{MvNormal{T}}, μ::AbstractVector, Σ::AbstractPDMat) where T<:Real
     MvNormal(convert(AbstractArray{T}, μ), convert(AbstractArray{T}, Σ))
 end

--- a/src/multivariate/mvnormalcanon.jl
+++ b/src/multivariate/mvnormalcanon.jl
@@ -129,6 +129,8 @@ distrname(d::ZeroMeanFullNormalCanon) = "ZeroMeanFullNormalCanon"
 function convert(::Type{MvNormalCanon{T}}, d::MvNormalCanon) where {T<:Real}
     MvNormalCanon(convert(AbstractArray{T}, d.μ), convert(AbstractArray{T}, d.h), convert(AbstractArray{T}, d.J))
 end
+Base.convert(::Type{MvNormalCanon{T}}, d::MvNormalCanon{T}) where {T<:Real} = d
+
 function convert(::Type{MvNormalCanon{T}}, μ::AbstractVector{<:Real}, h::AbstractVector{<:Real}, J::AbstractPDMat) where {T<:Real}
     MvNormalCanon(convert(AbstractArray{T}, μ), convert(AbstractArray{T}, h), convert(AbstractArray{T}, J))
 end

--- a/src/multivariate/mvtdist.jl
+++ b/src/multivariate/mvtdist.jl
@@ -39,6 +39,8 @@ function convert(::Type{GenericMvTDist{T}}, d::GenericMvTDist) where T<:Real
     m = convert(AbstractArray{T}, d.μ)
     GenericMvTDist{T, typeof(S), typeof(m)}(T(d.df), d.dim, m, S)
 end
+Base.convert(::Type{GenericMvTDist{T}}, d::GenericMvTDist{T}) where {T<:Real} = d
+
 function convert(::Type{GenericMvTDist{T}}, df, dim, μ::AbstractVector, Σ::AbstractPDMat) where T<:Real
     S = convert(AbstractArray{T}, Σ)
     m = convert(AbstractArray{T}, μ)

--- a/src/multivariate/vonmisesfisher.jl
+++ b/src/multivariate/vonmisesfisher.jl
@@ -42,7 +42,8 @@ end
 show(io::IO, d::VonMisesFisher) = show(io, d, (:μ, :κ))
 
 ### Conversions
-convert(::Type{VonMisesFisher{T}}, d::VonMisesFisher) where {T<:Real} = VonMisesFisher{T}(convert(Vector{T}, d.μ), T(d.κ))
+convert(::Type{VonMisesFisher{T}}, d::VonMisesFisher) where {T<:Real} = VonMisesFisher{T}(convert(Vector{T}, d.μ), T(d.κ); checknorm=false)
+Base.convert(::Type{VonMisesFisher{T}}, d::VonMisesFisher{T}) where {T<:Real} = d
 convert(::Type{VonMisesFisher{T}}, μ::Vector, κ, logCκ) where {T<:Real} =  VonMisesFisher{T}(convert(Vector{T}, μ), T(κ))
 
 

--- a/src/univariate/continuous/arcsine.jl
+++ b/src/univariate/continuous/arcsine.jl
@@ -47,9 +47,8 @@ Arcsine() = Arcsine{Float64}(0.0, 1.0)
 function convert(::Type{Arcsine{T}}, a::Real, b::Real) where T<:Real
     Arcsine(T(a), T(b))
 end
-function convert(::Type{Arcsine{T}}, d::Arcsine{S}) where {T <: Real, S <: Real}
-    Arcsine(T(d.a), T(d.b))
-end
+Base.convert(::Type{Arcsine{T}}, d::Arcsine) where {T<:Real} = Arcsine{T}(T(d.a), T(d.b))
+Base.convert(::Type{Arcsine{T}}, d::Arcsine{T}) where {T<:Real} = d
 
 ### Parameters
 

--- a/src/univariate/continuous/beta.jl
+++ b/src/univariate/continuous/beta.jl
@@ -51,9 +51,8 @@ Beta() = Beta{Float64}(1.0, 1.0)
 function convert(::Type{Beta{T}}, α::Real, β::Real) where T<:Real
     Beta(T(α), T(β))
 end
-function convert(::Type{Beta{T}}, d::Beta{S}) where {T <: Real, S <: Real}
-    Beta(T(d.α), T(d.β), check_args=false)
-end
+Base.convert(::Type{Beta{T}}, d::Beta) where {T<:Real} = Beta{T}(T(d.α), T(d.β))
+Base.convert(::Type{Beta{T}}, d::Beta{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/betaprime.jl
+++ b/src/univariate/continuous/betaprime.jl
@@ -51,9 +51,8 @@ BetaPrime() = BetaPrime{Float64}(1.0, 1.0)
 function convert(::Type{BetaPrime{T}}, α::Real, β::Real) where T<:Real
     BetaPrime(T(α), T(β))
 end
-function convert(::Type{BetaPrime{T}}, d::BetaPrime{S}) where {T <: Real, S <: Real}
-    BetaPrime(T(d.α), T(d.β), check_args=false)
-end
+Base.convert(::Type{BetaPrime{T}}, d::BetaPrime) where {T<:Real} = BetaPrime{T}(T(d.α), T(d.β))
+Base.convert(::Type{BetaPrime{T}}, d::BetaPrime{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/cauchy.jl
+++ b/src/univariate/continuous/cauchy.jl
@@ -43,9 +43,8 @@ Cauchy(μ::Real=0.0) = Cauchy(μ, one(μ); check_args=false)
 function convert(::Type{Cauchy{T}}, μ::Real, σ::Real) where T<:Real
     Cauchy(T(μ), T(σ))
 end
-function convert(::Type{Cauchy{T}}, d::Cauchy{S}) where {T <: Real, S <: Real}
-    Cauchy(T(d.μ), T(d.σ), check_args=false)
-end
+Base.convert(::Type{Cauchy{T}}, d::Cauchy) where {T<:Real} = Cauchy{T}(T(d.μ), T(d.σ))
+Base.convert(::Type{Cauchy{T}}, d::Cauchy{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/chi.jl
+++ b/src/univariate/continuous/chi.jl
@@ -37,7 +37,8 @@ Chi(ν::Integer; check_args::Bool=true) = Chi(float(ν); check_args=check_args)
 
 ### Conversions
 convert(::Type{Chi{T}}, ν::Real) where {T<:Real} = Chi(T(ν))
-convert(::Type{Chi{T}}, d::Chi{S}) where {T <: Real, S <: Real} = Chi(T(d.ν), check_args=false)
+Base.convert(::Type{Chi{T}}, d::Chi) where {T<:Real} = Chi{T}(T(d.ν))
+Base.convert(::Type{Chi{T}}, d::Chi{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/chisq.jl
+++ b/src/univariate/continuous/chisq.jl
@@ -42,8 +42,8 @@ params(d::Chisq) = (d.ν,)
 
 ### Conversions
 convert(::Type{Chisq{T}}, ν::Real) where {T<:Real} = Chisq(T(ν))
-convert(::Type{Chisq{T}}, d::Chisq{S}) where {T <: Real, S <: Real} = Chisq(T(d.ν))
-
+Base.convert(::Type{Chisq{T}}, d::Chisq) where {T<:Real} = Chisq{T}(T(d.ν))
+Base.convert(::Type{Chisq{T}}, d::Chisq{T}) where {T<:Real} = d
 
 #### Statistics
 

--- a/src/univariate/continuous/cosine.jl
+++ b/src/univariate/continuous/cosine.jl
@@ -28,9 +28,10 @@ Cosine(μ::Real=0.0) = Cosine(μ, one(µ); check_args=false)
 function convert(::Type{Cosine{T}}, μ::Real, σ::Real) where T<:Real
     Cosine(T(μ), T(σ))
 end
-function convert(::Type{Cosine{T}}, d::Cosine{S}) where {T <: Real, S <: Real}
-    Cosine(T(d.μ), T(d.σ), check_args=false)
+function Base.convert(::Type{Cosine{T}}, d::Cosine) where {T<:Real}
+    Cosine{T}(T(d.μ), T(d.σ))
 end
+Base.convert(::Type{Cosine{T}}, d::Cosine{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/epanechnikov.jl
+++ b/src/univariate/continuous/epanechnikov.jl
@@ -22,9 +22,10 @@ Epanechnikov(μ::Real=0.0) = Epanechnikov(μ, one(μ); check_args=false)
 function convert(::Type{Epanechnikov{T}}, μ::Real, σ::Real) where T<:Real
     Epanechnikov(T(μ), T(σ), check_args=false)
 end
-function convert(::Type{Epanechnikov{T}}, d::Epanechnikov{S}) where {T <: Real, S <: Real}
-    Epanechnikov(T(d.μ), T(d.σ), check_args=false)
+function Base.convert(::Type{Epanechnikov{T}}, d::Epanechnikov) where {T<:Real}
+    Epanechnikov{T}(T(d.μ), T(d.σ))
 end
+Base.convert(::Type{Epanechnikov{T}}, d::Epanechnikov{T}) where {T<:Real} = d
 
 ## Parameters
 

--- a/src/univariate/continuous/erlang.jl
+++ b/src/univariate/continuous/erlang.jl
@@ -42,9 +42,10 @@ Erlang(α::Integer=1) = Erlang(α, 1.0; check_args=false)
 function convert(::Type{Erlang{T}}, α::Integer, θ::S) where {T <: Real, S <: Real}
     Erlang(α, T(θ), check_args=false)
 end
-function convert(::Type{Erlang{T}}, d::Erlang{S}) where {T <: Real, S <: Real}
-    Erlang(d.α, T(d.θ), check_args=false)
+function Base.convert(::Type{Erlang{T}}, d::Erlang) where {T<:Real}
+    Erlang{T}(d.α, T(d.θ))
 end
+Base.convert(::Type{Erlang{T}}, d::Erlang{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/exponential.jl
+++ b/src/univariate/continuous/exponential.jl
@@ -38,7 +38,10 @@ Exponential() = Exponential{Float64}(1.0)
 
 ### Conversions
 convert(::Type{Exponential{T}}, θ::S) where {T <: Real, S <: Real} = Exponential(T(θ))
-convert(::Type{Exponential{T}}, d::Exponential{S}) where {T <: Real, S <: Real} = Exponential(T(d.θ), check_args=false)
+function Base.convert(::Type{Exponential{T}}, d::Exponential) where {T<:Real}
+    return Exponential(T(d.θ))
+end
+Base.convert(::Type{Exponential{T}}, d::Exponential{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/fdist.jl
+++ b/src/univariate/continuous/fdist.jl
@@ -42,9 +42,8 @@ FDist(ν1::Real, ν2::Real; check_args::Bool=true) = FDist(promote(ν1, ν2)...;
 function convert(::Type{FDist{T}}, ν1::S, ν2::S) where {T <: Real, S <: Real}
     FDist(T(ν1), T(ν2))
 end
-function convert(::Type{FDist{T}}, d::FDist{S}) where {T <: Real, S <: Real}
-    FDist(T(d.ν1), T(d.ν2))
-end
+Base.convert(::Type{FDist{T}}, d::FDist) where {T<:Real} = FDist{T}(T(d.ν1), T(d.ν2))
+Base.convert(::Type{FDist{T}}, d::FDist{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/frechet.jl
+++ b/src/univariate/continuous/frechet.jl
@@ -44,9 +44,8 @@ Frechet(α::Real=1.0) = Frechet(α, one(α); check_args=false)
 function convert(::Type{Frechet{T}}, α::S, θ::S) where {T <: Real, S <: Real}
     Frechet(T(α), T(θ))
 end
-function convert(::Type{Frechet{T}}, d::Frechet{S}) where {T <: Real, S <: Real}
-    Frechet(T(d.α), T(d.θ), check_args=false)
-end
+Base.convert(::Type{Frechet{T}}, d::Frechet) where {T<:Real} = Frechet{T}(T(d.α), T(d.θ))
+Base.convert(::Type{Frechet{T}}, d::Frechet{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/gamma.jl
+++ b/src/univariate/continuous/gamma.jl
@@ -44,7 +44,8 @@ Gamma() = Gamma{Float64}(1.0, 1.0)
 
 #### Conversions
 convert(::Type{Gamma{T}}, α::S, θ::S) where {T <: Real, S <: Real} = Gamma(T(α), T(θ))
-convert(::Type{Gamma{T}}, d::Gamma{S}) where {T <: Real, S <: Real} = Gamma(T(d.α), T(d.θ), check_args=false)
+Base.convert(::Type{Gamma{T}}, d::Gamma) where {T<:Real} = Gamma{T}(T(d.α), T(d.θ))
+Base.convert(::Type{Gamma{T}}, d::Gamma{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/generalizedextremevalue.jl
+++ b/src/univariate/continuous/generalizedextremevalue.jl
@@ -55,9 +55,10 @@ end
 function convert(::Type{GeneralizedExtremeValue{T}}, μ::Real, σ::Real, ξ::Real) where T<:Real
     GeneralizedExtremeValue(T(μ), T(σ), T(ξ))
 end
-function convert(::Type{GeneralizedExtremeValue{T}}, d::GeneralizedExtremeValue{S}) where {T <: Real, S <: Real}
-    GeneralizedExtremeValue(T(d.μ), T(d.σ), T(d.ξ))
+function Base.convert(::Type{GeneralizedExtremeValue{T}}, d::GeneralizedExtremeValue) where {T<:Real}
+    GeneralizedExtremeValue{T}(T(d.μ), T(d.σ), T(d.ξ))
 end
+Base.convert(::Type{GeneralizedExtremeValue{T}}, d::GeneralizedExtremeValue{T}) where {T<:Real} = d
 
 minimum(d::GeneralizedExtremeValue{T}) where {T<:Real} =
         d.ξ > 0 ? d.μ - d.σ / d.ξ : -T(Inf)

--- a/src/univariate/continuous/generalizedpareto.jl
+++ b/src/univariate/continuous/generalizedpareto.jl
@@ -61,9 +61,10 @@ maximum(d::GeneralizedPareto{T}) where {T<:Real} = d.ξ < 0 ? d.μ - d.σ / d.ξ
 function convert(::Type{GeneralizedPareto{T}}, μ::S, σ::S, ξ::S) where {T <: Real, S <: Real}
     GeneralizedPareto(T(μ), T(σ), T(ξ))
 end
-function convert(::Type{GeneralizedPareto{T}}, d::GeneralizedPareto{S}) where {T <: Real, S <: Real}
-    GeneralizedPareto(T(d.μ), T(d.σ), T(d.ξ), check_args=false)
+function Base.convert(::Type{GeneralizedPareto{T}}, d::GeneralizedPareto) where {T<:Real}
+    GeneralizedPareto{T}(T(d.μ), T(d.σ), T(d.ξ))
 end
+Base.convert(::Type{GeneralizedPareto{T}}, d::GeneralizedPareto{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/gumbel.jl
+++ b/src/univariate/continuous/gumbel.jl
@@ -46,7 +46,8 @@ Base.eltype(::Type{Gumbel{T}}) where {T} = T
 #### Conversions
 
 convert(::Type{Gumbel{T}}, μ::S, θ::S) where {T <: Real, S <: Real} = Gumbel(T(μ), T(θ))
-convert(::Type{Gumbel{T}}, d::Gumbel{S}) where {T <: Real, S <: Real} = Gumbel(T(d.μ), T(d.θ), check_args=false)
+Base.convert(::Type{Gumbel{T}}, d::Gumbel) where {T<:Real} = Gumbel{T}(T(d.μ), T(d.θ))
+Base.convert(::Type{Gumbel{T}}, d::Gumbel{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/inversegamma.jl
+++ b/src/univariate/continuous/inversegamma.jl
@@ -45,7 +45,10 @@ InverseGamma() = InverseGamma{Float64}(1.0, 1.0)
 
 #### Conversions
 convert(::Type{InverseGamma{T}}, α::S, θ::S) where {T <: Real, S <: Real} = InverseGamma(T(α), T(θ))
-convert(::Type{InverseGamma{T}}, d::InverseGamma{S}) where {T <: Real, S <: Real} = InverseGamma(T(shape(d.invd)), T(d.θ))
+function Base.convert(::Type{InverseGamma{T}}, d::InverseGamma) where {T<:Real}
+    return InverseGamma{T}(T(shape(d)), T(d.θ))
+end
+Base.convert(::Type{InverseGamma{T}}, d::InverseGamma{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/inversegaussian.jl
+++ b/src/univariate/continuous/inversegaussian.jl
@@ -46,9 +46,10 @@ InverseGaussian() = InverseGaussian{Float64}(1.0, 1.0)
 function convert(::Type{InverseGaussian{T}}, μ::S, λ::S) where {T <: Real, S <: Real}
     InverseGaussian(T(μ), T(λ))
 end
-function convert(::Type{InverseGaussian{T}}, d::InverseGaussian{S}) where {T <: Real, S <: Real}
-    InverseGaussian(T(d.μ), T(d.λ), check_args=false)
+function Base.convert(::Type{InverseGaussian{T}}, d::InverseGaussian) where {T<:Real}
+    InverseGaussian{T}(T(d.μ), T(d.λ))
 end
+Base.convert(::Type{InverseGaussian{T}}, d::InverseGaussian{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/laplace.jl
+++ b/src/univariate/continuous/laplace.jl
@@ -45,9 +45,10 @@ const Biexponential = Laplace
 function convert(::Type{Laplace{T}}, μ::S, θ::S) where {T <: Real, S <: Real}
     Laplace(T(μ), T(θ))
 end
-function convert(::Type{Laplace{T}}, d::Laplace{S}) where {T <: Real, S <: Real}
-    Laplace(T(d.μ), T(d.θ), check_args=false)
+function Base.convert(::Type{Laplace{T}}, d::Laplace) where {T<:Real}
+    Laplace{T}(T(d.μ), T(d.θ))
 end
+Base.convert(::Type{Laplace{T}}, d::Laplace{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/levy.jl
+++ b/src/univariate/continuous/levy.jl
@@ -41,7 +41,8 @@ Levy(μ::Real=0.0) = Levy(μ, one(μ); check_args=false)
 #### Conversions
 
 convert(::Type{Levy{T}}, μ::S, σ::S) where {T <: Real, S <: Real} = Levy(T(μ), T(σ))
-convert(::Type{Levy{T}}, d::Levy{S}) where {T <: Real, S <: Real} = Levy(T(d.μ), T(d.σ), check_args=false)
+Base.convert(::Type{Levy{T}}, d::Levy) where {T<:Real} = Levy{T}(T(d.μ), T(d.σ))
+Base.convert(::Type{Levy{T}}, d::Levy{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/logistic.jl
+++ b/src/univariate/continuous/logistic.jl
@@ -45,9 +45,10 @@ Logistic(μ::Real=0.0) = Logistic(μ, one(μ); check_args=false)
 function convert(::Type{Logistic{T}}, μ::S, θ::S) where {T <: Real, S <: Real}
     Logistic(T(μ), T(θ))
 end
-function convert(::Type{Logistic{T}}, d::Logistic{S}) where {T <: Real, S <: Real}
-    Logistic(T(d.μ), T(d.θ), check_args=false)
+function Base.convert(::Type{Logistic{T}}, d::Logistic) where {T<:Real}
+    Logistic{T}(T(d.μ), T(d.θ))
 end
+Base.convert(::Type{Logistic{T}}, d::Logistic{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/logitnormal.jl
+++ b/src/univariate/continuous/logitnormal.jl
@@ -76,8 +76,10 @@ LogitNormal(μ::Real=0.0) = LogitNormal(μ, one(μ); check_args=false)
 #### Conversions
 convert(::Type{LogitNormal{T}}, μ::S, σ::S) where
   {T <: Real, S <: Real} = LogitNormal(T(μ), T(σ))
-convert(::Type{LogitNormal{T}}, d::LogitNormal{S}) where
-  {T <: Real, S <: Real} = LogitNormal(T(d.μ), T(d.σ), check_args=false)
+function Base.convert(::Type{LogitNormal{T}}, d::LogitNormal) where {T<:Real}
+    LogitNormal{T}(T(d.μ), T(d.σ))
+end
+Base.convert(::Type{LogitNormal{T}}, d::LogitNormal{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/lognormal.jl
+++ b/src/univariate/continuous/lognormal.jl
@@ -45,7 +45,8 @@ LogNormal(μ::Real=0.0) = LogNormal(μ, one(μ); check_args=false)
 
 #### Conversions
 convert(::Type{LogNormal{T}}, μ::S, σ::S) where {T <: Real, S <: Real} = LogNormal(T(μ), T(σ))
-convert(::Type{LogNormal{T}}, d::LogNormal{S}) where {T <: Real, S <: Real} = LogNormal(T(d.μ), T(d.σ), check_args=false)
+Base.convert(::Type{LogNormal{T}}, d::LogNormal) where {T<:Real} = LogNormal{T}(T(d.μ), T(d.σ))
+Base.convert(::Type{LogNormal{T}}, d::LogNormal{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/loguniform.jl
+++ b/src/univariate/continuous/loguniform.jl
@@ -23,7 +23,9 @@ end
 
 LogUniform(a::Real, b::Real; check_args::Bool=true) = LogUniform(promote(a, b)...; check_args=check_args)
 
-convert(::Type{LogUniform{T}}, d::LogUniform) where {T<:Real} = LogUniform(T(d.a), T(d.b); check_args=false)
+Base.convert(::Type{LogUniform{T}}, d::LogUniform) where {T<:Real} = LogUniform{T}(T(d.a), T(d.b))
+Base.convert(::Type{LogUniform{T}}, d::LogUniform{T}) where {T<:Real} = d
+
 Base.minimum(d::LogUniform) = d.a
 Base.maximum(d::LogUniform) = d.b
 

--- a/src/univariate/continuous/noncentralbeta.jl
+++ b/src/univariate/continuous/noncentralbeta.jl
@@ -18,6 +18,13 @@ NoncentralBeta(α::Integer, β::Integer, λ::Integer; check_args::Bool=true) = N
 
 @distr_support NoncentralBeta 0.0 1.0
 
+#### Conversions
+
+function Base.convert(::Type{NoncentralBeta{T}}, d::NoncentralBeta) where {T<:Real}
+    NoncentralBeta{T}(T(d.α), T(d.β), T(d.λ))
+end
+Base.convert(::Type{NoncentralBeta{T}}, d::NoncentralBeta{T}) where {T<:Real} = d
+
 ### Parameters
 
 params(d::NoncentralBeta) = (d.α, d.β, d.λ)

--- a/src/univariate/continuous/noncentralchisq.jl
+++ b/src/univariate/continuous/noncentralchisq.jl
@@ -44,9 +44,10 @@ NoncentralChisq(ν::Integer, λ::Integer; check_args::Bool=true) = NoncentralChi
 function convert(::Type{NoncentralChisq{T}}, ν::S, λ::S) where {T <: Real, S <: Real}
     NoncentralChisq(T(ν), T(λ))
 end
-function convert(::Type{NoncentralChisq{T}}, d::NoncentralChisq{S}) where {T <: Real, S <: Real}
-    NoncentralChisq(T(d.ν), T(d.λ), check_args=false)
+function Base.convert(::Type{NoncentralChisq{T}}, d::NoncentralChisq) where {T<:Real}
+    NoncentralChisq{T}(T(d.ν), T(d.λ))
 end
+Base.convert(::Type{NoncentralChisq{T}}, d::NoncentralChisq{T}) where {T<:Real} = d
 
 ### Parameters
 

--- a/src/univariate/continuous/noncentralf.jl
+++ b/src/univariate/continuous/noncentralf.jl
@@ -23,9 +23,10 @@ NoncentralF(ν1::Integer, ν2::Integer, λ::Integer; check_args::Bool=true) = No
 function convert(::Type{NoncentralF{T}}, ν1::S, ν2::S, λ::S) where {T <: Real, S <: Real}
     NoncentralF(T(ν1), T(ν2), T(λ))
 end
-function convert(::Type{NoncentralF{T}}, d::NoncentralF{S}) where {T <: Real, S <: Real}
-    NoncentralF(T(d.ν1), T(d.ν2), T(d.λ), check_args=false)
+function Base.convert(::Type{NoncentralF{T}}, d::NoncentralF) where {T<:Real}
+    NoncentralF{T}(T(d.ν1), T(d.ν2), T(d.λ))
 end
+Base.convert(::Type{NoncentralF{T}}, d::NoncentralF{T}) where {T<:Real} = d
 
 ### Parameters
 

--- a/src/univariate/continuous/noncentralt.jl
+++ b/src/univariate/continuous/noncentralt.jl
@@ -19,7 +19,8 @@ NoncentralT(ν::Integer, λ::Integer; check_args::Bool=true) = NoncentralT(float
 
 ### Conversions
 convert(::Type{NoncentralT{T}}, ν::S, λ::S) where {T <: Real, S <: Real} = NoncentralT(T(ν), T(λ))
-convert(::Type{NoncentralT{T}}, d::NoncentralT{S}) where {T <: Real, S <: Real} = NoncentralT(T(d.ν), T(d.λ), check_args=false)
+Base.convert(::Type{NoncentralT{T}}, d::NoncentralT) where {T<:Real} = NoncentralT(T(d.ν), T(d.λ))
+Base.convert(::Type{NoncentralT{T}}, d::NoncentralT{T}) where {T<:Real} = d
 
 ### Parameters
 

--- a/src/univariate/continuous/normal.jl
+++ b/src/univariate/continuous/normal.jl
@@ -47,7 +47,8 @@ const Gaussian = Normal
 
 # #### Conversions
 convert(::Type{Normal{T}}, μ::S, σ::S) where {T <: Real, S <: Real} = Normal(T(μ), T(σ))
-convert(::Type{Normal{T}}, d::Normal{S}) where {T <: Real, S <: Real} = Normal(T(d.μ), T(d.σ), check_args=false)
+Base.convert(::Type{Normal{T}}, d::Normal) where {T<:Real} = Normal{T}(T(d.μ), T(d.σ))
+Base.convert(::Type{Normal{T}}, d::Normal{T}) where {T<:Real} = d
 
 @distr_support Normal -Inf Inf
 

--- a/src/univariate/continuous/normalcanon.jl
+++ b/src/univariate/continuous/normalcanon.jl
@@ -26,7 +26,8 @@ NormalCanon() = NormalCanon{Float64}(0.0, 1.0; check_args=false)
 
 #### Type Conversions
 convert(::Type{NormalCanon{T}}, η::S, λ::S) where {T <: Real, S <: Real} = NormalCanon(T(η), T(λ))
-convert(::Type{NormalCanon{T}}, d::NormalCanon{S}) where {T <: Real, S <: Real} = NormalCanon(T(d.η), T(d.λ); check_args=false)
+Base.convert(::Type{NormalCanon{T}}, d::NormalCanon) where {T<:Real} = NormalCanon{T}(T(d.η), T(d.λ); check_args=false)
+Base.convert(::Type{NormalCanon{T}}, d::NormalCanon{T}) where {T<:Real} = d
 
 ## conversion between Normal and NormalCanon
 

--- a/src/univariate/continuous/normalinversegaussian.jl
+++ b/src/univariate/continuous/normalinversegaussian.jl
@@ -39,9 +39,10 @@ end
 function convert(::Type{NormalInverseGaussian{T}}, μ::Real, α::Real, β::Real, δ::Real) where T<:Real
     NormalInverseGaussian(T(μ), T(α), T(β), T(δ))
 end
-function convert(::Type{NormalInverseGaussian{T}}, d::NormalInverseGaussian{S}) where {T <: Real, S <: Real}
-    NormalInverseGaussian(T(d.μ), T(d.α), T(d.β), T(d.δ))
+function Base.convert(::Type{NormalInverseGaussian{T}}, d::NormalInverseGaussian) where {T<:Real}
+    NormalInverseGaussian{T}(T(d.μ), T(d.α), T(d.β), T(d.δ))
 end
+Base.convert(::Type{NormalInverseGaussian{T}}, d::NormalInverseGaussian{T}) where {T<:Real} = d
 
 params(d::NormalInverseGaussian) = (d.μ, d.α, d.β, d.δ)
 @inline partype(d::NormalInverseGaussian{T}) where {T<:Real} = T

--- a/src/univariate/continuous/pareto.jl
+++ b/src/univariate/continuous/pareto.jl
@@ -41,7 +41,8 @@ Pareto() = Pareto{Float64}(1.0, 1.0)
 
 #### Conversions
 convert(::Type{Pareto{T}}, α::Real, θ::Real) where {T<:Real} = Pareto(T(α), T(θ))
-convert(::Type{Pareto{T}}, d::Pareto{S}) where {T <: Real, S <: Real} = Pareto(T(d.α), T(d.θ), check_args=false)
+Base.convert(::Type{Pareto{T}}, d::Pareto) where {T<:Real} = Pareto{T}(T(d.α), T(d.θ))
+Base.convert(::Type{Pareto{T}}, d::Pareto{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/pgeneralizedgaussian.jl
+++ b/src/univariate/continuous/pgeneralizedgaussian.jl
@@ -57,9 +57,10 @@ PGeneralizedGaussian() = PGeneralizedGaussian(0.0, √2, 2.0, check_args=false) 
 #### Conversions
 
 convert(::Type{PGeneralizedGaussian{T1,T2,T3}}, μ::S1, α::S2, p::S3) where {T1 <: Real, T2 <: Real, T3 <:Real, S1 <: Real, S2 <: Real, S3 <: Real} = PGeneralizedGaussian(T1(μ),T2(α),T3(p))
-function convert(::Type{PGeneralizedGaussian{T1,T2,T3}}, d::PGeneralizedGaussian{S1,S2,S3}) where {T1 <: Real, T2 <: Real, T3 <: Real, S1 <: Real, S2 <: Real, S3 <: Real}
-    return PGeneralizedGaussian(T1(d.μ), T2(d.α), T3(d.p), check_args=false)
+function Base.convert(::Type{PGeneralizedGaussian{T1,T2,T3}}, d::PGeneralizedGaussian) where {T1<:Real,T2<:Real,T3<:Real}
+    return PGeneralizedGaussian{T1,T2,T3}(T1(d.μ), T2(d.α), T3(d.p))
 end
+Base.convert(::Type{PGeneralizedGaussian{T1,T2,T3}}, d::PGeneralizedGaussian{T1,T2,T3}) where {T1<:Real,T2<:Real,T3<:Real} = d
 
 @distr_support PGeneralizedGaussian -Inf Inf
 

--- a/src/univariate/continuous/rayleigh.jl
+++ b/src/univariate/continuous/rayleigh.jl
@@ -41,7 +41,8 @@ Rayleigh() = Rayleigh{Float64}(1.0)
 #### Conversions
 
 convert(::Type{Rayleigh{T}}, σ::S) where {T <: Real, S <: Real} = Rayleigh(T(σ))
-convert(::Type{Rayleigh{T}}, d::Rayleigh{S}) where {T <: Real, S <: Real} = Rayleigh(T(d.σ), check_args=false)
+Base.convert(::Type{Rayleigh{T}}, d::Rayleigh) where {T<:Real} = Rayleigh{T}(T(d.σ))
+Base.convert(::Type{Rayleigh{T}}, d::Rayleigh{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/rician.jl
+++ b/src/univariate/continuous/rician.jl
@@ -50,9 +50,8 @@ function convert(::Type{Rician{T}}, ν::Real, σ::Real) where T<:Real
     Rician(T(ν), T(σ))
 end
 
-function convert(::Type{Rician{T}}, d::Rician{S}) where {T <: Real, S <: Real}
-    Rician(T(d.ν), T(d.σ); check_args=false)
-end
+Base.convert(::Type{Rician{T}}, d::Rician) where {T<:Real} = Rician{T}(T(d.ν), T(d.σ))
+Base.convert(::Type{Rician{T}}, d::Rician{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/skewedexponentialpower.jl
+++ b/src/univariate/continuous/skewedexponentialpower.jl
@@ -51,8 +51,10 @@ SkewedExponentialPower(μ::Real=0) = SkewedExponentialPower(μ, 1, 2, 1//2; chec
 
 ### Conversions
 convert(::Type{SkewedExponentialPower{T}}, μ::S, σ::S, p::S, α::S) where {T <: Real, S <: Real} = SkewedExponentialPower(T(μ), T(σ), T(p), T(α))
-convert(::Type{SkewedExponentialPower{T}}, d::SkewedExponentialPower{S}) where {T <: Real, S <: Real} = SkewedExponentialPower(T(d.μ), T(d.σ), T(d.p), T(d.α), check_args=false)
-convert(::Type{SkewedExponentialPower{T}}, d::SkewedExponentialPower{T}) where {T<:Real} = d
+function Base.convert(::Type{SkewedExponentialPower{T}}, d::SkewedExponentialPower) where {T<:Real}
+    SkewedExponentialPower{T}(T(d.μ), T(d.σ), T(d.p), T(d.α))
+end
+Base.convert(::Type{SkewedExponentialPower{T}}, d::SkewedExponentialPower{T}) where {T<:Real} = d
 
 ### Parameters
 @inline partype(d::SkewedExponentialPower{T}) where {T<:Real} = T

--- a/src/univariate/continuous/skewnormal.jl
+++ b/src/univariate/continuous/skewnormal.jl
@@ -27,7 +27,8 @@ SkewNormal(α::Real=0.0) = SkewNormal(zero(α), one(α), α; check_args=false)
 
 #### Conversions
 convert(::Type{SkewNormal{T}}, ξ::S, ω::S, α::S) where {T <: Real, S <: Real} = SkewNormal(T(ξ), T(ω), T(α))
-convert(::Type{SkewNormal{T}}, d::SkewNormal{S}) where {T <: Real, S <: Real} = SkewNormal(T(d.ξ), T(d.ω), T(d.α), check_args=false)
+Base.convert(::Type{SkewNormal{T}}, d::SkewNormal) where {T<:Real} = SkewNormal{T}(T(d.ξ), T(d.ω), T(d.α))
+Base.convert(::Type{SkewNormal{T}}, d::SkewNormal{T}) where {T<:Real} = d
 
 #### Parameters
 params(d::SkewNormal) = (d.ξ, d.ω, d.α)

--- a/src/univariate/continuous/studentizedrange.jl
+++ b/src/univariate/continuous/studentizedrange.jl
@@ -50,9 +50,10 @@ function convert(::Type{StudentizedRange{T}}, ν::S, k::S) where {T <: Real, S <
     StudentizedRange(T(ν), T(k))
 end
 
-function convert(::Type{StudentizedRange{T}}, d::StudentizedRange{S}) where {T <: Real, S <: Real}
-    StudentizedRange(T(d.ν), T(d.k), check_args=false)
+function Base.convert(::Type{StudentizedRange{T}}, d::StudentizedRange) where {T<:Real}
+    StudentizedRange{T}(T(d.ν), T(d.k))
 end
+Base.convert(::Type{StudentizedRange{T}}, d::StudentizedRange{T}) where {T<:Real} = d
 
 ### Parameters
 params(d::StudentizedRange) = (d.ν, d.k)

--- a/src/univariate/continuous/symtriangular.jl
+++ b/src/univariate/continuous/symtriangular.jl
@@ -39,9 +39,10 @@ SymTriangularDist(μ::Real=0.0) = SymTriangularDist(μ, one(μ); check_args=fals
 function convert(::Type{SymTriangularDist{T}}, μ::Real, σ::Real) where T<:Real
     SymTriangularDist(T(μ), T(σ))
 end
-function convert(::Type{SymTriangularDist{T}}, d::SymTriangularDist{S}) where {T <: Real, S <: Real}
-    SymTriangularDist(T(d.μ), T(d.σ), check_args=false)
+function Base.convert(::Type{SymTriangularDist{T}}, d::SymTriangularDist) where {T<:Real}
+    SymTriangularDist{T}(T(d.μ), T(d.σ))
 end
+Base.convert(::Type{SymTriangularDist{T}}, d::SymTriangularDist{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/tdist.jl
+++ b/src/univariate/continuous/tdist.jl
@@ -36,7 +36,8 @@ TDist(ν::Integer; check_args::Bool=true) = TDist(float(ν); check_args=check_ar
 
 #### Conversions
 convert(::Type{TDist{T}}, ν::Real) where {T<:Real} = TDist(T(ν))
-convert(::Type{TDist{T}}, d::TDist{S}) where {T<:Real, S<:Real} = TDist(T(d.ν), check_args=false)
+Base.convert(::Type{TDist{T}}, d::TDist) where {T<:Real} = TDist{T}(T(d.ν))
+Base.convert(::Type{TDist{T}}, d::TDist{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/triangular.jl
+++ b/src/univariate/continuous/triangular.jl
@@ -50,7 +50,8 @@ TriangularDist(a::Real, b::Real) = TriangularDist(a, b, middle(a, b); check_args
 
 #### Conversions
 convert(::Type{TriangularDist{T}}, a::Real, b::Real, c::Real) where {T<:Real} = TriangularDist(T(a), T(b), T(c))
-convert(::Type{TriangularDist{T}}, d::TriangularDist{S}) where {T<:Real, S<:Real} = TriangularDist(T(d.a), T(d.b), T(d.c), check_args=false)
+Base.convert(::Type{TriangularDist{T}}, d::TriangularDist) where {T<:Real} = TriangularDist{T}(T(d.a), T(d.b), T(d.c))
+Base.convert(::Type{TriangularDist{T}}, d::TriangularDist{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/triweight.jl
+++ b/src/univariate/continuous/triweight.jl
@@ -21,7 +21,8 @@ Triweight(μ::Real=0.0) = Triweight(μ, one(μ); check_args=false)
 ## Conversions
 
 convert(::Type{Triweight{T}}, μ::Real, σ::Real) where {T<:Real} = Triweight(T(μ), T(σ))
-convert(::Type{Triweight{T}}, d::Triweight{S}) where {T<:Real, S<:Real} = Triweight(T(d.μ), T(d.σ), check_args=false)
+Base.convert(::Type{Triweight{T}}, d::Triweight) where {T<:Real} = Triweight{T}(T(d.μ), T(d.σ))
+Base.convert(::Type{Triweight{T}}, d::Triweight{T}) where {T<:Real} = d
 
 ## Parameters
 

--- a/src/univariate/continuous/uniform.jl
+++ b/src/univariate/continuous/uniform.jl
@@ -42,7 +42,8 @@ Uniform() = Uniform{Float64}(0.0, 1.0)
 
 #### Conversions
 convert(::Type{Uniform{T}}, a::Real, b::Real) where {T<:Real} = Uniform(T(a), T(b))
-convert(::Type{Uniform{T}}, d::Uniform{S}) where {T<:Real, S<:Real} = Uniform(T(d.a), T(d.b), check_args=false)
+Base.convert(::Type{Uniform{T}}, d::Uniform) where {T<:Real} = Uniform{T}(T(d.a), T(d.b))
+Base.convert(::Type{Uniform{T}}, d::Uniform{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/vonmises.jl
+++ b/src/univariate/continuous/vonmises.jl
@@ -41,7 +41,8 @@ show(io::IO, d::VonMises) = show(io, d, (:μ, :κ))
 #### Conversions
 
 convert(::Type{VonMises{T}}, μ::Real, κ::Real) where {T<:Real} = VonMises(T(μ), T(κ))
-convert(::Type{VonMises{T}}, d::VonMises{S}) where {T<:Real, S<:Real} = VonMises(T(d.μ), T(d.κ), check_args=false)
+Base.convert(::Type{VonMises{T}}, d::VonMises) where {T<:Real} = VonMises{T}(T(d.μ), T(d.κ), T(d.I0κx))
+Base.convert(::Type{VonMises{T}}, d::VonMises{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/continuous/weibull.jl
+++ b/src/univariate/continuous/weibull.jl
@@ -46,7 +46,8 @@ Weibull(α::Real=1.0) = Weibull(α, one(α); check_args=false)
 #### Conversions
 
 convert(::Type{Weibull{T}}, α::Real, θ::Real) where {T<:Real} = Weibull(T(α), T(θ))
-convert(::Type{Weibull{T}}, d::Weibull{S}) where {T <: Real, S <: Real} = Weibull(T(d.α), T(d.θ), check_args=false)
+Base.convert(::Type{Weibull{T}}, d::Weibull) where {T<:Real} = Weibull{T}(T(d.α), T(d.θ))
+Base.convert(::Type{Weibull{T}}, d::Weibull{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/discrete/bernoulli.jl
+++ b/src/univariate/discrete/bernoulli.jl
@@ -44,7 +44,8 @@ Base.eltype(::Type{<:Bernoulli}) = Bool
 
 #### Conversions
 convert(::Type{Bernoulli{T}}, p::Real) where {T<:Real} = Bernoulli(T(p))
-convert(::Type{Bernoulli{T}}, d::Bernoulli{S}) where {T <: Real, S <: Real} = Bernoulli(T(d.p), check_args=false)
+Base.convert(::Type{Bernoulli{T}}, d::Bernoulli) where {T<:Real} = Bernoulli{T}(T(d.p))
+Base.convert(::Type{Bernoulli{T}}, d::Bernoulli{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -40,9 +40,10 @@ BetaBinomial(n::Integer, α::Integer, β::Integer; check_args::Bool=true) = Beta
 function convert(::Type{BetaBinomial{T}}, n::Int, α::S, β::S) where {T <: Real, S <: Real}
     BetaBinomial(n, T(α), T(β))
 end
-function convert(::Type{BetaBinomial{T}}, d::BetaBinomial{S}) where {T <: Real, S <: Real}
-    BetaBinomial(d.n, T(d.α), T(d.β), check_args=false)
+function Base.convert(::Type{BetaBinomial{T}}, d::BetaBinomial) where {T<:Real}
+    BetaBinomial{T}(d.n, T(d.α), T(d.β))
 end
+Base.convert(::Type{BetaBinomial{T}}, d::BetaBinomial{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -48,10 +48,10 @@ Binomial() = Binomial{Float64}(1, 0.5)
 function convert(::Type{Binomial{T}}, n::Int, p::Real) where T<:Real
     return Binomial(n, T(p))
 end
-function convert(::Type{Binomial{T}}, d::Binomial{S}) where {T <: Real, S <: Real}
-    return Binomial(d.n, T(d.p), check_args=false)
+function Base.convert(::Type{Binomial{T}}, d::Binomial) where {T<:Real}
+    return Binomial{T}(d.n, T(d.p))
 end
-
+Base.convert(::Type{Binomial{T}}, d::Binomial{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/discrete/discretenonparametric.jl
+++ b/src/univariate/discrete/discretenonparametric.jl
@@ -44,6 +44,7 @@ Base.eltype(::Type{<:DiscreteNonParametric{T}}) where T = T
 # Conversion
 convert(::Type{DiscreteNonParametric{T,P,Ts,Ps}}, d::DiscreteNonParametric) where {T,P,Ts,Ps} =
     DiscreteNonParametric{T,P,Ts,Ps}(convert(Ts, support(d)), convert(Ps, probs(d)), check_args=false)
+Base.convert(::Type{DiscreteNonParametric{T,P,Ts,Ps}}, d::DiscreteNonParametric{T,P,Ts,Ps}) where {T,P,Ts,Ps} = d
 
 # Accessors
 params(d::DiscreteNonParametric) = (d.support, d.p)

--- a/src/univariate/discrete/geometric.jl
+++ b/src/univariate/discrete/geometric.jl
@@ -40,7 +40,8 @@ Geometric() = Geometric{Float64}(0.5)
 
 ### Conversions
 convert(::Type{Geometric{T}}, p::Real) where {T<:Real} = Geometric(T(p))
-convert(::Type{Geometric{T}}, d::Geometric{S}) where {T <: Real, S <: Real} = Geometric(T(d.p), check_args=false)
+Base.convert(::Type{Geometric{T}}, d::Geometric) where {T<:Real} = Geometric{T}(T(d.p))
+Base.convert(::Type{Geometric{T}}, d::Geometric{T}) where {T<:Real} = d
 
 ### Parameters
 

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -54,9 +54,10 @@ NegativeBinomial() = NegativeBinomial{Float64}(1.0, 0.5)
 function convert(::Type{NegativeBinomial{T}}, r::Real, p::Real) where {T<:Real}
     return NegativeBinomial(T(r), T(p))
 end
-function convert(::Type{NegativeBinomial{T}}, d::NegativeBinomial{S}) where {T <: Real, S <: Real}
-    return NegativeBinomial(T(d.r), T(d.p), check_args=false)
+function Base.convert(::Type{NegativeBinomial{T}}, d::NegativeBinomial) where {T<:Real}
+    return NegativeBinomial{T}(T(d.r), T(d.p))
 end
+Base.convert(::Type{NegativeBinomial{T}}, d::NegativeBinomial{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/discrete/noncentralhypergeometric.jl
+++ b/src/univariate/discrete/noncentralhypergeometric.jl
@@ -59,7 +59,10 @@ FisherNoncentralHypergeometric(ns::Integer, nf::Integer, n::Integer, ω::Integer
 
 # Conversions
 convert(::Type{FisherNoncentralHypergeometric{T}}, ns::Real, nf::Real, n::Real, ω::Real) where {T<:Real} = FisherNoncentralHypergeometric(ns, nf, n, T(ω))
-convert(::Type{FisherNoncentralHypergeometric{T}}, d::FisherNoncentralHypergeometric{S}) where {T<:Real, S<:Real} = FisherNoncentralHypergeometric(d.ns, d.nf, d.n, T(d.ω); check_args=false)
+function Base.convert(::Type{FisherNoncentralHypergeometric{T}}, d::FisherNoncentralHypergeometric) where {T<:Real}
+    FisherNoncentralHypergeometric{T}(d.ns, d.nf, d.n, T(d.ω))
+end
+Base.convert(::Type{FisherNoncentralHypergeometric{T}}, d::FisherNoncentralHypergeometric{T}) where {T<:Real} = d
 
 function _mode(d::FisherNoncentralHypergeometric)
     A = d.ω - 1
@@ -247,7 +250,10 @@ WalleniusNoncentralHypergeometric(ns::Integer, nf::Integer, n::Integer, ω::Inte
 
 # Conversions
 convert(::Type{WalleniusNoncentralHypergeometric{T}}, ns::Real, nf::Real, n::Real, ω::Real) where {T<:Real} = WalleniusNoncentralHypergeometric(ns, nf, n, T(ω))
-convert(::Type{WalleniusNoncentralHypergeometric{T}}, d::WalleniusNoncentralHypergeometric{S}) where {T<:Real, S<:Real} = WalleniusNoncentralHypergeometric(d.ns, d.nf, d.n, T(d.ω); check_args=false)
+function Base.convert(::Type{WalleniusNoncentralHypergeometric{T}}, d::WalleniusNoncentralHypergeometric) where {T<:Real}
+    WalleniusNoncentralHypergeometric{T}(d.ns, d.nf, d.n, T(d.ω))
+end
+Base.convert(::Type{WalleniusNoncentralHypergeometric{T}}, d::WalleniusNoncentralHypergeometric{T}) where {T<:Real} = d
 
 # Properties
 mean(d::WalleniusNoncentralHypergeometric) = sum(support(d) .* pdf.(Ref(d), support(d)))

--- a/src/univariate/discrete/poisson.jl
+++ b/src/univariate/discrete/poisson.jl
@@ -38,7 +38,8 @@ Poisson() = Poisson{Float64}(1.0)
 
 #### Conversions
 convert(::Type{Poisson{T}}, λ::S) where {T <: Real, S <: Real} = Poisson(T(λ))
-convert(::Type{Poisson{T}}, d::Poisson{S}) where {T <: Real, S <: Real} = Poisson(T(d.λ), check_args=false)
+Base.convert(::Type{Poisson{T}}, d::Poisson) where {T<:Real} = Poisson{T}(T(d.λ))
+Base.convert(::Type{Poisson{T}}, d::Poisson{T}) where {T<:Real} = d
 
 ### Parameters
 

--- a/src/univariate/discrete/skellam.jl
+++ b/src/univariate/discrete/skellam.jl
@@ -50,7 +50,8 @@ Skellam() = Skellam{Float64}(1.0, 1.0)
 #### Conversions
 
 convert(::Type{Skellam{T}}, μ1::S, μ2::S) where {T<:Real, S<:Real} = Skellam(T(μ1), T(μ2))
-convert(::Type{Skellam{T}}, d::Skellam{S}) where {T<:Real, S} =  Skellam(T(d.μ1), T(d.μ2), check_args=false)
+Base.convert(::Type{Skellam{T}}, d::Skellam) where {T<:Real} = Skellam{T}(T(d.μ1), T(d.μ2))
+Base.convert(::Type{Skellam{T}}, d::Skellam{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/locationscale.jl
+++ b/src/univariate/locationscale.jl
@@ -87,7 +87,7 @@ AffineDistribution(μ::Real, σ::Real, d::AffineDistribution) = AffineDistributi
 
 convert(::Type{AffineDistribution{T}}, μ::Real, σ::Real, ρ::D) where {T<:Real, D<:UnivariateDistribution} = AffineDistribution(T(μ),T(σ),ρ)
 function Base.convert(::Type{AffineDistribution{T}}, d::AffineDistribution) where {T<:Real}
-    AffineDistribution{T}(T(d.μ),T(d.σ),d.ρ)
+    AffineDistribution{T}(T(d.μ), T(d.σ), d.ρ)
 end
 Base.convert(::Type{AffineDistribution{T}}, d::AffineDistribution{T}) where {T<:Real} = d
 

--- a/src/univariate/locationscale.jl
+++ b/src/univariate/locationscale.jl
@@ -37,7 +37,9 @@ struct AffineDistribution{T<:Real, S<:ValueSupport, D<:UnivariateDistribution{S}
     μ::T
     σ::T
     ρ::D
-    function AffineDistribution{T,S,D}(μ::T, σ::T, ρ::D) where {T<:Real, S<:ValueSupport, D<:UnivariateDistribution{S}}
+    # TODO: Remove? It is not used in Distributions anymore
+    function AffineDistribution{T,S,D}(μ::T, σ::T, ρ::D; check_args::Bool=true) where {T<:Real, S<:ValueSupport, D<:UnivariateDistribution{S}}
+        @check_args AffineDistribution (σ, σ > zero(σ))
         new{T, S, D}(μ, σ, ρ)
     end
     function AffineDistribution{T}(μ::T, σ::T, ρ::UnivariateDistribution) where {T<:Real}

--- a/src/univariate/locationscale.jl
+++ b/src/univariate/locationscale.jl
@@ -41,13 +41,17 @@ struct AffineDistribution{T<:Real, S<:ValueSupport, D<:UnivariateDistribution{S}
         @check_args AffineDistribution (σ, σ > zero(σ))
         new{T, S, D}(μ, σ, ρ)
     end
+    function AffineDistribution{T}(μ::T, σ::T, ρ::UnivariateDistribution; check_args::Bool=true) where {T<:Real}
+        @check_args AffineDistribution (σ, σ > zero(σ))
+        D = typeof(ρ)
+        S = value_support(D)
+        return new{T,S,D}(μ, σ, ρ)
+    end
 end
 
 function AffineDistribution(μ::T, σ::T, ρ::UnivariateDistribution; check_args::Bool=true) where {T<:Real}
     _T = promote_type(eltype(ρ), T)
-    D = typeof(ρ)
-    S = value_support(D)
-    return AffineDistribution{_T,S,D}(_T(μ), _T(σ), ρ; check_args=check_args)
+    return AffineDistribution{_T}(_T(μ), _T(σ), ρ; check_args=check_args)
 end
 
 function AffineDistribution(μ::Real, σ::Real, ρ::UnivariateDistribution; check_args::Bool=true)
@@ -81,7 +85,10 @@ AffineDistribution(μ::Real, σ::Real, d::AffineDistribution) = AffineDistributi
 #### Conversions
 
 convert(::Type{AffineDistribution{T}}, μ::Real, σ::Real, ρ::D) where {T<:Real, D<:UnivariateDistribution} = AffineDistribution(T(μ),T(σ),ρ)
-convert(::Type{AffineDistribution{T}}, d::AffineDistribution{S}) where {T<:Real, S<:Real} = AffineDistribution(T(d.μ),T(d.σ),d.ρ, check_args=false)
+function Base.convert(::Type{AffineDistribution{T}}, d::AffineDistribution) where {T<:Real}
+    AffineDistribution{T}(T(d.μ),T(d.σ),d.ρ)
+end
+Base.convert(::Type{AffineDistribution{T}}, d::AffineDistribution{T}) where {T<:Real} = d
 
 #### Parameters
 

--- a/src/univariate/locationscale.jl
+++ b/src/univariate/locationscale.jl
@@ -50,7 +50,7 @@ end
 function AffineDistribution(μ::T, σ::T, ρ::UnivariateDistribution; check_args::Bool=true) where {T<:Real}
     @check_args AffineDistribution (σ, σ > zero(σ))
     _T = promote_type(eltype(ρ), T)
-    return AffineDistribution{_T}(_T(μ), _T(σ), ρ; check_args=check_args)
+    return AffineDistribution{_T}(_T(μ), _T(σ), ρ)
 end
 
 function AffineDistribution(μ::Real, σ::Real, ρ::UnivariateDistribution; check_args::Bool=true)

--- a/src/univariate/locationscale.jl
+++ b/src/univariate/locationscale.jl
@@ -37,12 +37,10 @@ struct AffineDistribution{T<:Real, S<:ValueSupport, D<:UnivariateDistribution{S}
     μ::T
     σ::T
     ρ::D
-    function AffineDistribution{T,S,D}(μ::T, σ::T, ρ::D; check_args::Bool=true) where {T<:Real, S<:ValueSupport, D<:UnivariateDistribution{S}}
-        @check_args AffineDistribution (σ, σ > zero(σ))
+    function AffineDistribution{T,S,D}(μ::T, σ::T, ρ::D) where {T<:Real, S<:ValueSupport, D<:UnivariateDistribution{S}}
         new{T, S, D}(μ, σ, ρ)
     end
-    function AffineDistribution{T}(μ::T, σ::T, ρ::UnivariateDistribution; check_args::Bool=true) where {T<:Real}
-        @check_args AffineDistribution (σ, σ > zero(σ))
+    function AffineDistribution{T}(μ::T, σ::T, ρ::UnivariateDistribution) where {T<:Real}
         D = typeof(ρ)
         S = value_support(D)
         return new{T,S,D}(μ, σ, ρ)
@@ -50,6 +48,7 @@ struct AffineDistribution{T<:Real, S<:ValueSupport, D<:UnivariateDistribution{S}
 end
 
 function AffineDistribution(μ::T, σ::T, ρ::UnivariateDistribution; check_args::Bool=true) where {T<:Real}
+    @check_args AffineDistribution (σ, σ > zero(σ))
     _T = promote_type(eltype(ρ), T)
     return AffineDistribution{_T}(_T(μ), _T(σ), ρ; check_args=check_args)
 end

--- a/test/categorical.jl
+++ b/test/categorical.jl
@@ -73,8 +73,12 @@ println("    testing $d as Categorical")
 p = ones(10^6) * 1.0e-6
 @test Distributions.isprobvec(p)
 
-@test typeof(convert(Categorical{Float32,Vector{Float32}}, d)) == Categorical{Float32,Vector{Float32}}
-@test typeof(convert(Categorical{Float32,Vector{Float32}}, d.p)) == Categorical{Float32,Vector{Float32}}
+@test convert(Categorical{Float64,Vector{Float64}}, d) === d
+for x in (d, probs(d))
+    d32 = convert(Categorical{Float32,Vector{Float32}}, d)
+    @test d32 isa Categorical{Float32,Vector{Float32}}
+    @test probs(d32) == map(Float32, probs(d))
+end
 
 @testset "test args... constructor" begin
     @test Categorical(0.3, 0.7) == Categorical([0.3, 0.7])

--- a/test/lkjcholesky.jl
+++ b/test/lkjcholesky.jl
@@ -106,6 +106,8 @@ using FiniteDifferences
 
     @testset "Conversion" begin
         d = LKJCholesky(5, 3.5)
+        @test convert(LKJCholesky{Float64}, d) === d
+
         df0_1 = convert(LKJCholesky{Float32}, d)
         @test df0_1 isa LKJCholesky{Float32}
         @test df0_1.d == d.d

--- a/test/logitnormal.jl
+++ b/test/logitnormal.jl
@@ -61,5 +61,6 @@ end
     test_logitnormal( LogitNormal(2,0.5) )
     d = LogitNormal(Float32(2))
     typeof(rand(d, 5)) # still Float64
+    @test convert(LogitNormal{Float32}, d) === d
     @test typeof(convert(LogitNormal{Float64}, d)) == typeof(LogitNormal(2,1))
 end

--- a/test/lognormal.jl
+++ b/test/lognormal.jl
@@ -7,6 +7,10 @@ isnan_type(::Type{T}, v) where {T} = isnan(v) && v isa T
 @testset "LogNormal" begin
     @test isa(convert(LogNormal{Float64}, Float16(0), Float16(1)),
               LogNormal{Float64})
+    d = LogNormal(0, 1)
+    @test convert(LogNormal{Float64}, d) === d
+    @test convert(LogNormal{Float32}, d) isa LogNormal{Float32}
+
     @test logpdf(LogNormal(0, 0), 1) === Inf
     @test logpdf(LogNormal(), Inf) === -Inf
     @test iszero(logcdf(LogNormal(0, 0), 1))

--- a/test/matrixvariates.jl
+++ b/test/matrixvariates.jl
@@ -122,6 +122,9 @@ function test_convert(d::MatrixDistribution)
         @test del2 isa distname{elty}
         @test partype(del1) == elty
         @test partype(del2) == elty
+        if elty === partype(d)
+            @test del1 === d
+        end
     end
     nothing
 end

--- a/test/multinomial.jl
+++ b/test/multinomial.jl
@@ -33,6 +33,8 @@ rng = MersenneTwister(123)
 @test typeof(convert(Multinomial{Float32, Vector{Float32}}, d)) == Multinomial{Float32, Vector{Float32}}
 @test typeof(convert(Multinomial{Float32}, params(d)...)) == Multinomial{Float32, Vector{Float32}}
 @test typeof(convert(Multinomial{Float32, Vector{Float32}}, params(d)...)) == Multinomial{Float32, Vector{Float32}}
+@test convert(Multinomial{Float64}, d) === d
+@test convert(Multinomial{Float64, Vector{Float64}}, d) === d
 
 # random sampling
 

--- a/test/mvlognormal.jl
+++ b/test/mvlognormal.jl
@@ -131,6 +131,7 @@ end
         test_mvlognormal(g, 10^4)
     end
     d = MvLogNormal(Array{Float32}(mu), PDMats.PDMat(Array{Float32}(C)))
+    @test convert(MvLogNormal{Float32}, d) === d
     @test typeof(convert(MvLogNormal{Float64}, d)) == typeof(MvLogNormal(mu, PDMats.PDMat(C)))
     @test typeof(convert(MvLogNormal{Float64}, d.normal.μ, d.normal.Σ)) == typeof(MvLogNormal(mu, PDMats.PDMat(C)))
     @test d == deepcopy(d)

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -87,10 +87,12 @@ end
     @test typeof(MvNormalCanon(mu, Array{Float16}(h), PDMat(Array{Float32}(J)))) == typeof(MvNormalCanon(mu, h, PDMat(J)))
 
     d = MvNormal(Array{Float32}(mu), PDMat(Array{Float32}(C)))
+    @test convert(MvNormal{Float32}, d) === d
     @test typeof(convert(MvNormal{Float64}, d)) == typeof(MvNormal(mu, PDMat(C)))
     @test typeof(convert(MvNormal{Float64}, d.μ, d.Σ)) == typeof(MvNormal(mu, PDMat(C)))
 
     d = MvNormalCanon(Array{Float32}(mu), Array{Float32}(h), PDMat(Array{Float32}(J)))
+    @test convert(MvNormalCanon{Float32}, d) === d
     @test typeof(convert(MvNormalCanon{Float64}, d)) == typeof(MvNormalCanon(mu, h, PDMat(J)))
     @test typeof(convert(MvNormalCanon{Float64}, d.μ, d.h, d.J)) == typeof(MvNormalCanon(mu, h, PDMat(J)))
 

--- a/test/mvtdist.jl
+++ b/test/mvtdist.jl
@@ -39,6 +39,7 @@ end
 @test typeof(GenericMvTDist(1, mu, PDMat(Array{Float32}(Sigma)))) == typeof(GenericMvTDist(1., mu, PDMat(Sigma)))
 
 d = GenericMvTDist(1, Array{Float32}(mu), PDMat(Array{Float32}(Sigma)))
+@test convert(GenericMvTDist{Float32}, d) === d
 @test typeof(convert(GenericMvTDist{Float64}, d)) == typeof(GenericMvTDist(1, mu, PDMat(Sigma)))
 @test typeof(convert(GenericMvTDist{Float64}, d.df, d.dim, d.μ, d.Σ)) == typeof(GenericMvTDist(1, mu, PDMat(Sigma)))
 @test partype(d) == Float32

--- a/test/normal.jl
+++ b/test/normal.jl
@@ -5,6 +5,12 @@ isnan_type(::Type{T}, v) where {T} = isnan(v) && v isa T
 @testset "Normal" begin
     @test isa(convert(Normal{Float64}, Float16(0), Float16(1)),
               Normal{Float64})
+    d = Normal(1.1, 2.3)
+    @test convert(Normal{Float64}, d) === d
+    d32 = convert(Normal{Float32}, d)
+    @test d32 isa Normal{Float32}
+    @test params(d32) == map(Float32, params(d))
+
     @test Inf === logpdf(Normal(0, 0), 0)
     @test -Inf === logpdf(Normal(), Inf)
     @test iszero(logcdf(Normal(0, 0), 0))

--- a/test/pgeneralizedgaussian.jl
+++ b/test/pgeneralizedgaussian.jl
@@ -131,3 +131,8 @@ d = PGeneralizedGaussian(0.0, α, β)
 @test var(d) ≈ α^2 * (gamma(3.0 * inv(β)) / gamma(inv(β)))
 @test kurtosis(d) ≈ gamma(5.0 * inv(β)) * gamma(inv(β)) / (gamma(3.0 * inv(β))^2) - 3.0
 @test entropy(d) ≈ inv(β) - log( β / (2.0 * α * gamma(inv(β))))
+
+@test convert(PGeneralizedGaussian{Float64,Float64,Float64}, d) === d
+d32 = convert(PGeneralizedGaussian{Int,Float32,Float16}, d)
+@test d32 isa PGeneralizedGaussian{Int,Float32,Float16}
+@test params(d32) == (0, Float32(α), Float16(β))

--- a/test/univariates.jl
+++ b/test/univariates.jl
@@ -78,6 +78,13 @@ function verify_and_test(D::Union{Type,Function}, d::UnivariateDistribution, dct
         @test typeof(D(int_pars...)) == typeof(d)
     end
 
+    # conversions
+    if D isa Type && !isconcretetype(D)
+        @test convert(D{partype(d)}, d) === d
+        d32 = convert(D{Float32}, d)
+        @test d32 isa D{Float32}
+    end
+
     # verify properties (params & stats)
     pdct = dct["properties"]
     for (fname, val) in pdct

--- a/test/vonmises.jl
+++ b/test/vonmises.jl
@@ -15,7 +15,10 @@ function test_vonmises(μ::Float64, κ::Float64)
     # println(d)
 
     # conversions
-    @test typeof(convert(VonMises{Float32}, d)) == VonMises{Float32}
+    @test convert(VonMises{Float64}, d) === d
+    d32 = convert(VonMises{Float32}, d)
+    @test d32 isa VonMises{Float32}
+    @test params(d32) == map(Float32, params(d))
 
     # Support
     @test support(d) == RealInterval(d.μ-π,d.μ+π)

--- a/test/vonmisesfisher.jl
+++ b/test/vonmisesfisher.jl
@@ -87,8 +87,11 @@ function test_vonmisesfisher(p::Int, κ::Real, n::Int, ns::Int,
     @test partype(d) == Float64
 
     # conversions
-    @test typeof(convert(VonMisesFisher{Float32}, d)) == VonMisesFisher{Float32}
-    @test typeof(convert(VonMisesFisher{Float32}, d.μ, d.κ, d.logCκ)) == VonMisesFisher{Float32}
+    @test convert(VonMisesFisher{partype(d)}, d) === d
+    for d32 in (convert(VonMisesFisher{Float32}, d), convert(VonMisesFisher{Float32}, d.μ, d.κ, d.logCκ))
+        @test d32 isa VonMisesFisher{Float32}
+        @test params(d32) == (map(Float32, μ), Float32(κ))
+    end
 
     θ = κ * μ
     d2 = VonMisesFisher(θ)


### PR DESCRIPTION
This PR fixes two bugs of the current `convert` definitions:
- `convert(::Type{MyDist{T}}, d::MyDist)` is not always of type `MyDist{T}` (see e.g. https://github.com/JuliaStats/Distributions.jl/issues/1485)
- `convert(::Type{MyDist{T}}, d::MyDist{T})` is not always a no-op (see e.g. https://github.com/JuliaStats/Distributions.jl/issues/1514)

I went through all `convert` implementations, fixed them and added missing definitions, and added tests.

Fixes https://github.com/JuliaStats/Distributions.jl/issues/1514. Fixes https://github.com/JuliaStats/Distributions.jl/issues/1485.

cc: @sethaxen @KDr2