### PR TITLE
Improve Bernoulli and Binomial

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.60"
+version = "0.25.61"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/univariate/discrete/bernoulli.jl
+++ b/src/univariate/discrete/bernoulli.jl
@@ -122,7 +122,7 @@ BernoulliStats(c0::Real, c1::Real) = BernoulliStats(promote(c0, c1)...)
 
 fit_mle(::Type{<:Bernoulli}, ss::BernoulliStats) = Bernoulli(ss.cnt1 / (ss.cnt0 + ss.cnt1))
 
-function suffstats(::Type{<:Bernoulli}, x::AbstractArray{T}) where T<:Integer
+function suffstats(::Type{<:Bernoulli}, x::AbstractArray{<:Integer})
     c0 = c1 = 0
     for xi in x
         if xi == 0
@@ -136,9 +136,10 @@ function suffstats(::Type{<:Bernoulli}, x::AbstractArray{T}) where T<:Integer
     BernoulliStats(c0, c1)
 end
 
-function suffstats(::Type{<:Bernoulli}, x::AbstractArray{T}, w::AbstractArray{<:Real}) where T<:Integer
+function suffstats(::Type{<:Bernoulli}, x::AbstractArray{<:Integer}, w::AbstractArray{<:Real})
     length(x) == length(w) || throw(DimensionMismatch("inconsistent argument dimensions"))
-    c0 = c1 = zero(eltype(w))
+    z = zero(eltype(w))
+    c0 = c1 = z + z # possibly widened and different from `z`, e.g., if `z = true`
     for (xi, wi) in zip(x, w)
         if xi == 0
             c0 += wi

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -156,31 +156,28 @@ end
 
 #### Fit model
 
-struct BinomialStats <: SufficientStats
-    ns::Float64   # the total number of successes
-    ne::Float64   # the number of experiments
+struct BinomialStats{N<:Real} <: SufficientStats
+    ns::N         # the total number of successes
+    ne::N         # the number of experiments
     n::Int        # the number of trials in each experiment
-
-    BinomialStats(ns::Real, ne::Real, n::Integer) = new(ns, ne, n)
 end
+
+BinomialStats(ns::Real, ne::Real, n::Integer) = BinomialStats(promote(ns, ne)..., n)
 
 function suffstats(::Type{<:Binomial}, n::Integer, x::AbstractArray{T}) where T<:Integer
     ns = zero(T)
-    for i = 1:length(x)
-        @inbounds xi = x[i]
-        0 <= xi <= n || throw(DomainError())
+    for xi in x
+        0 <= xi <= n || throw(DomainError(xi, "samples must be between 0 and $n"))
         ns += xi
     end
     BinomialStats(ns, length(x), n)
 end
 
-function suffstats(::Type{<:Binomial}, n::Integer, x::AbstractArray{T}, w::AbstractArray{Float64}) where T<:Integer
-    ns = 0.
-    ne = 0.
-    for i = 1:length(x)
-        @inbounds xi = x[i]
-        @inbounds wi = w[i]
-        0 <= xi <= n || throw(DomainError())
+function suffstats(::Type{<:Binomial}, n::Integer, x::AbstractArray{T}, w::AbstractArray{<:Real}) where T<:Integer
+    ns = zero(T) * zero(eltype(w))
+    ne = zero(eltype(w))
+    for (xi, wi) in zip(x, w)
+        0 <= xi <= n || throw(DomainError(xi, "samples must be between 0 and $n"))
         ns += xi * wi
         ne += wi
     end
@@ -190,14 +187,14 @@ end
 const BinomData = Tuple{Int, AbstractArray}
 
 suffstats(::Type{<:Binomial}, data::BinomData) = suffstats(Binomial, data...)
-suffstats(::Type{<:Binomial}, data::BinomData, w::AbstractArray{Float64}) = suffstats(Binomial, data..., w)
+suffstats(::Type{<:Binomial}, data::BinomData, w::AbstractArray{<:Real}) = suffstats(Binomial, data..., w)
 
 fit_mle(::Type{<:Binomial}, ss::BinomialStats) = Binomial(ss.n, ss.ns / (ss.ne * ss.n))
 
 fit_mle(::Type{<:Binomial}, n::Integer, x::AbstractArray{T}) where {T<:Integer} = fit_mle(Binomial, suffstats(Binomial, n, x))
-fit_mle(::Type{<:Binomial}, n::Integer, x::AbstractArray{T}, w::AbstractArray{Float64}) where {T<:Integer} = fit_mle(Binomial, suffstats(Binomial, n, x, w))
+fit_mle(::Type{<:Binomial}, n::Integer, x::AbstractArray{T}, w::AbstractArray{<:Real}) where {T<:Integer} = fit_mle(Binomial, suffstats(Binomial, n, x, w))
 fit_mle(::Type{<:Binomial}, data::BinomData) = fit_mle(Binomial, suffstats(Binomial, data))
-fit_mle(::Type{<:Binomial}, data::BinomData, w::AbstractArray{Float64}) = fit_mle(Binomial, suffstats(Binomial, data, w))
+fit_mle(::Type{<:Binomial}, data::BinomData, w::AbstractArray{<:Real}) = fit_mle(Binomial, suffstats(Binomial, data, w))
 
 fit(::Type{<:Binomial}, data::BinomData) = fit_mle(Binomial, data)
-fit(::Type{<:Binomial}, data::BinomData, w::AbstractArray{Float64}) = fit_mle(Binomial, data, w)
+fit(::Type{<:Binomial}, data::BinomData, w::AbstractArray{<:Real}) = fit_mle(Binomial, data, w)

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -162,10 +162,11 @@ struct BinomialStats{N<:Real} <: SufficientStats
     n::Int        # the number of trials in each experiment
 end
 
-BinomialStats(ns::Real, ne::Real, n::Integer) = BinomialStats(promote(ns, ne)..., n)
+BinomialStats(ns::Real, ne::Real, n::Integer) = BinomialStats(promote(ns, ne)..., Int(n))
 
-function suffstats(::Type{<:Binomial}, n::Integer, x::AbstractArray{T}) where T<:Integer
-    ns = zero(T)
+function suffstats(::Type{<:Binomial}, n::Integer, x::AbstractArray{<:Integer})
+    z = zero(eltype(x))
+    ns = z + z # possibly widened and different from `z`, e.g., if `z = true`
     for xi in x
         0 <= xi <= n || throw(DomainError(xi, "samples must be between 0 and $n"))
         ns += xi
@@ -173,9 +174,9 @@ function suffstats(::Type{<:Binomial}, n::Integer, x::AbstractArray{T}) where T<
     BinomialStats(ns, length(x), n)
 end
 
-function suffstats(::Type{<:Binomial}, n::Integer, x::AbstractArray{T}, w::AbstractArray{<:Real}) where T<:Integer
-    ns = zero(T) * zero(eltype(w))
-    ne = zero(eltype(w))
+function suffstats(::Type{<:Binomial}, n::Integer, x::AbstractArray{<:Integer}, w::AbstractArray{<:Real})
+    z = zero(eltype(x)) * zero(eltype(w))
+    ns = ne = z + z # possibly widened and different from `z`, e.g., if `z = true`
     for (xi, wi) in zip(x, w)
         0 <= xi <= n || throw(DomainError(xi, "samples must be between 0 and $n"))
         ns += xi * wi
@@ -191,8 +192,8 @@ suffstats(::Type{<:Binomial}, data::BinomData, w::AbstractArray{<:Real}) = suffs
 
 fit_mle(::Type{<:Binomial}, ss::BinomialStats) = Binomial(ss.n, ss.ns / (ss.ne * ss.n))
 
-fit_mle(::Type{<:Binomial}, n::Integer, x::AbstractArray{T}) where {T<:Integer} = fit_mle(Binomial, suffstats(Binomial, n, x))
-fit_mle(::Type{<:Binomial}, n::Integer, x::AbstractArray{T}, w::AbstractArray{<:Real}) where {T<:Integer} = fit_mle(Binomial, suffstats(Binomial, n, x, w))
+fit_mle(::Type{<:Binomial}, n::Integer, x::AbstractArray{<:Integer}) = fit_mle(Binomial, suffstats(Binomial, n, x))
+fit_mle(::Type{<:Binomial}, n::Integer, x::AbstractArray{<:Integer}, w::AbstractArray{<:Real}) = fit_mle(Binomial, suffstats(Binomial, n, x, w))
 fit_mle(::Type{<:Binomial}, data::BinomData) = fit_mle(Binomial, suffstats(Binomial, data))
 fit_mle(::Type{<:Binomial}, data::BinomData, w::AbstractArray{<:Real}) = fit_mle(Binomial, suffstats(Binomial, data, w))
 


### PR DESCRIPTION
Some improvements to `Bernoulli`. Other distributions might benefit from similar changes, but I didn't go through all of them before knowing whether such modifications would be appreciated.

### Changes

- replace `1:length(x)` with `eachindex(x)` so that it works with more arrays, for instance `OffsetArrays`
- initialize the counters `c0` and `c1` with `zero(eltype(w))` so that they are type-stable (previously they were `Int32/Float64`)
- fix the creation of domain error: the void method `DomainError()` does not exist
- make `BernoulliStats` generic so that it can collect counters of more general type, for instance `ForwardDiff.Dual`

### Examples

This new version allows for instance

```julia
using OffsetArrays
x = [0, 1]; w = [1., 2.];
ox = OffsetArray(x, 5); ow = OffsetArray(w, 5);
suffstats(Bernoulli, ox, ow) #=> Distributions.BernoulliStats{Float64}(1.0, 2.0)
```

and

```julia
julia> ForwardDiff.gradient([1.,2.]) do w
           mean(fit_mle(Bernoulli, suffstats(Bernoulli, [0,1], w)))
       end
2-element Vector{Float64}:
 -0.2222222222222222
  0.1111111111111111
```