### PR TITLE
Update ksdist.jl

### DIFF
--- a/src/univariate/continuous/ksdist.jl
+++ b/src/univariate/continuous/ksdist.jl
@@ -4,7 +4,7 @@
 Distribution of the (two-sided) Kolmogorov-Smirnoff statistic
 
 ```math
-D_n = \\sup_x | \\hat{F}_n(x) -F(x)| \\sqrt(n)
+D_n = \\sup_x | \\hat{F}_n(x) -F(x)|
 ```
 
 ``D_n`` converges a.s. to the Kolmogorov distribution.


### PR DESCRIPTION
While the sqrt(n) factor is often part of the test statistic this is not what is implemented here. To witness, see

https://github.com/JuliaStats/Distributions.jl/blob/254f27f1b32a72d6529e2f78a3745b68bd38b31e/test/testutils.jl#L597-L607

where there is no sqrt(n) factor.