### PR TITLE
Add analytical formula for KL of two `Laplace`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.53"
+version = "0.25.54"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/functionals.jl
+++ b/src/functionals.jl
@@ -26,9 +26,9 @@ mcexpectation(rng, f, sampler, n) = sum(f, rand(rng, sampler) for _ in 1:n) / n
 #     expectation(distr, x -> -log(f(x)))
 # end
 
-function kldivergence(P::Distribution{V}, Q::Distribution{V}; kwargs...) where {V<:VariateForm}
-    return expectation(P; kwargs...) do x
-        logp = logpdf(P, x)
-        return (logp > oftype(logp, -Inf)) * (logp - logpdf(Q, x))
+function kldivergence(p::Distribution{V}, q::Distribution{V}; kwargs...) where {V<:VariateForm}
+    return expectation(p; kwargs...) do x
+        logp = logpdf(p, x)
+        return (logp > oftype(logp, -Inf)) * (logp - logpdf(q, x))
     end
 end

--- a/src/univariate/continuous/laplace.jl
+++ b/src/univariate/continuous/laplace.jl
@@ -72,8 +72,10 @@ kurtosis(d::Laplace{T}) where {T<:Real} = 3one(T)
 entropy(d::Laplace) = log(2d.θ) + 1
         
 function kldivergence(p::Laplace, q::Laplace)
-    r = abs(p.μ - q.μ)
-    return (p.θ * exp(-r / p.θ) + r) / q.θ + log(q.θ / p.θ) - 1
+    pμ, pθ = params(p)
+    qμ, qθ = params(q)
+    r = abs(pμ - qμ)
+    return (pθ * exp(-r / pθ) + r) / qθ + log(qθ / pθ) - 1
 end
 
 #### Evaluations

--- a/src/univariate/continuous/laplace.jl
+++ b/src/univariate/continuous/laplace.jl
@@ -71,9 +71,9 @@ kurtosis(d::Laplace{T}) where {T<:Real} = 3one(T)
 
 entropy(d::Laplace) = log(2d.θ) + 1
         
-function kldivergence(P::Laplace, Q::Laplace)
-    r = abs(P.μ - Q.μ)
-    return (P.θ * exp(-r / P.θ) + r) / Q.θ + log(Q.θ / P.θ) - 1
+function kldivergence(p::Laplace, q::Laplace)
+    r = abs(p.μ - q.μ)
+    return (p.θ * exp(-r / p.θ) + r) / q.θ + log(q.θ / p.θ) - 1
 end
 
 #### Evaluations

--- a/src/univariate/continuous/laplace.jl
+++ b/src/univariate/continuous/laplace.jl
@@ -70,6 +70,11 @@ skewness(d::Laplace{T}) where {T<:Real} = zero(T)
 kurtosis(d::Laplace{T}) where {T<:Real} = 3one(T)
 
 entropy(d::Laplace) = log(2d.θ) + 1
+        
+function kldivergence(P::Laplace, Q::Laplace)
+    r = abs(P.μ - Q.μ)
+    return (P.θ * exp(-r / P.θ) + r) / Q.θ + log(Q.θ / P.θ) - 1
+end
 
 #### Evaluations
 

--- a/test/functionals.jl
+++ b/test/functionals.jl
@@ -90,6 +90,11 @@ end
             p0 = Poisson(0.0)
             test_kl(p0, p)
         end
+        @testset "Laplace" begin
+            p = Laplace(2.0)
+            q = Laplace(3.0)
+            test_kl(p, q)
+        end
     end
 
     @testset "multivariate" begin

--- a/test/functionals.jl
+++ b/test/functionals.jl
@@ -76,6 +76,11 @@ end
             q = InverseGamma(3.0, 2.0)
             test_kl(p, q)
         end
+        @testset "Laplace" begin
+            p = Laplace(2.0)
+            q = Laplace(3.0)
+            test_kl(p, q)
+        end
         @testset "Normal" begin
             p = Normal(0, 1)
             q = Normal(0.5, 0.5)
@@ -89,11 +94,6 @@ end
             # special case (test function also checks `kldivergence(p0, p0)`)
             p0 = Poisson(0.0)
             test_kl(p0, p)
-        end
-        @testset "Laplace" begin
-            p = Laplace(2.0)
-            q = Laplace(3.0)
-            test_kl(p, q)
         end
     end
 


### PR DESCRIPTION
This gives a speedup by over four orders of magnitude.

Before:

```julia
julia> @btime kldivergence(Laplace(0., 1.), Laplace(1., 2.))
  31.333 μs (402 allocations: 9.22 KiB)
0.37708690051216676
```

After:

```julia
julia> @btime kldivergence(Laplace(0., 1.), Laplace(1., 2.))
  1.500 ns (0 allocations: 0 bytes)
0.37708690114566634
```