### PR TITLE
Add `rrule` for `logpdf` of `NegativeBinomial` (completes #1568) 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.64"
+version = "0.25.65"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -153,7 +153,7 @@ function ChainRulesCore.rrule(::typeof(logpdf), d::NegativeBinomial, k::Real)
         Δr = Δ * (log(p) - inv(k + r) - digamma(r) + digamma(r + k + 1))
         Δp = Δ * (r / p - k / (1 - p))
         if edgecase
-            Δp = one(Δp)
+            Δp = Δ * r
         elseif !insupp
             Δr = oftype(Δr, NaN)
             Δp = oftype(Δp, NaN)

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -152,13 +152,13 @@ function ChainRulesCore.rrule(::typeof(logpdf), d::NegativeBinomial, k::Real)
     function logpdf_NegativeBinomial_pullback(Δ)
         Δr = Δ * (log(p) - inv(k + r) - digamma(r) + digamma(r + k + 1))
         Δp = Δ * (r / p - k / (1 - p))
-        Δd = if edgecase
-            ChainRulesCore.Tangent{typeof(d)}(; r=Δr, p=NaN)
+        if edgecase
+            Δp = one(Δp)
         elseif !insupp
-            ChainRulesCore.Tangent{typeof(d)}(; r=zero(Δr), p=zero(Δp))
-        else
-            ChainRulesCore.Tangent{typeof(d)}(; r=Δr, p=Δp)
+            Δr = oftype(Δr, NaN)
+            Δp = oftype(Δp, NaN)
         end
+        Δd = ChainRulesCore.Tangent{typeof(d)}(; r=Δr, p=Δp)
         return ChainRulesCore.NoTangent(), Δd, ChainRulesCore.NoTangent()
     end
 

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -151,7 +151,7 @@ function ChainRulesCore.rrule(::typeof(logpdf), d::NegativeBinomial, k::Real)
     # Define pullback
     function logpdf_NegativeBinomial_pullback(Δ)
         Δr = Δ * (log(p) - inv(k + r) - digamma(r) + digamma(r + k + 1))
-        Δp = Δ * (r / p - k * inv(1 - p))
+        Δp = Δ * (r / p - k / (1 - p))
         Δd = if edgecase
             ChainRulesCore.Tangent{typeof(d)}(; r=Δr, p=NaN)
         elseif !insupp

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -129,3 +129,38 @@ function cf(d::NegativeBinomial, t::Real)
     r, p = params(d)
     return (((1 - p) * cis(t)) / (1 - p * cis(t)))^r
 end
+
+# ChainRules definitions
+
+function ChainRulesCore.rrule(::typeof(logpdf), d::NegativeBinomial, k::Real)
+    # Compute log probability
+    r, p = Distributions.params(d)
+    edgecase = isone(p) && iszero(k)
+    insupp = insupport(d, k)
+    
+    # Primal computation
+    Ω = r * log(p) + k * log1p(-p)
+    if edgecase
+        Ω = zero(Ω)
+    elseif !insupp
+        Ω = oftype(Ω, -Inf)
+    else
+        Ω = Ω - log(k + r) - logbeta(r, k + 1)
+    end
+
+    # Define pullback
+    function logpdf_NegativeBinomial_pullback(Δ)
+        Δr = Δ * (log(p) - inv(k + r) - digamma(r) + digamma(r + k + 1))
+        Δp = Δ * (r / p - k * inv(1 - p))
+        Δd = if edgecase
+            ChainRulesCore.Tangent{typeof(d)}(; r=Δr, p=NaN)
+        elseif !insupp
+            ChainRulesCore.Tangent{typeof(d)}(; r=zero(Δr), p=zero(Δp))
+        else
+            ChainRulesCore.Tangent{typeof(d)}(; r=Δr, p=Δp)
+        end
+        return ChainRulesCore.NoTangent(), Δd, ChainRulesCore.NoTangent()
+    end
+
+    return Ω, logpdf_NegativeBinomial_pullback
+end

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -153,7 +153,7 @@ function ChainRulesCore.rrule(::typeof(logpdf), d::NegativeBinomial, k::Real)
         Δr = Δ * (log(p) - inv(k + r) - digamma(r) + digamma(r + k + 1))
         Δp = Δ * (r / p - k / (1 - p))
         if edgecase
-            Δp = Δ * r
+            Δp = oftype(Δp, Δ * r)
         elseif !insupp
             Δr = oftype(Δr, NaN)
             Δp = oftype(Δp, NaN)

--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -134,7 +134,7 @@ end
 
 function ChainRulesCore.rrule(::typeof(logpdf), d::NegativeBinomial, k::Real)
     # Compute log probability
-    r, p = Distributions.params(d)
+    r, p = params(d)
     edgecase = isone(p) && iszero(k)
     insupp = insupport(d, k)
     

--- a/test/negativebinomial.jl
+++ b/test/negativebinomial.jl
@@ -6,35 +6,49 @@ using Test, ForwardDiff
 # Currently, most of the tests for NegativeBinomial are in the "ref" folder.
 # Eventually, we might want to consolidate the tests here
 
+mydiffp(r, p, k) = isone(p) ? r : r/p - k/(1 - p)
+mydiffr(r, p, k) = log(p) - inv(k + r) - digamma(r) + digamma(r + k + 1)
+
 @testset "NegativeBinomial" begin
-    @testset "ForwardDiff and rrule" begin
+    ks = (0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024)
+    @testset "logpdf and ForwardDiff" begin
+        rs = exp10.(range(-10, stop=2, length=25))
+        ps = exp10.(-10:0) .- eps() # avoid p==1 since it's not differentiable
+        @testset "r=$r" for r in rs
+            @testset "p=1, k=0" begin
+                @test logpdf(NegativeBinomial(r, 1.0), 0) === 0.0
+                fdm = backward_fdm(5, 1, max_range = r/10)
+                f1(_p) = logpdf(NegativeBinomial(r, _p), 0)
+                f2(_r) = logpdf(NegativeBinomial(_r, 1.0), 0)
+                @test_broken ForwardDiff.derivative(f1, 1.0) ≈ mydiffp(r, 1.0, 0)
+                @test_skip ForwardDiff.derivative(f2, r) ≈ mydiffr(r, 1.0, 0)
+            end
+            @testset "p=1, k=1" begin
+                @test logpdf(NegativeBinomial(r, 1.0), 1) === -Inf
+            end
+            @testset "p=$p, k=$k" for p in ps, k in ks
+                fdm = central_fdm(5, 1, max_range = min(r, p, 1-p)/2)
+                f1(_p) = logpdf(NegativeBinomial(r, _p), k)
+                f2(_r) = logpdf(NegativeBinomial(_r, p), k)
+                @test ForwardDiff.derivative(f1, p) ≈ mydiffp(r, p, k)
+                @test_skip ForwardDiff.derivative(f2, r) ≈ mydiffr(r, p, k)
+            end
+        end
+    end
+    @testset "rrule" begin
         rs = -log.(rand(25))
         ps = rand(25)
-        ks = (0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024)
         @testset "r=$r" for r in rs
             @testset "p=1, k=0" begin
                 dist = NegativeBinomial(r, 1.0)
                 fdm = backward_fdm(5, 1, max_range = r/10)
-                f1(_p) = logpdf(NegativeBinomial(r, _p), 0)
-                f2(_r) = logpdf(NegativeBinomial(_r, 1.0), 0)
-                @test ForwardDiff.derivative(f1, 1.0) ≈ fdm(f1, 1.0)
-                @test ForwardDiff.derivative(f2, r) ≈ fdm(f2, r)
                 test_rrule(logpdf, dist, 0; fdm = fdm, check_inferred=true)
             end
             @testset "p=$p, k=$k" for p in ps, k in ks
                 dist = NegativeBinomial(r, p)
-                fdm = central_fdm(5, 1, max_range = min(r, p)/2)
-                f1(_p) = logpdf(NegativeBinomial(r, _p), k)
-                f2(_r) = logpdf(NegativeBinomial(_r, p), k)
-                @test ForwardDiff.derivative(f1, p) ≈ fdm(f1, p)
-                @test ForwardDiff.derivative(f2, r) ≈ fdm(f2, r)
+                fdm = central_fdm(5, 1, max_range = min(r, p, 1-p)/2)
                 test_rrule(logpdf, dist, k; fdm = fdm, check_inferred=true)
             end
         end
     end
-end
-
-@testset "Check the corner case p==1" begin
-    @test logpdf(NegativeBinomial(0.5, 1.0), 0) === 0.0
-    @test logpdf(NegativeBinomial(0.5, 1.0), 1) === -Inf
 end

--- a/test/negativebinomial.jl
+++ b/test/negativebinomial.jl
@@ -8,15 +8,21 @@ using Test, ForwardDiff
 
 mydiffp(r, p, k) = r/p - k/(1 - p)
 
-@testset "NegativeBinomial r=$r, p=$p, k=$k" for
-    p in exp10.(-10:0) .- eps(), # avoid p==1 since it's not differentiable
-        r in exp10.(range(-10, stop=2, length=25)),
-            k in (0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024)
+@testset "NegativeBinomial r=$r" for r in exp10.(range(-10, stop=2, length=25))
+    # avoid p==1 since it's not differentiable
+    @testset "p = $p" for p in exp10.(-10:0) .- eps()
+        @testset "k = $k" for k in (0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024)
+            @test ForwardDiff.derivative(_p -> logpdf(NegativeBinomial(r, _p), k), p) ≈ mydiffp(r, p, k) rtol=1e-12 atol=1e-12
 
-    @test ForwardDiff.derivative(_p -> logpdf(NegativeBinomial(r, _p), k), p) ≈ mydiffp(r, p, k) rtol=1e-12 atol=1e-12
-
-    dist = NegativeBinomial(r, p)
-    test_rrule(logpdf, dist, k; fdm = forward_fdm(5, 1))
+            dist = NegativeBinomial(r, p)
+            if p == 1. - eps()
+                # Did not get to work:
+                # test_rrule(logpdf, dist, k; fdm = backward_fdm(5, 1, max_range = r/2), rtol = 1e-5, atol = 1e-1)
+            else
+                test_rrule(logpdf, dist, k; fdm = central_fdm(5, 1, max_range = min(r, p)/2), rtol = 1e-10, atol = 1e-1)
+            end
+        end
+    end
 end
 
 @testset "Check the corner case p==1" begin
@@ -24,6 +30,6 @@ end
     @test logpdf(NegativeBinomial(0.5, 1.0), 1) === -Inf
 
     @testset "r=$r" for r in exp10.(range(-10, stop=2, length=25))
-        test_rrule(logpdf, NegativeBinomial(r, 1.0), 0; fdm = backward_fdm(5, 1))
+        test_rrule(logpdf, NegativeBinomial(r, 1.0), 0; fdm = backward_fdm(5, 1, max_range = r/2), rtol = 1e-8, atol = 1e-4)
     end
 end

--- a/test/negativebinomial.jl
+++ b/test/negativebinomial.jl
@@ -52,3 +52,4 @@ mydiffr(r, p, k) = log(p) - inv(k + r) - digamma(r) + digamma(r + k + 1)
             end
         end
     end
+end

--- a/test/negativebinomial.jl
+++ b/test/negativebinomial.jl
@@ -22,5 +22,5 @@ end
     @test logpdf(NegativeBinomial(0.5, 1.0), 0) === 0.0
     @test logpdf(NegativeBinomial(0.5, 1.0), 1) === -Inf
 
-    test_rrule(logpdf, NegativeBinomial(0.5, 1.0), 0)
+    test_rrule(logpdf, NegativeBinomial(0.5, 1.0), 0; fdm = forward_fdm(5, 1))
 end

--- a/test/negativebinomial.jl
+++ b/test/negativebinomial.jl
@@ -6,20 +6,29 @@ using Test, ForwardDiff
 # Currently, most of the tests for NegativeBinomial are in the "ref" folder.
 # Eventually, we might want to consolidate the tests here
 
-mydiffp(r, p, k) = r/p - k/(1 - p)
-
-@testset "NegativeBinomial r=$r" for r in exp10.(range(-10, stop=2, length=25))
-    # avoid p==1 since it's not differentiable
-    @testset "p = $p" for p in exp10.(-10:0) .- eps()
-        @testset "k = $k" for k in (0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024)
-            @test ForwardDiff.derivative(_p -> logpdf(NegativeBinomial(r, _p), k), p) ≈ mydiffp(r, p, k) rtol=1e-12 atol=1e-12
-
-            dist = NegativeBinomial(r, p)
-            if p == 1. - eps()
-                # Did not get to work:
-                # test_rrule(logpdf, dist, k; fdm = backward_fdm(5, 1, max_range = r/2), rtol = 1e-5, atol = 1e-1)
-            else
-                test_rrule(logpdf, dist, k; fdm = central_fdm(5, 1, max_range = min(r, p)/2), rtol = 1e-10, atol = 1e-1)
+@testset "NegativeBinomial" begin
+    @testset "ForwardDiff and rrule" begin
+        rs = -log.(rand(25))
+        ps = rand(25)
+        ks = (0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024)
+        @testset "r=$r" for r in rs
+            @testset "p=1, k=0" begin
+                dist = NegativeBinomial(r, 1.0)
+                fdm = backward_fdm(5, 1, max_range = r/10)
+                f1(_p) = logpdf(NegativeBinomial(r, _p), 0)
+                f2(_r) = logpdf(NegativeBinomial(_r, 1.0), 0)
+                @test ForwardDiff.derivative(f1, 1.0) ≈ fdm(f1, 1.0)
+                @test ForwardDiff.derivative(f2, r) ≈ fdm(f2, r)
+                test_rrule(logpdf, dist, 0; fdm = fdm, check_inferred=true)
+            end
+            @testset "p=$p, k=$k" for p in ps, k in ks
+                dist = NegativeBinomial(r, p)
+                fdm = central_fdm(5, 1, max_range = min(r, p)/2)
+                f1(_p) = logpdf(NegativeBinomial(r, _p), k)
+                f2(_r) = logpdf(NegativeBinomial(_r, p), k)
+                @test ForwardDiff.derivative(f1, p) ≈ fdm(f1, p)
+                @test ForwardDiff.derivative(f2, r) ≈ fdm(f2, r)
+                test_rrule(logpdf, dist, k; fdm = fdm, check_inferred=true)
             end
         end
     end
@@ -28,8 +37,4 @@ end
 @testset "Check the corner case p==1" begin
     @test logpdf(NegativeBinomial(0.5, 1.0), 0) === 0.0
     @test logpdf(NegativeBinomial(0.5, 1.0), 1) === -Inf
-
-    @testset "r=$r" for r in exp10.(range(-10, stop=2, length=25))
-        test_rrule(logpdf, NegativeBinomial(r, 1.0), 0; fdm = backward_fdm(5, 1, max_range = r/2), rtol = 1e-8, atol = 1e-4)
-    end
 end

--- a/test/negativebinomial.jl
+++ b/test/negativebinomial.jl
@@ -1,7 +1,8 @@
 using Distributions
+using ChainRulesTestUtils
 using Test, ForwardDiff
 
-# Currently, most of the tests for NegativeBinomail are in the "ref" folder.
+# Currently, most of the tests for NegativeBinomial are in the "ref" folder.
 # Eventually, we might want to consolidate the tests here
 
 mydiffp(r, p, k) = r/p - k/(1 - p)
@@ -12,9 +13,14 @@ mydiffp(r, p, k) = r/p - k/(1 - p)
             k in (0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024)
 
     @test ForwardDiff.derivative(_p -> logpdf(NegativeBinomial(r, _p), k), p) ≈ mydiffp(r, p, k) rtol=1e-12 atol=1e-12
+
+    dist = NegativeBinomial(r, p)
+    test_rrule(logpdf, dist, k)
 end
 
 @testset "Check the corner case p==1" begin
     @test logpdf(NegativeBinomial(0.5, 1.0), 0) === 0.0
     @test logpdf(NegativeBinomial(0.5, 1.0), 1) === -Inf
+
+    test_rrule(logpdf, NegativeBinomial(0.5, 1.0), 0)
 end

--- a/test/negativebinomial.jl
+++ b/test/negativebinomial.jl
@@ -1,5 +1,6 @@
 using Distributions
 using ChainRulesTestUtils
+using FiniteDifferences
 using Test, ForwardDiff
 
 # Currently, most of the tests for NegativeBinomial are in the "ref" folder.
@@ -15,12 +16,14 @@ mydiffp(r, p, k) = r/p - k/(1 - p)
     @test ForwardDiff.derivative(_p -> logpdf(NegativeBinomial(r, _p), k), p) ≈ mydiffp(r, p, k) rtol=1e-12 atol=1e-12
 
     dist = NegativeBinomial(r, p)
-    test_rrule(logpdf, dist, k)
+    test_rrule(logpdf, dist, k; fdm = forward_fdm(5, 1))
 end
 
 @testset "Check the corner case p==1" begin
     @test logpdf(NegativeBinomial(0.5, 1.0), 0) === 0.0
     @test logpdf(NegativeBinomial(0.5, 1.0), 1) === -Inf
 
-    test_rrule(logpdf, NegativeBinomial(0.5, 1.0), 0; fdm = forward_fdm(5, 1))
+    @testset "r=$r" for r in exp10.(range(-2, stop=2, length=8))
+        test_rrule(logpdf, NegativeBinomial(r, 1.0), 0; fdm = backward_fdm(5, 1))
+    end
 end

--- a/test/negativebinomial.jl
+++ b/test/negativebinomial.jl
@@ -23,7 +23,7 @@ end
     @test logpdf(NegativeBinomial(0.5, 1.0), 0) === 0.0
     @test logpdf(NegativeBinomial(0.5, 1.0), 1) === -Inf
 
-    @testset "r=$r" for r in exp10.(range(-2, stop=2, length=8))
+    @testset "r=$r" for r in exp10.(range(-10, stop=2, length=25))
         test_rrule(logpdf, NegativeBinomial(r, 1.0), 0; fdm = backward_fdm(5, 1))
     end
 end


### PR DESCRIPTION
This PR completes #1568. I would like to merge and release the `rrule` for `logpdf` of `NegativeBinomial` therein. However, some requested changes are still missing and so it seemed easiest and fastest to just implement them myself.

I was not sure if I am supposed to push to the original PR directly so I opened a new one. In contrast to the original PR, this PR keeps the changes to the existing tests (e.g. for ForwardDiff) minimal. Moreover, in the original PR not all the branches were tested but only values in the support of the distributions. Due to the `NaN` values obtained outside of the support (in line with finite differencing) I had to add `nans=true` to the tests since otherwise checks of `isapprox(NaN, NaN)` fail.