### PR TITLE
Support MvNormal holding Symmetric{<:Real,<:Diagonal} or Hermitian

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.49"
+version = "0.25.50"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -200,6 +200,7 @@ Construct a multivariate normal distribution with mean `μ` and covariance matri
 """
 MvNormal(μ::AbstractVector{<:Real}, Σ::AbstractMatrix{<:Real}) = MvNormal(μ, PDMat(Σ))
 MvNormal(μ::AbstractVector{<:Real}, Σ::Diagonal{<:Real}) = MvNormal(μ, PDiagMat(Σ.diag))
+MvNormal(μ::AbstractVector{<:Real}, Σ::Union{Symmetric{<:Real,<:Diagonal{<:Real}},Hermitian{<:Real,<:Diagonal{<:Real}}}) = MvNormal(μ, PDiagMat(Σ.data.diag))
 MvNormal(μ::AbstractVector{<:Real}, Σ::UniformScaling{<:Real}) =
     MvNormal(μ, ScalMat(length(μ), Σ.λ))
 function MvNormal(

--- a/src/multivariate/mvnormalcanon.jl
+++ b/src/multivariate/mvnormalcanon.jl
@@ -91,6 +91,7 @@ Construct a multivariate normal distribution with potential vector `h` and preci
 """
 MvNormalCanon(h::AbstractVector{<:Real}, J::AbstractMatrix{<:Real}) = MvNormalCanon(h, PDMat(J))
 MvNormalCanon(h::AbstractVector{<:Real}, J::Diagonal{<:Real}) = MvNormalCanon(h, PDiagMat(J.diag))
+MvNormalCanon(μ::AbstractVector{<:Real}, J::Union{Symmetric{<:Real,<:Diagonal{<:Real}},Hermitian{<:Real,<:Diagonal{<:Real}}}) = MvNormalCanon(μ, PDiagMat(J.data.diag))
 function MvNormalCanon(h::AbstractVector{<:Real}, J::UniformScaling{<:Real})
     return MvNormalCanon(h, ScalMat(length(h), J.λ))
 end

--- a/test/mvlognormal.jl
+++ b/test/mvlognormal.jl
@@ -125,6 +125,8 @@ end
         (@test_deprecated(MvLogNormal(mu, Vector{Float64}(sqrt.(va)))), mu, Matrix(Diagonal(va))), # Julia 0.4 loses type information so Vector{Float64} can be dropped when we don't support 0.4
         (@test_deprecated(MvLogNormal(Vector{Float64}(sqrt.(va)))), zeros(3), Matrix(Diagonal(va))), # Julia 0.4 loses type information so Vector{Float64} can be dropped when we don't support 0.4
         (MvLogNormal(mu, C), mu, C),
+        (MvLogNormal(mu, Diagonal(C)), mu, Diagonal(C)),
+        (MvLogNormal(mu, Symmetric(Diagonal(C))), mu, Diagonal(C)),
         (MvLogNormal(C), zeros(3), C) ]
         m, s = params(g)
         @test Vector(m) ≈ μ

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -21,7 +21,7 @@ using FillArrays
     h = [1., 2., 3.]
     dv = [1.2, 3.4, 2.6]
     J = [4. -2. -1.; -2. 5. -1.; -1. -1. 6.]
-
+    D = Diagonal(J);
     for (g, μ, Σ) in [
         (@test_deprecated(MvNormal(mu, sqrt(2.0))), mu, Matrix(2.0I, 3, 3)),
         (@test_deprecated(MvNormal(mu_r, sqrt(2.0))), mu_r, Matrix(2.0I, 3, 3)),
@@ -42,6 +42,10 @@ using FillArrays
         (@test_deprecated(MvNormalCanon(dv)), zeros(3), Matrix(Diagonal(inv.(dv)))),
         (MvNormalCanon(h, J), J \ h, inv(J)),
         (MvNormalCanon(J), zeros(3), inv(J)),
+        (MvNormalCanon(h, D), Diagonal(D) \ h, inv(D)),
+        (MvNormalCanon(D), zeros(3), inv(D)),
+        (MvNormalCanon(h, Symmetric(D)), D \ h, inv(D)),
+        (MvNormalCanon(Hermitian(D)), zeros(3), inv(D)),
         (MvNormal(mu, Symmetric(C)), mu, Matrix(Symmetric(C))),
         (MvNormal(mu_r, Symmetric(C)), mu_r, Matrix(Symmetric(C))),
         (MvNormal(mu, Diagonal(dv)), mu, Matrix(Diagonal(dv))),

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -45,6 +45,8 @@ using FillArrays
         (MvNormal(mu, Symmetric(C)), mu, Matrix(Symmetric(C))),
         (MvNormal(mu_r, Symmetric(C)), mu_r, Matrix(Symmetric(C))),
         (MvNormal(mu, Diagonal(dv)), mu, Matrix(Diagonal(dv))),
+        (MvNormal(mu, Symmetric(Diagonal(dv))), mu, Matrix(Diagonal(dv))),
+        (MvNormal(mu, Hermitian(Diagonal(dv))), mu, Matrix(Diagonal(dv))),
         (MvNormal(mu_r, Diagonal(dv)), mu_r, Matrix(Diagonal(dv))) ]
 
         @test mean(g)   ≈ μ


### PR DESCRIPTION
On master:
```julia
julia> using Distributions, LinearAlgebra, FillArrays

julia> MvNormal(rand(2), Symmetric(Diagonal([1.0,2.0])))
ERROR: MethodError: Cannot `convert` an object of type Symmetric{Float64, Diagonal{Float64, Vector{Float64}}} to an object of type Diagonal{Float64, Vector{Float64}}

julia> MvNormal(Zeros(2), Symmetric(Diagonal([1.0,2.0])))
ERROR: MethodError: Cannot `convert` an object of type Symmetric{Float64, Diagonal{Float64, Vector{Float64}}} to an object of type Diagonal{Float64, Vector{Float64}}
```
On this PR:
```julia
julia> using Distributions, LinearAlgebra, FillArrays

julia> MvNormal(rand(2), Symmetric(Diagonal([1.0,2.0])))
DiagNormal(
dim: 2
μ: [0.1851389943338715, 0.9573799942189535]
Σ: [1.0 0.0; 0.0 2.0]
)

julia> MvNormal(Zeros(2), Symmetric(Diagonal([1.0,2.0])))
ZeroMeanDiagNormal(
dim: 2
μ: Zeros(2)
Σ: [1.0 0.0; 0.0 2.0]
)
```