### PR TITLE
Fix fitting `Uniform` with `OffsetArray`s

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.58"
+version = "0.25.59"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -37,9 +37,10 @@ Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["StableRNGs", "Calculus", "ChainRulesTestUtils", "Distributed", "FiniteDifferences", "ForwardDiff", "JSON", "StaticArrays", "Test"]
+test = ["StableRNGs", "Calculus", "ChainRulesTestUtils", "Distributed", "FiniteDifferences", "ForwardDiff", "JSON", "StaticArrays", "Test", "OffsetArrays"]

--- a/src/univariate/continuous/uniform.jl
+++ b/src/univariate/continuous/uniform.jl
@@ -125,22 +125,11 @@ _rand!(rng::AbstractRNG, d::Uniform, A::AbstractArray{<:Real}) =
 
 #### Fitting
 
-function fit_mle(::Type{<:Uniform}, x::AbstractArray{T}) where T<:Real
+function fit_mle(::Type{<:Uniform}, x::AbstractArray{<:Real})
     if isempty(x)
         throw(ArgumentError("x cannot be empty."))
     end
-
-    xmin = xmax = x[1]
-    for i = 2:length(x)
-        xi = x[i]
-        if xi < xmin
-            xmin = xi
-        elseif xi > xmax
-            xmax = xi
-        end
-    end
-
-    Uniform(xmin, xmax)
+    return Uniform(extrema(x)...)
 end
 
 # ChainRules definitions

--- a/test/discreteuniform.jl
+++ b/test/discreteuniform.jl
@@ -1,4 +1,7 @@
 using Distributions
+using OffsetArrays
+
+using Random
 using Test
 
 # #1474
@@ -17,4 +20,11 @@ end
 @testset "type stability regression tests" begin
     @test @inferred(mgf(DiscreteUniform(2, 5), 0//1)) === 1.0
     @test @inferred(cf(DiscreteUniform(1, 3), 0//1)) === 1.0 + 0.0im
+end
+
+@testset "fit: array indexing (#1253)" begin
+    x = shuffle(10:20)
+    for data in (x, OffsetArray(x, -5:5))
+        @test fit(DiscreteUniform, data) == DiscreteUniform(10, 20)
+    end
 end

--- a/test/uniform.jl
+++ b/test/uniform.jl
@@ -1,5 +1,8 @@
 using Distributions
 using ChainRulesTestUtils
+using OffsetArrays
+
+using Random
 using Test
 
 @testset "uniform.jl" begin
@@ -35,6 +38,13 @@ using Test
                 ChainRulesTestUtils.Tangent{Uniform{Float64}}(; a=0.0, b=0.0),
                 ChainRulesTestUtils.ZeroTangent(),
             )
+        end
+    end
+
+    @testset "fit: array indexing (#1253)" begin
+        x = shuffle(10:20)
+        for data in (x, OffsetArray(x, -5:5))
+            @test fit(Uniform, data) == Uniform(10, 20)
         end
     end
 end


### PR DESCRIPTION
Fixes #1253 and adds tests for it. The case of `DiscreteUniform` was already fixed in #1475.