### PR TITLE
Fix sampling from truncated distribution with small mass

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.58"
+version = "0.25.59"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/test/truncate.jl
+++ b/test/truncate.jl
@@ -132,11 +132,11 @@ for (μ, lower, upper) in [(0, -1, 1), (1, 2, 4)]
     @test truncated(Normal(μ, 1); lower=lower, upper=upper) === d
 end
 for bound in (-2, 1)
-    d = Distributions.Truncated(Normal(), Float64(bound), Inf)
+    d = @test_deprecated Distributions.Truncated(Normal(), Float64(bound), Inf)
     @test truncated(Normal(); lower=bound) == d
     @test truncated(Normal(); lower=bound, upper=Inf) == d
 
-    d = Distributions.Truncated(Normal(), -Inf, Float64(bound))
+    d = @test_deprecated Distributions.Truncated(Normal(), -Inf, Float64(bound))
     @test truncated(Normal(); upper=bound) == d
     @test truncated(Normal(); lower=-Inf, upper=bound) == d
 end
@@ -184,4 +184,10 @@ end
     @test sprint(show, "text/plain", truncated(Normal(); lower=2.0)) == "Truncated($(Normal()); lower=2.0)"
     @test sprint(show, "text/plain", truncated(Normal(); upper=3.0)) == "Truncated($(Normal()); upper=3.0)"
     @test sprint(show, "text/plain", truncated(Normal(), 2.0, 3.0)) == "Truncated($(Normal()); lower=2.0, upper=3.0)"
+end
+
+@testset "sampling with small mass (#1548)" begin
+    d = truncated(Beta(10, 100); lower=0.5)
+    x = rand(d, 10_000)
+    @test mean(x) ≈ 0.5 atol=0.05
 end


### PR DESCRIPTION
This PR fixes sampling from truncated distributions whose mass (in terms of the original untruncated distribution) is tiny.

Fixes https://github.com/JuliaStats/Distributions.jl/issues/1548.