### PR TITLE
Fix rand for Product(Fill(...)) distributions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.51"
+version = "0.25.52"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/multivariate/product.jl
+++ b/src/multivariate/product.jl
@@ -31,7 +31,7 @@ function Base.eltype(::Type{<:Product{S,T}}) where {S<:ValueSupport,
 end
 
 _rand!(rng::AbstractRNG, d::Product, x::AbstractVector{<:Real}) =
-    broadcast!(dn->rand(rng, dn), x, d.v)
+    map!(Base.Fix1(rand, rng), x, d.v)
 _logpdf(d::Product, x::AbstractVector{<:Real}) =
     sum(n->logpdf(d.v[n], x[n]), 1:length(d))
 

--- a/test/product.jl
+++ b/test/product.jl
@@ -1,4 +1,4 @@
-using Distributions, Test, Random, LinearAlgebra
+using Distributions, Test, Random, LinearAlgebra, FillArrays
 using Distributions: Product
 
 @testset "Testing normal product distributions" begin
@@ -80,3 +80,13 @@ end
         @test length(y) == N
     end
 end
+
+@testset "Testing iid product distributions" begin
+    Random.seed!(123456)
+    N = 11
+    d = Product(Fill(Laplace(0.0, 2.3), N))
+    @test N == length(unique(rand(d)));
+    @test mean(d) === Fill(0.0, N)
+    @test cov(d) === Diagonal(Fill(var(Laplace(0.0, 2.3)), N))
+end
+


### PR DESCRIPTION
`Product(Fill(...))` is useful for iid distributions.
```julia
julia> using Random, Distributions, FillArrays

julia> rng = Random.default_rng();

julia> x = Vector{Float64}(undef, 4);

julia> x .= rand.(rng, Fill(Exponential(2.3), 4))
4-element Vector{Float64}:
 1.9539101912937518
 1.9539101912937518
 1.9539101912937518
 1.9539101912937518

julia> map!(Base.Fix1(rand, rng), x, Fill(Exponential(2.3), 4))
4-element Vector{Float64}:
 8.827816210804809
 0.4896979114931074
 1.6137874001903105
 1.0617829479264902
```
I haven't really looked into the problem, but am guessing that `FillArray`s overloads broadcasts, causing the same value of `rand` to fill all values of the result. Using `map!` instead avoids this problem.