### PR TITLE
Allow `Product` to represent independent multivariate distributions

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -9,6 +9,7 @@ import Base: sum, maximum, minimum, extrema, +, -, *, ==
 import Base.Math: @horner
 
 using FillArrays
+using SparseArrays: SparseMatrixCSC, sparse, spdiagm, blockdiag
 
 using LinearAlgebra, Printf
 import LinearAlgebra: dot, rank

--- a/src/multivariate/product.jl
+++ b/src/multivariate/product.jl
@@ -4,7 +4,7 @@ import Statistics: mean, var, cov
     Product <: MultivariateDistribution
 
 An N dimensional `MultivariateDistribution` constructed from a vector of N independent
-`UnivariateDistribution`s.
+`Distribution`s.
 
 ```julia
 Product(Uniform.(rand(10), 1)) # A 10-dimensional Product from 10 independent `Uniform` distributions.
@@ -67,13 +67,13 @@ minimum(d::Product) = _flatten(map(minimum, d.v))
 maximum(d::Product) = _flatten(map(maximum, d.v))
 
 """
-    product_distribution(dists::AbstractVector{<:UnivariateDistribution})
+    product_distribution(dists::AbstractVector{<:Distribution})
 
-Creates a multivariate product distribution `P` from a vector of univariate distributions.
+Creates a multivariate product distribution `P` from a vector of distributions.
 Fallback is the `Product constructor`, but specialized methods can be defined
 for distributions with a special multivariate product.
 """
-function product_distribution(dists::AbstractVector{<:UnivariateDistribution})
+function product_distribution(dists::AbstractVector{<:Distribution})
     return Product(dists)
 end
 

--- a/src/multivariate/product.jl
+++ b/src/multivariate/product.jl
@@ -51,6 +51,14 @@ end
 _logpdf(d::Product, x::AbstractVector{<:Real}) =
     sum(n->logpdf(d.v[n], _partitionargs(d, x)[n]), 1:length(d.v))
 
+function _flatten(v::AbstractVector)
+    if all(length.(v) .== 1)
+        return v
+    else
+        return collect(Iterators.flatten(v))
+    end
+end    
+
 function _partitionargs(d::Product, x::AbstractVector{T}) where T<:Real
     dshape = length.(d.v)
     args = Vector{Union{T,Vector{T}}}(undef, length(dshape))
@@ -58,7 +66,7 @@ function _partitionargs(d::Product, x::AbstractVector{T}) where T<:Real
     start_idx = 1
     for (i, n) in enumerate(dshape)
         if n == 1
-            args[i] = x[start_idx + i - 1]
+            args[i] = x[start_idx]
         else
             args[i] = x[start_idx:(start_idx + n - 1)]
         end
@@ -67,8 +75,8 @@ function _partitionargs(d::Product, x::AbstractVector{T}) where T<:Real
     return args
 end
 
-mean(d::Product) = collect(Iterators.flatten(mean.(d.v)))
-var(d::Product) = collect(Iterators.flatten(var.(d.v)))
+mean(d::Product) = _flatten(mean.(d.v))
+var(d::Product) = _flatten(var.(d.v))
 
 function cov(d::Product)
     if all(length.(d.v) .== 1)
@@ -88,8 +96,8 @@ end
 
 entropy(d::Product) = sum(entropy, d.v)
 insupport(d::Product, x::AbstractVector) = all(insupport.(d.v, _partitionargs(d, x)))
-minimum(d::Product) = collect(Iterators.flatten(map(minimum, d.v)))
-maximum(d::Product) = collect(Iterators.flatten(map(maximum, d.v)))
+minimum(d::Product) = _flatten(map(minimum, d.v))
+maximum(d::Product) = _flatten(map(maximum, d.v))
 
 """
     product_distribution(dists::AbstractVector{<:UnivariateDistribution})

--- a/test/product.jl
+++ b/test/product.jl
@@ -90,8 +90,10 @@ end
     @test cov(d) === Diagonal(Fill(var(Laplace(0.0, 2.3)), N))
 end
 
-@testset "Testing non-iid product distributions" begin
+@testset "Testing non-independent product distributions" begin
     Random.seed!(123456)
+
+    # Construct two non-isotropic Gaussians and some iid Laplaces
     N1, N2, N3 = 2, 3, 6
     N = N1 + N2 + N3
 
@@ -111,6 +113,7 @@ end
 
     _diagv(A) = [A[i,i] for i in 1:size(A, 1)]
     
+    # check summary statistics
     @test length(d_product) == N
     @test mean(d_product) ≈ [μ1; μ2; μ3]
     @test var(d_product) ≈ [_diagv(Σ1); _diagv(Σ2); var.(d3)]
@@ -129,5 +132,24 @@ end
     y = rand(d_product)
     @test y isa Vector{eltype(d_product)}
     @test length(y) == N
+end
+
+@testset "Testing independent discrete distributions" begin
+    Random.seed!(123456)
+
+    d1 = Multinomial(10, [0.25, 0.25, 0.5])
+    d2 = Geometric(0.5)
+    N = 4
+
+    d_product = Product([d1, d2])
+
+    @test !insupport(d_product, Fill(0.5, N))
+    @test length(d_product) == N
+    
+    # check sampling
+    y = rand(d_product)
+    @test y isa Vector{eltype(d_product)}
+    @test length(y) == N
+    
 end
 

--- a/test/product.jl
+++ b/test/product.jl
@@ -109,7 +109,7 @@ end
     b3 = randn(N3) .^ 2
     d3 = Laplace.(μ3, b3)
 
-    d_product = Product([d1; d2; d3])
+    d_product = product_distribution([d1; d2; d3])
 
     _diagv(A) = [A[i,i] for i in 1:size(A, 1)]
     
@@ -141,7 +141,7 @@ end
     d2 = Geometric(0.5)
     N = 4
 
-    d_product = Product([d1, d2])
+    d_product = product_distribution([d1, d2])
 
     @test !insupport(d_product, Fill(0.5, N))
     @test length(d_product) == N


### PR DESCRIPTION
This PR extends `Product` to build a multivariate distribution out of a list of independent multivariate or univariate distributions.

All of the existing functionality of `Product` that represents the joint distribution of independent univariate distributions is conceptually unchanged for the joint distribution of independent multivariate distributions.
Functions like `mean`, `cov`, `pdf` etc. can all be assembled out of the independent components in much the same way as in the univariate case.

This PR implements this idea while leaving the previous functionality of `Product` unchanged.
In particular,
* the `Product` type has been extended to allow for a vector of both univariate and multivariate distributions with the same `ValueSupport`. Distributions with mixed variate types may now have types like `Product{Continuous, ContinuousDistribution, Vector{ContinuousDistribution}}`,
* all methods previously implemented for `Product` of univariate distributions have been extended to allow for the multivariate case, and
* the construction of `Product` distributions out of multivariate distributions is identical to that out of univariate distributions. In particular, continuous and discrete distributions cannot be mixed,
* univariate and multivariate distributions can be mixed in the same vector when constructing a product distribution.

Notes
* The existing tests showed no issues, and tests have been written for the new functionality.
* Covariance matrices are block-diagonal, and are represented as `SparseArrays.SparseMatricCSC`s so as not to introduce a `BlockDiagonals.jl` dependency.
* There is an inelegance in `eltype()` --- namely, `eltype(ContinuousDistribution)` returns `Any` rather than `Float64` (and same in the discrete case), as I believe it should. I've put in a workaround, but let me know if this behaviour is expected.

