### PR TITLE
Collect a `MixtureModel` of `DiscreteNonParametric`s into a `DiscreteNonParametric`

### DIFF
--- a/src/univariate/discrete/discretenonparametric.jl
+++ b/src/univariate/discrete/discretenonparametric.jl
@@ -312,3 +312,9 @@ end
 fit_mle(::Type{<:DiscreteNonParametric},
         ss::DiscreteNonParametricStats{T,W,Ts,Ws}) where {T,W,Ts,Ws} =
     DiscreteNonParametric{T,W,Ts,Ws}(ss.support, normalize!(copy(ss.freq), 1), check_args=false)
+
+# Collect a MixtureModel of DiscreteNonParametrics
+function Distributions.DiscreteNonParametric(mm::MixtureModel{<:VariateForm,Discrete,DiscreteNonParametric{T,P,Ts,Ps}}) where {T,P,Ts,Ps}
+	supp = unique(reduce(vcat, (support(m) for m in components(mm))))
+	DiscreteNonParametric(supp, pdf.(mm, supp))
+end


### PR DESCRIPTION
It is sometimes convenient to "collect" a `MixtureModel` of `DiscreteNonParametric`s into a single `DiscreteNonParametric` object. This PR implements this as an additional constructor but I guess can also be a function with a different name if that is preferred. I was not sure whether to put it in `discretenonparametric.jl` or `mixturemodel.jl`, to me it seemed more specific to `DiscreteNonParametric` than to `MixtureModel`. The implementation is quite trivial however I benchmarked several similar ways of collecting the support:
```
f1(mm) = unique(vcat(support.(components(mm))...))
f2(mm) = unique(reduce(vcat, support.(components(mm))))
f3(mm) = unique(reduce(vcat, (support(m) for m in components(mm)))) # eventually chosen

N = 100000
# create some overlapping support
n = 5000
a1 = sample(1:N, n, replace=false, ordered=true)
a2 = sample(1:N, n, replace=false)
idx = rand(1:n, 2500)
a2 = [a2; a1[idx]] |> unique |> sort
# create some pdf, not actually relevant
b1 = rand(n)
b1 /= sum(b1)
b2 = rand(length(a2))
b2 /= sum(b2)
d1 = DiscreteNonParametric(a1,b1)
d2 = DiscreteNonParametric(a2,b2)
mm = MixtureModel([d1,d2])


julia> @btime f1($mm);
  438.500 μs (34 allocations: 612.31 KiB)

julia> @btime f2($mm);
  438.100 μs (35 allocations: 612.39 KiB)

julia> @btime f3($mm);
  437.200 μs (33 allocations: 612.25 KiB)
```