### PR TITLE
Fix deprecations of `dim`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.62"
+version = "0.25.63"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -21,7 +21,7 @@ import StatsBase: kurtosis, skewness, entropy, mode, modes,
                   fit, kldivergence, loglikelihood, dof, span,
                   params, params!
 
-import PDMats: dim, PDMat, invquad
+import PDMats: PDMat, invquad
 
 using SpecialFunctions
 
@@ -191,7 +191,6 @@ export
     componentwise_logpdf,   # component-wise logpdf for mixture models
     concentration,      # the concentration parameter
     convolve,           # convolve distributions of the same type
-    dim,                # sample dimension of multivariate distribution
     dof,                # get the degree of freedom
     entropy,            # entropy of distribution in nats
     failprob,           # failing probability

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -57,3 +57,7 @@ const MatrixReshaped{S<:ValueSupport,D<:MultivariateDistribution{S}} = ReshapedD
 @deprecate MatrixReshaped(
     d::MultivariateDistribution, n::Integer, p::Integer=n
 ) reshape(d, (n, p))
+
+for D in (:InverseWishart, :LKJ, :MatrixBeta, :MatrixFDist, :Wishart)
+    @eval @deprecate dim(d::$D) size(d, 1)
+end

--- a/src/matrix/inversewishart.jl
+++ b/src/matrix/inversewishart.jl
@@ -29,7 +29,7 @@ end
 #  -----------------------------------------------------------------------------
 
 function InverseWishart(df::T, Ψ::AbstractPDMat{T}) where T<:Real
-    p = dim(Ψ)
+    p = size(Ψ, 1)
     df > p - 1 || throw(ArgumentError("df should be greater than dim - 1."))
     logc0 = invwishart_logc0(df, Ψ)
     R = Base.promote_eltype(T, logc0)
@@ -74,31 +74,31 @@ end
 insupport(::Type{InverseWishart}, X::Matrix) = isposdef(X)
 insupport(d::InverseWishart, X::Matrix) = size(X) == size(d) && isposdef(X)
 
-dim(d::InverseWishart) = dim(d.Ψ)
-size(d::InverseWishart) = (p = dim(d); (p, p))
-rank(d::InverseWishart) = dim(d)
+size(d::InverseWishart) = size(d.Ψ)
+rank(d::InverseWishart) = rank(d.Ψ)
+
 params(d::InverseWishart) = (d.df, d.Ψ)
 @inline partype(d::InverseWishart{T}) where {T<:Real} = T
 
 function mean(d::InverseWishart)
     df = d.df
-    p = dim(d)
+    p = size(d, 1)
     r = df - (p + 1)
     r > 0.0 || throw(ArgumentError("mean only defined for df > p + 1"))
     return Matrix(d.Ψ) * (1.0 / r)
 end
 
-mode(d::InverseWishart) = d.Ψ * inv(d.df + dim(d) + 1.0)
+mode(d::InverseWishart) = d.Ψ * inv(d.df + size(d, 1) + 1.0)
 
 #  https://en.wikipedia.org/wiki/Inverse-Wishart_distribution#Moments
 function cov(d::InverseWishart, i::Integer, j::Integer, k::Integer, l::Integer)
-    p, ν, Ψ = (dim(d), d.df, Matrix(d.Ψ))
+    p, ν, Ψ = (size(d, 1), d.df, Matrix(d.Ψ))
     ν > p + 3 || throw(ArgumentError("cov only defined for df > dim + 3"))
     inv((ν - p)*(ν - p - 3)*(ν - p - 1)^2)*(2Ψ[i,j]*Ψ[k,l] + (ν-p-1)*(Ψ[i,k]*Ψ[j,l] + Ψ[i,l]*Ψ[k,j]))
 end
 
 function var(d::InverseWishart, i::Integer, j::Integer)
-    p, ν, Ψ = (dim(d), d.df, Matrix(d.Ψ))
+    p, ν, Ψ = (size(d, 1), d.df, Matrix(d.Ψ))
     ν > p + 3 || throw(ArgumentError("var only defined for df > dim + 3"))
     inv((ν - p)*(ν - p - 3)*(ν - p - 1)^2)*((ν - p + 1)*Ψ[i,j]^2 + (ν - p - 1)*Ψ[i,i]*Ψ[j,j])
 end
@@ -109,12 +109,12 @@ end
 
 function invwishart_logc0(df::Real, Ψ::AbstractPDMat)
     h_df = df / 2
-    p = dim(Ψ)
+    p = size(Ψ, 1)
     -h_df * (p * typeof(df)(logtwo) - logdet(Ψ)) - logmvgamma(p, h_df)
 end
 
 function logkernel(d::InverseWishart, X::AbstractMatrix)
-    p = dim(d)
+    p = size(d, 1)
     df = d.df
     Xcf = cholesky(X)
     # we use the fact: tr(Ψ * inv(X)) = tr(inv(X) * Ψ) = tr(X \ Ψ)

--- a/src/matrix/lkj.jl
+++ b/src/matrix/lkj.jl
@@ -66,15 +66,14 @@ end
 #  Properties
 #  -----------------------------------------------------------------------------
 
-dim(d::LKJ) = d.d
 
-size(d::LKJ) = (dim(d), dim(d))
+size(d::LKJ) = (d.d, d.d)
 
-rank(d::LKJ) = dim(d)
+rank(d::LKJ) = d.d
 
 insupport(d::LKJ, R::AbstractMatrix) = isreal(R) && size(R) == size(d) && isone(Diagonal(R)) && isposdef(R)
 
-mean(d::LKJ) = Matrix{partype(d)}(I, dim(d), dim(d))
+mean(d::LKJ) = Matrix{partype(d)}(I, d.d, d.d)
 
 function mode(d::LKJ; check_args::Bool=true)
     @check_args(
@@ -86,7 +85,7 @@ function mode(d::LKJ; check_args::Bool=true)
 end
 
 function var(lkj::LKJ)
-    d = dim(lkj)
+    d = lkj.d
     d > 1 || return zeros(d, d)
     σ² = var(_marginal(lkj))
     σ² * (ones(partype(lkj), d, d) - I)

--- a/src/matrix/matrixbeta.jl
+++ b/src/matrix/matrixbeta.jl
@@ -72,15 +72,13 @@ end
 #  Properties
 #  -----------------------------------------------------------------------------
 
-dim(d::MatrixBeta) = dim(d.W1)
-
 size(d::MatrixBeta) = size(d.W1)
 
-rank(d::MatrixBeta) = dim(d)
+rank(d::MatrixBeta) = rank(d.W1)
 
 insupport(d::MatrixBeta, U::AbstractMatrix) = isreal(U) && size(U) == size(d) && isposdef(U) && isposdef(I - U)
 
-params(d::MatrixBeta) = (dim(d), d.W1.df, d.W2.df)
+params(d::MatrixBeta) = (size(d, 1), d.W1.df, d.W2.df)
 
 mean(d::MatrixBeta) = ((p, n1, n2) = params(d); Matrix((n1 / (n1 + n2)) * I, p, p))
 

--- a/src/matrix/matrixfdist.jl
+++ b/src/matrix/matrixfdist.jl
@@ -41,7 +41,7 @@ end
 #  -----------------------------------------------------------------------------
 
 function MatrixFDist(n1::Real, n2::Real, B::AbstractPDMat)
-    p = dim(B)
+    p = size(B, 1)
     n1 > p - 1 || throw(ArgumentError("first degrees of freedom must be larger than $(p - 1)"))
     n2 > p - 1 || throw(ArgumentError("second degrees of freedom must be larger than $(p - 1)"))
     logc0 = matrixfdist_logc0(n1, n2, B)
@@ -78,18 +78,16 @@ end
 #  Properties
 #  -----------------------------------------------------------------------------
 
-dim(d::MatrixFDist) = dim(d.W)
-
 size(d::MatrixFDist) = size(d.W)
 
-rank(d::MatrixFDist) = dim(d)
+rank(d::MatrixFDist) = rank(d.W)
 
 insupport(d::MatrixFDist, Σ::AbstractMatrix) = isreal(Σ) && size(Σ) == size(d) && isposdef(Σ)
 
 params(d::MatrixFDist) = (d.W.df, d.n2, d.W.S)
 
 function mean(d::MatrixFDist)
-    p = dim(d)
+    p = size(d, 1)
     n1, n2, B = params(d)
     n2 > p + 1 || throw(ArgumentError("mean only defined for df2 > dim + 1"))
     return (n1 / (n2 - p - 1)) * Matrix(B)
@@ -99,7 +97,7 @@ end
 
 #  Konno (1988 JJSS) Corollary 2.4.i
 function cov(d::MatrixFDist, i::Integer, j::Integer, k::Integer, l::Integer)
-    p = dim(d)
+    p = size(d, 1)
     n1, n2, PDB = params(d)
     n2 > p + 3 || throw(ArgumentError("cov only defined for df2 > dim + 3"))
     n = n1 + n2
@@ -108,7 +106,7 @@ function cov(d::MatrixFDist, i::Integer, j::Integer, k::Integer, l::Integer)
 end
 
 function var(d::MatrixFDist, i::Integer, j::Integer)
-    p = dim(d)
+    p = size(d, 1)
     n1, n2, PDB = params(d)
     n2 > p + 3 || throw(ArgumentError("var only defined for df2 > dim + 3"))
     n = n1 + n2
@@ -122,14 +120,14 @@ end
 
 function matrixfdist_logc0(n1::Real, n2::Real, B::AbstractPDMat)
     #  returns the natural log of the normalizing constant for the pdf
-    p = dim(B)
+    p = size(B, 1)
     term1 = -logmvbeta(p, n1 / 2, n2 / 2)
     term2 = (n2 / 2) * logdet(B)
     return term1 + term2
 end
 
 function logkernel(d::MatrixFDist, Σ::AbstractMatrix)
-    p = dim(d)
+    p = size(d, 1)
     n1, n2, B = params(d)
     ((n1 - p - 1) / 2) * logdet(Σ) - ((n1 + n2) / 2) * logdet(pdadd(Σ, B))
 end

--- a/src/matrix/matrixnormal.jl
+++ b/src/matrix/matrixnormal.jl
@@ -30,8 +30,8 @@ end
 
 function MatrixNormal(M::AbstractMatrix{T}, U::AbstractPDMat{T}, V::AbstractPDMat{T}) where T <: Real
     n, p = size(M)
-    n == dim(U) || throw(ArgumentError("Number of rows of M must equal dim of U."))
-    p == dim(V) || throw(ArgumentError("Number of columns of M must equal dim of V."))
+    n == size(U, 1) || throw(ArgumentError("Number of rows of M must equal dim of U."))
+    p == size(V, 1) || throw(ArgumentError("Number of columns of M must equal dim of V."))
     logc0 = matrixnormal_logc0(U, V)
     R = Base.promote_eltype(T, logc0)
     prom_M = convert(AbstractArray{R}, M)
@@ -105,8 +105,8 @@ params(d::MatrixNormal) = (d.M, d.U, d.V)
 #  -----------------------------------------------------------------------------
 
 function matrixnormal_logc0(U::AbstractPDMat, V::AbstractPDMat)
-    n = dim(U)
-    p = dim(V)
+    n = size(U, 1)
+    p = size(V, 1)
     -(n * p / 2) * (logtwo + logπ) - (n / 2) * logdet(V) - (p / 2) * logdet(U)
 end
 

--- a/src/matrix/matrixtdist.jl
+++ b/src/matrix/matrixtdist.jl
@@ -50,8 +50,8 @@ end
 function MatrixTDist(ν::T, M::AbstractMatrix{T}, Σ::AbstractPDMat{T}, Ω::AbstractPDMat{T}) where T <: Real
     n, p = size(M)
     0 < ν < Inf || throw(ArgumentError("degrees of freedom must be positive and finite."))
-    n == dim(Σ) || throw(ArgumentError("Number of rows of M must equal dim of Σ."))
-    p == dim(Ω) || throw(ArgumentError("Number of columns of M must equal dim of Ω."))
+    n == size(Σ, 1) || throw(ArgumentError("Number of rows of M must equal dim of Σ."))
+    p == size(Ω, 1) || throw(ArgumentError("Number of columns of M must equal dim of Ω."))
     logc0 = matrixtdist_logc0(Σ, Ω, ν)
     R = Base.promote_eltype(T, logc0)
     prom_M = convert(AbstractArray{R}, M)
@@ -128,8 +128,8 @@ params(d::MatrixTDist) = (d.ν, d.M, d.Σ, d.Ω)
 
 function matrixtdist_logc0(Σ::AbstractPDMat, Ω::AbstractPDMat, ν::Real)
     #  returns the natural log of the normalizing constant for the pdf
-    n = dim(Σ)
-    p = dim(Ω)
+    n = size(Σ, 1)
+    p = size(Ω, 1)
     term1 = logmvgamma(p, (ν + n + p - 1) / 2)
     term2 = - (n * p / 2) * logπ
     term3 = - logmvgamma(p, (ν + p - 1) / 2)

--- a/src/matrix/wishart.jl
+++ b/src/matrix/wishart.jl
@@ -44,7 +44,7 @@ end
 
 function Wishart(df::T, S::AbstractPDMat{T}) where T<:Real
     df > 0 || throw(ArgumentError("df must be positive. got $(df)."))
-    p = dim(S)
+    p = size(S, 1)
     singular = df <= p - 1
     if singular
         isinteger(df) || throw(
@@ -100,8 +100,8 @@ function insupport(d::Wishart, X::AbstractMatrix)
     end
 end
 
-dim(d::Wishart) = dim(d.S)
-size(d::Wishart) = (p = dim(d); (p, p))
+size(d::Wishart) = size(d.S)
+
 rank(d::Wishart) = d.rank
 params(d::Wishart) = (d.df, d.S)
 @inline partype(d::Wishart{T}) where {T<:Real} = T
@@ -109,14 +109,14 @@ params(d::Wishart) = (d.df, d.S)
 mean(d::Wishart) = d.df * Matrix(d.S)
 
 function mode(d::Wishart)
-    r = d.df - dim(d) - 1
+    r = d.df - size(d, 1) - 1
     r > 0 || throw(ArgumentError("mode is only defined when df > p + 1"))
     return Matrix(d.S) * r
 end
 
 function meanlogdet(d::Wishart)
     logdet_S = logdet(d.S)
-    p = dim(d)
+    p = size(d, 1)
     v = logdet_S + p * oftype(logdet_S, logtwo)
     df = oftype(logdet_S, d.df)
     for i in 0:(p - 1)
@@ -127,7 +127,7 @@ end
 
 function entropy(d::Wishart)
     d.singular && throw(ArgumentError("entropy not defined for singular Wishart."))
-    p = dim(d)
+    p = size(d, 1)
     df = d.df
     return -d.logc0 - ((df - p - 1) * meanlogdet(d) - df * p) / 2
 end
@@ -148,7 +148,7 @@ end
 #  -----------------------------------------------------------------------------
 
 function wishart_logc0(df::T, S::AbstractPDMat{T}, rnk::Integer) where {T<:Real}
-    p = dim(S)
+    p = size(S, 1)
     if df <= p - 1
         return singular_wishart_logc0(p, df, S, rnk)
     else
@@ -172,7 +172,7 @@ function singular_wishart_logc0(p::Integer, df::T, S::AbstractPDMat{T}, rnk::Int
 end
 
 function singular_wishart_logkernel(d::Wishart, X::AbstractMatrix)
-    p = dim(d)
+    p = size(d, 1)
     r = rank(d)
     L = eigvals(Hermitian(X), (p - r + 1):p)
     return ((d.df - (p + 1)) * sum(log, L) - tr(d.S \ X)) / 2
@@ -186,7 +186,7 @@ function nonsingular_wishart_logc0(p::Integer, df::T, S::AbstractPDMat{T}) where
 end
 
 function nonsingular_wishart_logkernel(d::Wishart, X::AbstractMatrix)
-    return ((d.df - (dim(d) + 1)) * logdet(cholesky(X)) - tr(d.S \ X)) / 2
+    return ((d.df - (size(d, 1) + 1)) * logdet(cholesky(X)) - tr(d.S \ X)) / 2
 end
 
 #  -----------------------------------------------------------------------------

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -183,7 +183,7 @@ const ZeroMeanFullNormal{Axes} = MvNormal{Float64,PDMat{Float64,Matrix{Float64}}
 
 ### Construction
 function MvNormal(μ::AbstractVector{T}, Σ::AbstractPDMat{T}) where {T<:Real}
-    dim(Σ) == length(μ) || throw(DimensionMismatch("The dimensions of mu and Sigma are inconsistent."))
+    size(Σ, 1) == length(μ) || throw(DimensionMismatch("The dimensions of mu and Sigma are inconsistent."))
     MvNormal{T,typeof(Σ), typeof(μ)}(μ, Σ)
 end
 
@@ -317,7 +317,7 @@ MvNormalKnownCov(d::Int, σ::Real) = MvNormalKnownCov(ScalMat(d, abs2(Float64(σ
 MvNormalKnownCov(σ::Vector{Float64}) = MvNormalKnownCov(PDiagMat(abs2.(σ)))
 MvNormalKnownCov(Σ::Matrix{Float64}) = MvNormalKnownCov(PDMat(Σ))
 
-length(g::MvNormalKnownCov) = dim(g.Σ)
+length(g::MvNormalKnownCov) = size(g.Σ, 1)
 
 struct MvNormalKnownCovStats{Cov<:AbstractPDMat}
     invΣ::Cov              # inverse covariance

--- a/src/multivariate/mvnormalcanon.jl
+++ b/src/multivariate/mvnormalcanon.jl
@@ -57,7 +57,7 @@ const ZeroMeanIsoNormalCanon{Axes}  = MvNormalCanon{Float64,ScalMat{Float64},Zer
 
 ### Constructors
 function MvNormalCanon(μ::AbstractVector{T}, h::AbstractVector{T}, J::AbstractPDMat{T}) where {T<:Real}
-    length(μ) == length(h) == dim(J) || throw(DimensionMismatch("Inconsistent argument dimensions"))
+    length(μ) == length(h) == size(J, 1) || throw(DimensionMismatch("Inconsistent argument dimensions"))
     if typeof(μ) === typeof(h)
         return MvNormalCanon{T,typeof(J),typeof(μ)}(μ, h, J)
     else
@@ -76,7 +76,7 @@ function MvNormalCanon(μ::AbstractVector{<:Real}, h::AbstractVector{<:Real}, J:
 end
 
 function MvNormalCanon(h::AbstractVector{<:Real}, J::AbstractPDMat)
-    length(h) == dim(J) || throw(DimensionMismatch("Inconsistent argument dimensions"))
+    length(h) == size(J, 1) || throw(DimensionMismatch("Inconsistent argument dimensions"))
     R = Base.promote_eltype(h, J)
     hh = convert(AbstractArray{R}, h)
     JJ = convert(AbstractArray{R}, J)

--- a/src/multivariate/mvtdist.jl
+++ b/src/multivariate/mvtdist.jl
@@ -18,7 +18,7 @@ end
 
 function GenericMvTDist(df::T, μ::Mean, Σ::Cov) where {Cov<:AbstractPDMat, Mean<:AbstractVector, T<:Real}
     d = length(μ)
-    dim(Σ) == d || throw(DimensionMismatch("The dimensions of μ and Σ are inconsistent."))
+    size(Σ, 1) == d || throw(DimensionMismatch("The dimensions of μ and Σ are inconsistent."))
     R = Base.promote_eltype(T, μ, Σ)
     S = convert(AbstractArray{R}, Σ)
     m = convert(AbstractArray{R}, μ)
@@ -27,7 +27,7 @@ end
 
 function GenericMvTDist(df::Real, Σ::AbstractPDMat)
     R = Base.promote_eltype(df, Σ)
-    GenericMvTDist(df, Zeros{R}(dim(Σ)), Σ)
+    GenericMvTDist(df, Zeros{R}(size(Σ, 1)), Σ)
 end
 
 GenericMvTDist{T,Cov,Mean}(df, μ, Σ) where {T,Cov,Mean} =

--- a/test/matrixvariates.jl
+++ b/test/matrixvariates.jl
@@ -145,10 +145,11 @@ test_cov(d::LKJ) = nothing
 #  --------------------------------------------------
 
 function test_dim(d::MatrixDistribution)
-    @test dim(d) == size(d, 1)
-    @test dim(d) == size(d, 2)
-    @test dim(d) == size(mean(d), 1)
-    @test dim(d) == size(mean(d), 2)
+    n = @test_deprecated(dim(d))
+    @test n == size(d, 1)
+    @test n == size(d, 2)
+    @test n == size(mean(d), 1)
+    @test n == size(mean(d), 2)
 end
 
 test_dim(d::Union{MatrixNormal, MatrixTDist}) = nothing


### PR DESCRIPTION
This PR fixes the deprecations introduced in the recent release of PDMats (https://github.com/JuliaStats/PDMats.jl/pull/170). Additionally, it deprecates `dim(::Wishart)` etc. to simplify the transition to the next breaking release of PDMats which might not export `dim` anymore.