### PR TITLE
Do not include docstring for deprecated `TruncatedNormal`

### DIFF
--- a/docs/src/truncate.md
+++ b/docs/src/truncate.md
@@ -41,8 +41,4 @@ are defined for all truncated univariate distributions:
 
 Functions to compute statistics, such as `mean`, `mode`, `var`, `std`, and `entropy`, are not available for generic truncated distributions.
 Generally, there are no easy ways to compute such quantities due to the complications incurred by truncation.
-However, these methods are supported for truncated normal distributions `Truncated{<:Normal}`.
-
-```@docs
-TruncatedNormal
-```
+However, these methods are supported for truncated normal distributions `Truncated{<:Normal}` which can be constructed with `truncated(::Normal, ...)`.


### PR DESCRIPTION
`TruncatedNormal` is deprecated, hence it seems a bit strange (and possibly misleading) to include it in the documentation.