### PR TITLE
Add analytical formula for KL between `LogNormal`, `LogitNormal`, and `NormalCanon`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.54"
+version = "0.25.56"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/univariate/continuous/logitnormal.jl
+++ b/src/univariate/continuous/logitnormal.jl
@@ -103,7 +103,7 @@ scale(d::LogitNormal) = d.σ
 
 median(d::LogitNormal) = logistic(d.μ)
 
-#### Evalution
+#### Evaluation
 
 #TODO check pd and logpdf
 function pdf(d::LogitNormal{T}, x::Real) where T<:Real

--- a/src/univariate/continuous/logitnormal.jl
+++ b/src/univariate/continuous/logitnormal.jl
@@ -103,6 +103,12 @@ scale(d::LogitNormal) = d.σ
 
 median(d::LogitNormal) = logistic(d.μ)
 
+function kldivergence(p::LogitNormal, q::LogitNormal)
+    pn = Normal{partype(p)}(p.μ, p.σ)
+    qn = Normal{partype(q)}(q.μ, q.σ)
+    return kldivergence(pn, qn)
+end
+
 #### Evaluation
 
 #TODO check pd and logpdf

--- a/src/univariate/continuous/lognormal.jl
+++ b/src/univariate/continuous/lognormal.jl
@@ -89,7 +89,7 @@ function entropy(d::LogNormal)
     (1 + log(twoπ * σ^2))/2 + μ
 end
 
-function Distributions.kldivergence(p::LogNormal, q::LogNormal)
+function kldivergence(p::LogNormal, q::LogNormal)
     pn = Normal{partype(p)}(p.μ, p.σ)
     qn = Normal{partype(q)}(q.μ, q.σ)
     return kldivergence(pn, qn)

--- a/src/univariate/continuous/lognormal.jl
+++ b/src/univariate/continuous/lognormal.jl
@@ -96,7 +96,7 @@ function kldivergence(p::LogNormal, q::LogNormal)
 end
 
 
-#### Evalution
+#### Evaluation
 
 function pdf(d::LogNormal, x::Real)
     if x ≤ zero(x)

--- a/src/univariate/continuous/lognormal.jl
+++ b/src/univariate/continuous/lognormal.jl
@@ -89,6 +89,12 @@ function entropy(d::LogNormal)
     (1 + log(twoπ * σ^2))/2 + μ
 end
 
+function Distributions.kldivergence(p::LogNormal, q::LogNormal)
+    pn = Normal(p.μ, p.σ)
+    qn = Normal(q.μ, q.σ)
+    return kldivergence(pn, qn)
+end
+
 
 #### Evalution
 

--- a/src/univariate/continuous/lognormal.jl
+++ b/src/univariate/continuous/lognormal.jl
@@ -90,8 +90,8 @@ function entropy(d::LogNormal)
 end
 
 function Distributions.kldivergence(p::LogNormal, q::LogNormal)
-    pn = Normal(p.μ, p.σ)
-    qn = Normal(q.μ, q.σ)
+    pn = Normal{partype(p)}(p.μ, p.σ)
+    qn = Normal{partype(q)}(q.μ, q.σ)
     return kldivergence(pn, qn)
 end
 

--- a/src/univariate/continuous/lognormal.jl
+++ b/src/univariate/continuous/lognormal.jl
@@ -95,7 +95,6 @@ function kldivergence(p::LogNormal, q::LogNormal)
     return kldivergence(pn, qn)
 end
 
-
 #### Evaluation
 
 function pdf(d::LogNormal, x::Real)

--- a/src/univariate/continuous/normalcanon.jl
+++ b/src/univariate/continuous/normalcanon.jl
@@ -59,6 +59,12 @@ entropy(d::NormalCanon) = (-log(d.λ) + log2π + 1) / 2
 location(d::NormalCanon) = mean(d)
 scale(d::NormalCanon) = std(d)
 
+function kldivergence(p::NormalCanon, q::NormalCanon)
+    pn = convert(Normal, p)
+    qn = convert(Normal, q)
+    return kldivergence(pn, qn)
+end
+
 #### Evaluation
 
 pdf(d::NormalCanon, x::Real) = (sqrt(d.λ) / sqrt2π) * exp(-d.λ * abs2(x - d.μ)/2)

--- a/src/univariate/continuous/normalcanon.jl
+++ b/src/univariate/continuous/normalcanon.jl
@@ -60,9 +60,10 @@ location(d::NormalCanon) = mean(d)
 scale(d::NormalCanon) = std(d)
 
 function kldivergence(p::NormalCanon, q::NormalCanon)
-    pn = convert(Normal, p)
-    qn = convert(Normal, q)
-    return kldivergence(pn, qn)
+    μp = mean(p)
+    μq = mean(q)
+    σ²p_over_σ²q = q.λ / p.λ
+    return (abs2(μp - μq) * q.λ - logmxp1(σ²p_over_σ²q)) / 2
 end
 
 #### Evaluation

--- a/src/univariate/continuous/skewnormal.jl
+++ b/src/univariate/continuous/skewnormal.jl
@@ -49,7 +49,7 @@ kurtosis(d::SkewNormal) = 2 * (π-3) * ((delta(d) * sqrt(2/π))^4/(1-2 * (delta(
 m_0(d::SkewNormal) = mean_z(d) - (skewness(d) * std_z(d))/2 - (sign(d.α)/2) * exp(-2π/abs(d.α))
 mode(d::SkewNormal) = d.ξ + d.ω * m_0(d)  
 
-#### Evalution
+#### Evaluation
 pdf(d::SkewNormal, x::Real) = (2/d.ω) * normpdf((x-d.ξ)/d.ω) * normcdf(d.α * (x-d.ξ)/d.ω)
 logpdf(d::SkewNormal, x::Real) = log(2) - log(d.ω) + normlogpdf((x-d.ξ) / d.ω) + normlogcdf(d.α * (x-d.ξ) / d.ω)
 #cdf requires Owen's T function.

--- a/test/functionals.jl
+++ b/test/functionals.jl
@@ -76,6 +76,12 @@ end
             q = InverseGamma(3.0, 2.0)
             test_kl(p, q)
         end
+        @testset "LogNormal" begin
+            p = LogNormal(0, 1)
+            q = LogNormal(0.5, 0.5)
+            test_kl(p, q)
+            @test kldivergence(p, q) ≈ kldivergence(Normal(0, 1), Normal(0.5, 0.5))
+        end
         @testset "Normal" begin
             p = Normal(0, 1)
             q = Normal(0.5, 0.5)

--- a/test/functionals.jl
+++ b/test/functionals.jl
@@ -98,6 +98,12 @@ end
             q = Normal(0.5, 0.5)
             test_kl(p, q)
         end
+        @testset "NormalCanon" begin
+            p = NormalCanon(1, 2)
+            q = NormalCanon(3, 4)
+            test_kl(p, q)
+            @test kldivergence(p, q) ≈ kldivergence(Normal(1/2, 1/sqrt(2)), Normal(3/4, 1/2))
+        end
         @testset "Poisson" begin
             p = Poisson(4.0)
             q = Poisson(3.0)

--- a/test/functionals.jl
+++ b/test/functionals.jl
@@ -87,6 +87,12 @@ end
             test_kl(p, q)
             @test kldivergence(p, q) ≈ kldivergence(Normal(0, 1), Normal(0.5, 0.5))
         end
+        @testset "LogitNormal" begin
+            p = LogitNormal(0, 1)
+            q = LogitNormal(0.5, 0.5)
+            test_kl(p, q)
+            @test kldivergence(p, q) ≈ kldivergence(Normal(0, 1), Normal(0.5, 0.5))
+        end
         @testset "Normal" begin
             p = Normal(0, 1)
             q = Normal(0.5, 0.5)


### PR DESCRIPTION
Here, I chose to refer back to the `Normal` case.
I tried to use `params` with a splat, but that was slightly slower than using the explicit fields.
Since each field only appears once and the field names of `Normal` are unlikely to change, that should be fine.