### PR TITLE
Add `-(::MvNormal, ::AbstractVector)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.52"
+version = "0.25.53"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -291,11 +291,11 @@ end
 
 ### Affine transformations
 
-+(d::MvNormal, c::AbstractVector) = MvNormal(d.μ .+ c, d.Σ)
+Base.:+(d::MvNormal, c::AbstractVector) = MvNormal(d.μ + c, d.Σ)
+Base.:+(c::AbstractVector, d::MvNormal) = d + c
+Base.:-(d::MvNormal, c::AbstractVector) = MvNormal(d.μ - c, d.Σ)
 
-+(c::AbstractVector, d::MvNormal) = d + c
-
-*(B::AbstractMatrix, d::MvNormal) = MvNormal(B * d.μ, X_A_Xt(d.Σ, B))
+Base.:*(B::AbstractMatrix, d::MvNormal) = MvNormal(B * d.μ, X_A_Xt(d.Σ, B))
 
 dot(b::AbstractVector, d::MvNormal) = Normal(dot(d.μ, b), √quad(d.Σ, b))
 

--- a/test/mvnormal.jl
+++ b/test/mvnormal.jl
@@ -259,8 +259,12 @@ end
 
                 d_c = d + c
                 c_d = c + d
-                @test mean(d_c) == mean(c_d) == μ .+ c
+                @test mean(d_c) == mean(c_d) == μ + c
                 @test cov(c_d) == cov(d_c) == cov(d)
+
+                d_c = d - c
+                @test mean(d_c) == μ - c
+                @test cov(d_c) == cov(d)
 
                 B_d = B * d
                 @test B_d isa MvNormal


### PR DESCRIPTION
Fixes #1518.

Replaces #1524 with a simpler less general but more efficient implementation that avoids potential method ambiguity errors, surprising error messages, and definitions of `-` for incompatible and intentionally unsupported types (such as, e.g., `-(::MvNormal, ::MvNormal)`, `-(::MvNormal, ::Real)` or `-(::MvNormal, ::AbstractArray{<:Real,N})` for `N != 1`.

I checked and currently `MvNormal` is the only multivariate distribution for which addition with vectors is implemented. Hence no other fixes are needed currently. In a future PR probably we should generalize `AffineDistribution` - but even then we would like to keep the definition in this PR in addition to a generic fallback since it avoids unnecessary allocations.