### PR TITLE
Implement log10-normal distribution

### DIFF
--- a/docs/src/fit.md
+++ b/docs/src/fit.md
@@ -44,6 +44,7 @@ The `fit_mle` method has been implemented for the following distributions:
 - [`DiscreteUniform`](@ref)
 - [`Exponential`](@ref)
 - [`LogNormal`](@ref)
+- [`Log10Normal`](@ref)
 - [`Normal`](@ref)
 - [`Gamma`](@ref)
 - [`Geometric`](@ref)

--- a/docs/src/univariate.md
+++ b/docs/src/univariate.md
@@ -319,6 +319,13 @@ plotdensity((0, 5), LogNormal, (0, 1)) # hide
 ```
 
 ```@docs
+Log10Normal
+```
+```@example plotdensity
+plotdensity((0, 20), Log10Normal, (1, 0.2)) # hide
+```
+
+```@docs
 LogUniform
 ```
 ```@example plotdensity

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -118,6 +118,7 @@ export
     LocationScale,
     Logistic,
     LogNormal,
+    Log10Normal,
     LogUniform,
     LogitNormal,
     MatrixBeta,

--- a/src/univariate/continuous/log10normal.jl
+++ b/src/univariate/continuous/log10normal.jl
@@ -1,0 +1,171 @@
+"""
+    Log10Normal(μ,σ)
+
+The *log10 normal distribution* is the distribution of the base 10 exponential of a [`Normal`](@ref) variate: if ``X \\sim \\operatorname{Normal}(\\mu, \\sigma)`` then
+``\\exp10(X) \\sim \\operatorname{Log10Normal}(\\mu,\\sigma)``. The probability density function is
+```math
+f(x; \\mu, \\sigma) = \\frac{1}{x \\ln10 \\sqrt{2 \\pi \\sigma^2}}
+\\exp \\left( - \\frac{(\\log10(x) - \\mu)^2}{2 \\sigma^2} \\right),
+\\quad x > 0
+```
+```julia
+Log10Normal()          # Log10-normal distribution with zero log10-mean and unit scale
+Log10Normal(μ)         # Log10-normal distribution with log10-mean `μ` and unit scale
+Log10Normal(μ, σ)      # Log10-normal distribution with log10-mean `μ` and scale `σ`
+
+params(d)              # Get the parameters, i.e. (μ, σ)
+```
+External links
+
+* [Log normal distribution on Wikipedia](http://en.wikipedia.org/wiki/Log-normal_distribution)
+
+"""
+struct Log10Normal{T<:Real} <: ContinuousUnivariateDistribution
+    μ::T
+    σ::T
+    Log10Normal{T}(μ::T, σ::T) where {T} = new{T}(μ, σ)
+end
+
+function Log10Normal(μ::T, σ::T; check_args::Bool=true) where {T <: Real}
+    @check_args Log10Normal (σ, σ ≥ zero(σ))
+    return Log10Normal{T}(μ, σ)
+end
+
+Log10Normal(μ::Real, σ::Real; check_args::Bool=true) = Log10Normal(promote(μ, σ)...; check_args=check_args)
+Log10Normal(μ::Integer, σ::Integer; check_args::Bool=true) = Log10Normal(float(μ), float(σ); check_args=check_args)
+Log10Normal(μ::Real=0.0) = Log10Normal(μ, one(μ); check_args=false)
+
+@distr_support Log10Normal 0.0 Inf
+
+#### Conversions
+convert(::Type{Log10Normal{T}}, μ::S, σ::S) where {T <: Real, S <: Real} = Log10Normal(T(μ), T(σ))
+Base.convert(::Type{Log10Normal{T}}, d::Log10Normal) where {T<:Real} = Log10Normal{T}(T(d.μ), T(d.σ))
+Base.convert(::Type{Log10Normal{T}}, d::Log10Normal{T}) where {T<:Real} = d
+
+#### Parameters
+
+params(d::Log10Normal) = (d.μ, d.σ)
+partype(::Log10Normal{T}) where {T} = T
+
+#### Statistics
+
+mean(d::Log10Normal) = ((μ, σ) = params(d); exp10(μ + σ^2*log(10)/2))
+median(d::Log10Normal) = exp10(d.μ)
+mode(d::Log10Normal) = ((μ, σ) = params(d); exp10(μ - σ^2*log(10)))
+
+function var(d::Log10Normal)
+    σ2 = d.σ^2
+    σ2 *= log(one(σ2)*10)^2
+    e = exp(σ2)
+    μ = d.μ
+    10^2μ * e * (e-1)
+end
+# function vartest(d::Log10Normal)
+#     quadgk(x-> (exp10(x)-mean(d))^2 * pdf(d,exp10(x)) * exp10(x) * log(10), min(1e-5,d.μ-5*d.σ),d.μ+5*d.σ)[1]
+# end
+# function meantest(d::Log10Normal)
+#     quadgk(x-> exp10(x) * pdf(d,exp10(x)) * exp10(x) * log(10), min(1e-5,d.μ-5*d.σ),d.μ+5*d.σ)[1]
+# end
+
+function skewness(d::Log10Normal)
+    σ2 = d.σ^2
+    σ2 *= log(one(σ2)*10)^2
+    e = exp(σ2)
+    (e + 2) * sqrt(e - 1)
+end
+
+function kurtosis(d::Log10Normal)
+    σ2 = d.σ^2
+    σ2 *= log(one(σ2)*10)^2
+    e = exp(σ2)
+    e2 = e * e
+    e3 = e2 * e
+    e4 = e3 * e
+    e4 + 2*e3 + 3*e2 - 3
+end
+
+function entropy(d::Log10Normal)
+    (μ, σ) = params(d)
+    (1 + μ * log(100) + log(twoπ) + 2*log(σ*log(10)))/2
+end
+# function entropytest(d::Log10Normal)
+#     quadgk(x-> -logpdf(d,exp10(x)) * pdf(d,exp10(x)) * exp10(x) * log(10), min(1e-5,d.μ-5*d.σ),d.μ+5*d.σ)
+# end
+
+
+#### Evalution
+
+function pdf(d::Log10Normal, x::Real)
+    if x ≤ zero(x)
+        log10x = log10(zero(x))
+        x = one(x)
+    else
+        log10x = log10(x)
+    end
+    return pdf(Normal(d.μ, d.σ), log10x) / x / log(one(x)*10)
+end
+
+function logpdf(d::Log10Normal, x::Real)
+    if x ≤ zero(x)
+        log10x = log10(zero(x))
+        b = zero(log10x)
+    else
+        log10x = log10(x)
+        b = log(x)
+    end
+    return logpdf(Normal(d.μ, d.σ), log10x) - b - log(log(one(x)*10))
+end
+
+function cdf(d::Log10Normal, x::Real)
+    log10x = x ≤ zero(x) ? log10(zero(x)) : log10(x)
+    return cdf(Normal(d.μ, d.σ), log10x)
+end
+
+function ccdf(d::Log10Normal, x::Real)
+    log10x = x ≤ zero(x) ? log10(zero(x)) : log10(x)
+    return ccdf(Normal(d.μ, d.σ), log10x)
+end
+
+function logcdf(d::Log10Normal, x::Real)
+    log10x = x ≤ zero(x) ? log10(zero(x)) : log10(x)
+    return logcdf(Normal(d.μ, d.σ), log10x)
+end
+
+function logccdf(d::Log10Normal, x::Real)
+    log10x = x ≤ zero(x) ? log10(zero(x)) : log10(x)
+    return logccdf(Normal(d.μ, d.σ), log10x)
+end
+
+quantile(d::Log10Normal, q::Real) = exp10(quantile(Normal(params(d)...), q))
+cquantile(d::Log10Normal, q::Real) = exp10(cquantile(Normal(params(d)...), q))
+invlogcdf(d::Log10Normal, lq::Real) = exp10(invlogcdf(Normal(params(d)...), lq))
+invlogccdf(d::Log10Normal, lq::Real) = exp10(invlogccdf(Normal(params(d)...), lq))
+
+function gradlogpdf(d::Log10Normal, x::Real)
+    outofsupport = x ≤ zero(x)
+    y = outofsupport ? one(x) : x
+    μ,σ = params(d)
+    ln10 = log(one(μ)*10)
+    z = ( ln10 * (μ - σ^2 * ln10) - log(y) ) / (y * σ^2 * ln10^2)
+    return outofsupport ? zero(z) : z
+end
+
+#### Sampling
+
+rand(rng::AbstractRNG, d::Log10Normal) = exp10(randn(rng) * d.σ + d.μ)
+
+## Fitting
+
+function fit_mle(::Type{<:Log10Normal}, x::AbstractArray{T}) where T<:Real
+    lx = log10.(x)
+    μ, σ = mean_and_std(lx)
+    Log10Normal(μ, σ)
+end
+
+function fit_mle(::Type{<:Log10Normal}, x::AbstractArray{T}, w::AbstractArray{S}) where {T<:Real,S<:Real}
+    @assert size(x) == size(w)
+    lx = log10.(x)
+    μ = sum( lx .* w ) / sum(w)
+    σ = sqrt( sum( (lx .- μ ).^2 .* w) / sum(w) )
+    Log10Normal(μ, σ)
+end

--- a/src/univariate/continuous/log10normal.jl
+++ b/src/univariate/continuous/log10normal.jl
@@ -60,12 +60,6 @@ function var(d::Log10Normal)
     μ = d.μ
     10^2μ * e * (e-1)
 end
-# function vartest(d::Log10Normal)
-#     quadgk(x-> (exp10(x)-mean(d))^2 * pdf(d,exp10(x)) * exp10(x) * log(10), min(1e-5,d.μ-5*d.σ),d.μ+5*d.σ)[1]
-# end
-# function meantest(d::Log10Normal)
-#     quadgk(x-> exp10(x) * pdf(d,exp10(x)) * exp10(x) * log(10), min(1e-5,d.μ-5*d.σ),d.μ+5*d.σ)[1]
-# end
 
 function skewness(d::Log10Normal)
     σ2 = d.σ^2
@@ -88,12 +82,8 @@ function entropy(d::Log10Normal)
     (μ, σ) = params(d)
     (1 + μ * log(100) + log(twoπ) + 2*log(σ*log(10)))/2
 end
-# function entropytest(d::Log10Normal)
-#     quadgk(x-> -logpdf(d,exp10(x)) * pdf(d,exp10(x)) * exp10(x) * log(10), min(1e-5,d.μ-5*d.σ),d.μ+5*d.σ)
-# end
 
-
-#### Evalution
+#### Evaluation
 
 function pdf(d::Log10Normal, x::Real)
     if x ≤ zero(x)

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -686,6 +686,7 @@ const continuous_distributions = [
     "normalcanon",
     "normalinversegaussian",
     "lognormal",    # LogNormal depends on Normal
+    "log10normal",  # Log10Normal depends on Normal
     "logitnormal",    # LogitNormal depends on Normal
     "pareto",
     "rayleigh",

--- a/test/log10normal.jl
+++ b/test/log10normal.jl
@@ -1,0 +1,316 @@
+using Distributions
+using ForwardDiff
+using Test
+
+isnan_type(::Type{T}, v) where {T} = isnan(v) && v isa T
+
+@testset "Log10Normal" begin
+    @test isa(convert(Log10Normal{Float64}, Float16(0), Float16(1)),
+              Log10Normal{Float64})
+    d = Log10Normal(0, 1)
+    @test convert(Log10Normal{Float64}, d) === d
+    @test convert(Log10Normal{Float32}, d) isa Log10Normal{Float32}
+
+    @test logpdf(Log10Normal(0, 0), 1) === Inf
+    @test logpdf(Log10Normal(), Inf) === -Inf
+    @test iszero(logcdf(Log10Normal(0, 0), 1))
+    @test iszero(logcdf(Log10Normal(), Inf))
+    @test logdiffcdf(Log10Normal(), Float32(exp10(3)), Float32(exp10(3))) === -Inf
+    @test logdiffcdf(Log10Normal(), Float32(exp10(5)), Float32(exp10(3))) ≈ -6.607938594596893 rtol=1e-12
+    @test logdiffcdf(Log10Normal(), Float32(exp10(5)), Float64(exp10(3))) ≈ -6.607938594596893 rtol=1e-12
+    @test logdiffcdf(Log10Normal(), Float64(exp10(5)), Float64(exp10(3))) ≈ -6.607938594596893 rtol=1e-12
+    let d = Log10Normal(Float64(0), Float64(1)), x = Float64(exp10(-60)), y = Float64(exp10(-60.001))
+        float_res = logdiffcdf(d, x, y)
+        big_x = BigFloat(x; precision=100)
+        big_y = BigFloat(y; precision=100)
+        big_float_res = log(cdf(d, big_x) - cdf(d, big_y))
+        @test float_res ≈ big_float_res
+    end
+
+    @test logccdf(Log10Normal(0, 0), 1) === -Inf
+    @test iszero(logccdf(Log10Normal(eps(), 0), 1))
+
+    @test iszero(quantile(Log10Normal(), 0))
+    @test isone(quantile(Log10Normal(), 0.5))
+    @test quantile(Log10Normal(), 1) === Inf
+
+    @test iszero(quantile(Log10Normal(0, 0), 0))
+    @test isone(quantile(Log10Normal(0, 0), 0.75))
+    @test quantile(Log10Normal(0, 0), 1) === Inf
+
+    @test iszero(quantile(Log10Normal(0.25, 0), 0))
+    @test quantile(Log10Normal(0.25, 0), 0.95) == exp10(0.25)
+    @test quantile(Log10Normal(0.25, 0), 1) === Inf
+
+    @test cquantile(Log10Normal(), 0) === Inf
+    @test isone(cquantile(Log10Normal(), 0.5))
+    @test iszero(cquantile(Log10Normal(), 1))
+
+    @test cquantile(Log10Normal(0, 0), 0) === Inf
+    @test isone(cquantile(Log10Normal(0, 0), 0.75))
+    @test iszero(cquantile(Log10Normal(0, 0), 1))
+
+    @test cquantile(Log10Normal(0.25, 0), 0) === Inf
+    @test cquantile(Log10Normal(0.25, 0), 0.95) == exp10(0.25)
+    @test iszero(cquantile(Log10Normal(0.25, 0), 1))
+
+    @test iszero(invlogcdf(Log10Normal(), -Inf))
+    @test isnan_type(Float64, invlogcdf(Log10Normal(), NaN))
+
+    @test invlogccdf(Log10Normal(), -Inf) === Inf
+    @test isnan_type(Float64, invlogccdf(Log10Normal(), NaN))
+
+    # test for #996 being fixed
+    let d = Log10Normal(0, 1), x = exp10(1), ∂x = exp10(2)
+        @inferred cdf(d, ForwardDiff.Dual(x, ∂x)) ≈ ForwardDiff.Dual(cdf(d, x), ∂x * pdf(d, x))
+    end
+end
+
+
+@testset "Log10Normal type inference" begin
+    # pdf
+    @test @inferred(pdf(Log10Normal(0.0, 0.0), 1.0)) === Inf
+    @test @inferred(pdf(Log10Normal(0.0, 0.0), 0.5)) === 0.0
+    @test @inferred(pdf(Log10Normal(0.0, 0.0), 0.0)) === 0.0
+    @test @inferred(pdf(Log10Normal(0.0, 0.0), -0.5)) === 0.0
+
+    @test @inferred(pdf(Log10Normal(0.0, 0.0), 1.0f0)) === Inf
+    @test @inferred(pdf(Log10Normal(0.0f0, 0.0f0), 1.0)) === Inf
+    @test @inferred(pdf(Log10Normal(0.0f0, 0.0f0), 1.0f0)) === Inf32
+
+    @test isnan_type(Float64, @inferred(pdf(Log10Normal(0.0, 0.0), NaN)))
+    @test isnan_type(Float64, @inferred(pdf(Log10Normal(NaN, 0.0), 1.0f0)))
+    @test isnan_type(Float64, @inferred(pdf(Log10Normal(NaN, 0.0), 0.0f0)))
+    @test isnan_type(Float64, @inferred(pdf(Log10Normal(NaN, 0.0), -1.0f0)))
+
+    @test isnan_type(Float32, @inferred(pdf(Log10Normal(NaN32, 0.0f0), 1.0f0)))
+    @test isnan_type(Float32, @inferred(pdf(Log10Normal(NaN32, 0.0f0), 0.0f0)))
+    @test isnan_type(Float32, @inferred(pdf(Log10Normal(NaN32, 0.0f0), -1.0f0)))
+
+    @test @inferred(pdf(Log10Normal(0 // 1, 0 // 1), 1 // 1)) === Inf
+    @test @inferred(pdf(Log10Normal(0 // 1, 0 // 1), 0 // 1)) === 0.0
+    @test @inferred(pdf(Log10Normal(0 // 1, 0 // 1), -1 // 1)) === 0.0
+    @test isnan_type(Float64, @inferred(pdf(Log10Normal(0 // 1, 0 // 1), NaN)))
+
+    @test @inferred(pdf(Log10Normal(0.0, 0.0), BigInt(1))) == big(Inf)
+    @test @inferred(pdf(Log10Normal(0.0, 0.0), BigInt(0))) == big(0.0)
+    @test @inferred(pdf(Log10Normal(0.0, 0.0), BigInt(-1))) == big(0.0)
+    @test @inferred(pdf(Log10Normal(0.0, 0.0), BigFloat(1))) == big(Inf)
+    @test @inferred(pdf(Log10Normal(0.0, 0.0), BigFloat(0))) == big(0.0)
+    @test @inferred(pdf(Log10Normal(0.0, 0.0), BigFloat(-1))) == big(0.0)
+    @test isnan_type(BigFloat, @inferred(pdf(Log10Normal(0.0, 0.0), BigFloat(NaN))))
+
+    # logpdf
+    @test @inferred(logpdf(Log10Normal(0.0, 0.0), 1.0)) === Inf
+    @test @inferred(logpdf(Log10Normal(0.0, 0.0), 0.5)) === -Inf
+    @test @inferred(logpdf(Log10Normal(0.0, 0.0), 0.0)) === -Inf
+    @test @inferred(logpdf(Log10Normal(0.0, 0.0), -0.5)) === -Inf
+
+    @test @inferred(logpdf(Log10Normal(0.0, 0.0), 1.0f0)) === Inf
+    @test @inferred(logpdf(Log10Normal(0.0f0, 0.0f0), 1.0)) === Inf
+    @test @inferred(logpdf(Log10Normal(0.0f0, 0.0f0), 1.0f0)) === Inf32
+
+    @test isnan_type(Float64, @inferred(logpdf(Log10Normal(0.0, 0.0), NaN)))
+    @test isnan_type(Float64, @inferred(logpdf(Log10Normal(NaN, 0.0), 1.0f0)))
+    @test isnan_type(Float64, @inferred(logpdf(Log10Normal(NaN, 0.0), 0.0f0)))
+    @test isnan_type(Float64, @inferred(logpdf(Log10Normal(NaN, 0.0), -1.0f0)))
+
+    @test isnan_type(Float32, @inferred(logpdf(Log10Normal(NaN32, 0.0f0), 1.0f0)))
+    @test isnan_type(Float32, @inferred(logpdf(Log10Normal(NaN32, 0.0f0), 0.0f0)))
+    @test isnan_type(Float32, @inferred(logpdf(Log10Normal(NaN32, 0.0f0), -1.0f0)))
+
+    @test @inferred(logpdf(Log10Normal(0 // 1, 0 // 1), 1 // 1)) === Inf
+    @test @inferred(logpdf(Log10Normal(0 // 1, 0 // 1), 0 // 1)) === -Inf
+    @test @inferred(logpdf(Log10Normal(0 // 1, 0 // 1), -1 // 1)) === -Inf
+    @test isnan_type(Float64, @inferred(logpdf(Log10Normal(0 // 1, 0 // 1), NaN)))
+
+    @test @inferred(logpdf(Log10Normal(0.0, 0.0), BigInt(1))) == big(Inf)
+    @test @inferred(logpdf(Log10Normal(0.0, 0.0), BigInt(0))) == big(-Inf)
+    @test @inferred(logpdf(Log10Normal(0.0, 0.0), BigInt(-1))) == big(-Inf)
+    @test @inferred(logpdf(Log10Normal(0.0, 0.0), BigFloat(1))) == big(Inf)
+    @test @inferred(logpdf(Log10Normal(0.0, 0.0), BigFloat(0))) == big(-Inf)
+    @test @inferred(logpdf(Log10Normal(0.0, 0.0), BigFloat(-1))) == big(-Inf)
+    @test isnan_type(BigFloat, @inferred(logpdf(Log10Normal(0.0, 0.0), BigFloat(NaN))))
+
+    # cdf
+    @test @inferred(cdf(Log10Normal(0.0, 0.0), 1.0)) === 1.0
+    @test @inferred(cdf(Log10Normal(0.0, 0.0), 0.5)) === 0.0
+    @test @inferred(cdf(Log10Normal(0.0, 0.0), 0.0)) === 0.0
+    @test @inferred(cdf(Log10Normal(0.0, 0.0), -0.5)) === 0.0
+
+    @test @inferred(cdf(Log10Normal(0.0, 0.0), 1.0f0)) === 1.0
+    @test @inferred(cdf(Log10Normal(0.0f0, 0.0f0), 1.0)) === 1.0
+    @test @inferred(cdf(Log10Normal(0.0f0, 0.0f0), 1.0f0)) === 1.0f0
+
+    @test isnan_type(Float64, @inferred(cdf(Log10Normal(0.0, 0.0), NaN)))
+    @test isnan_type(Float64, @inferred(cdf(Log10Normal(NaN, 0.0), 1.0f0)))
+    @test isnan_type(Float64, @inferred(cdf(Log10Normal(NaN, 0.0), 0.0f0)))
+    @test isnan_type(Float64, @inferred(cdf(Log10Normal(NaN, 0.0), -1.0f0)))
+
+    @test isnan_type(Float32, @inferred(cdf(Log10Normal(NaN32, 0.0f0), 1.0f0)))
+    @test isnan_type(Float32, @inferred(cdf(Log10Normal(NaN32, 0.0f0), 0.0f0)))
+    @test isnan_type(Float32, @inferred(cdf(Log10Normal(NaN32, 0.0f0), -1.0f0)))
+
+    @test @inferred(cdf(Log10Normal(0 // 1, 0 // 1), 1 // 1)) === 1.0
+    @test @inferred(cdf(Log10Normal(0 // 1, 0 // 1), 0 // 1)) === 0.0
+    @test @inferred(cdf(Log10Normal(0 // 1, 0 // 1), -1 // 1)) === 0.0
+    @test isnan_type(Float64, @inferred(cdf(Log10Normal(0 // 1, 0 // 1), NaN)))
+
+    @test @inferred(cdf(Log10Normal(0.0, 0.0), BigInt(1))) == big(1.0)
+    @test @inferred(cdf(Log10Normal(0.0, 0.0), BigInt(0))) == big(0.0)
+    @test @inferred(cdf(Log10Normal(0.0, 0.0), BigInt(-1))) == big(0.0)
+    @test @inferred(cdf(Log10Normal(0.0, 0.0), BigFloat(1))) == big(1.0)
+    @test @inferred(cdf(Log10Normal(0.0, 0.0), BigFloat(0))) == big(0.0)
+    @test @inferred(cdf(Log10Normal(0.0, 0.0), BigFloat(-1))) == big(0.0)
+    @test isnan_type(BigFloat, @inferred(cdf(Log10Normal(0.0, 0.0), BigFloat(NaN))))
+
+    # logcdf
+    @test @inferred(logcdf(Log10Normal(0.0, 0.0), 1.0)) === -0.0
+    @test @inferred(logcdf(Log10Normal(0.0, 0.0), 0.5)) === -Inf
+    @test @inferred(logcdf(Log10Normal(0.0, 0.0), 0.0)) === -Inf
+    @test @inferred(logcdf(Log10Normal(0.0, 0.0), -0.5)) === -Inf
+
+    @test @inferred(logcdf(Log10Normal(0.0, 0.0), 1.0f0)) === -0.0
+    @test @inferred(logcdf(Log10Normal(0.0f0, 0.0f0), 1.0)) === -0.0
+    @test @inferred(logcdf(Log10Normal(0.0f0, 0.0f0), 1.0f0)) === -0.0f0
+
+    @test isnan_type(Float64, @inferred(logcdf(Log10Normal(0.0, 0.0), NaN)))
+    @test isnan_type(Float64, @inferred(logcdf(Log10Normal(NaN, 0.0), 1.0f0)))
+    @test isnan_type(Float64, @inferred(logcdf(Log10Normal(NaN, 0.0), 0.0f0)))
+    @test isnan_type(Float64, @inferred(logcdf(Log10Normal(NaN, 0.0), -1.0f0)))
+
+    @test isnan_type(Float32, @inferred(logcdf(Log10Normal(NaN32, 0.0f0), 1.0f0)))
+    @test isnan_type(Float32, @inferred(logcdf(Log10Normal(NaN32, 0.0f0), 0.0f0)))
+    @test isnan_type(Float32, @inferred(logcdf(Log10Normal(NaN32, 0.0f0), -1.0f0)))
+
+    @test @inferred(logcdf(Log10Normal(0 // 1, 0 // 1), 1 // 1)) === -0.0
+    @test @inferred(logcdf(Log10Normal(0 // 1, 0 // 1), 0 // 1)) === -Inf
+    @test @inferred(logcdf(Log10Normal(0 // 1, 0 // 1), -1 // 1)) === -Inf
+    @test isnan_type(Float64, @inferred(logcdf(Log10Normal(0 // 1, 0 // 1), NaN)))
+
+    @test @inferred(logcdf(Log10Normal(0.0, 0.0), BigInt(1))) == big(0.0)
+    @test @inferred(logcdf(Log10Normal(0.0, 0.0), BigInt(0))) == big(-Inf)
+    @test @inferred(logcdf(Log10Normal(0.0, 0.0), BigInt(-1))) == big(-Inf)
+    @test @inferred(logcdf(Log10Normal(0.0, 0.0), BigFloat(1))) == big(0.0)
+    @test @inferred(logcdf(Log10Normal(0.0, 0.0), BigFloat(0))) == big(-Inf)
+    @test @inferred(logcdf(Log10Normal(0.0, 0.0), BigFloat(-1))) == big(-Inf)
+    @test isnan_type(BigFloat, @inferred(logcdf(Log10Normal(0.0, 0.0), BigFloat(NaN))))
+
+    # ccdf
+    @test @inferred(ccdf(Log10Normal(0.0, 0.0), 1.0)) === 0.0
+    @test @inferred(ccdf(Log10Normal(0.0, 0.0), 0.5)) === 1.0
+    @test @inferred(ccdf(Log10Normal(0.0, 0.0), 0.0)) === 1.0
+    @test @inferred(ccdf(Log10Normal(0.0, 0.0), -0.5)) === 1.0
+
+    @test @inferred(ccdf(Log10Normal(0.0, 0.0), 1.0f0)) === 0.0
+    @test @inferred(ccdf(Log10Normal(0.0f0, 0.0f0), 1.0)) === 0.0
+    @test @inferred(ccdf(Log10Normal(0.0f0, 0.0f0), 1.0f0)) === 0.0f0
+
+    @test isnan_type(Float64, @inferred(ccdf(Log10Normal(0.0, 0.0), NaN)))
+    @test isnan_type(Float64, @inferred(ccdf(Log10Normal(NaN, 0.0), 1.0f0)))
+    @test isnan_type(Float64, @inferred(ccdf(Log10Normal(NaN, 0.0), 0.0f0)))
+    @test isnan_type(Float64, @inferred(ccdf(Log10Normal(NaN, 0.0), -1.0f0)))
+
+    @test isnan_type(Float32, @inferred(ccdf(Log10Normal(NaN32, 0.0f0), 1.0f0)))
+    @test isnan_type(Float32, @inferred(ccdf(Log10Normal(NaN32, 0.0f0), 0.0f0)))
+    @test isnan_type(Float32, @inferred(ccdf(Log10Normal(NaN32, 0.0f0), -1.0f0)))
+
+    @test @inferred(ccdf(Log10Normal(0 // 1, 0 // 1), 1 // 1)) === 0.0
+    @test @inferred(ccdf(Log10Normal(0 // 1, 0 // 1), 0 // 1)) === 1.0
+    @test @inferred(ccdf(Log10Normal(0 // 1, 0 // 1), -1 // 1)) === 1.0
+    @test isnan_type(Float64, @inferred(ccdf(Log10Normal(0 // 1, 0 // 1), NaN)))
+
+    @test @inferred(ccdf(Log10Normal(0.0, 0.0), BigInt(1))) == big(0.0)
+    @test @inferred(ccdf(Log10Normal(0.0, 0.0), BigInt(0))) == big(1.0)
+    @test @inferred(ccdf(Log10Normal(0.0, 0.0), BigInt(-1))) == big(1.0)
+    @test @inferred(ccdf(Log10Normal(0.0, 0.0), BigFloat(1))) == big(0.0)
+    @test @inferred(ccdf(Log10Normal(0.0, 0.0), BigFloat(0))) == big(1.0)
+    @test @inferred(ccdf(Log10Normal(0.0, 0.0), BigFloat(-1))) == big(1.0)
+    @test isnan_type(BigFloat, @inferred(ccdf(Log10Normal(0.0, 0.0), BigFloat(NaN))))
+
+    # logccdf
+    @test @inferred(logccdf(Log10Normal(0.0, 0.0), 1.0)) === -Inf
+    @test @inferred(logccdf(Log10Normal(0.0, 0.0), 0.5)) === -0.0
+    @test @inferred(logccdf(Log10Normal(0.0, 0.0), 0.0)) === -0.0
+    @test @inferred(logccdf(Log10Normal(0.0, 0.0), -0.5)) === -0.0
+
+    @test @inferred(logccdf(Log10Normal(0.0, 0.0), 1.0f0)) === -Inf
+    @test @inferred(logccdf(Log10Normal(0.0f0, 0.0f0), 1.0)) === -Inf
+    @test @inferred(logccdf(Log10Normal(0.0f0, 0.0f0), 1.0f0)) === -Inf32
+
+    @test isnan_type(Float64, @inferred(logccdf(Log10Normal(0.0, 0.0), NaN)))
+    @test isnan_type(Float64, @inferred(logccdf(Log10Normal(NaN, 0.0), 1.0f0)))
+    @test isnan_type(Float64, @inferred(logccdf(Log10Normal(NaN, 0.0), 0.0f0)))
+    @test isnan_type(Float64, @inferred(logccdf(Log10Normal(NaN, 0.0), -1.0f0)))
+
+    @test isnan_type(Float32, @inferred(logccdf(Log10Normal(NaN32, 0.0f0), 1.0f0)))
+    @test isnan_type(Float32, @inferred(logccdf(Log10Normal(NaN32, 0.0f0), 0.0f0)))
+    @test isnan_type(Float32, @inferred(logccdf(Log10Normal(NaN32, 0.0f0), -1.0f0)))
+
+    @test @inferred(logccdf(Log10Normal(0 // 1, 0 // 1), 1 // 1)) === -Inf
+    @test @inferred(logccdf(Log10Normal(0 // 1, 0 // 1), 0 // 1)) === -0.0
+    @test @inferred(logccdf(Log10Normal(0 // 1, 0 // 1), -1 // 1)) === -0.0
+    @test isnan_type(Float64, @inferred(logccdf(Log10Normal(0 // 1, 0 // 1), NaN)))
+
+    @test @inferred(logccdf(Log10Normal(0.0, 0.0), BigInt(1))) == big(-Inf)
+    @test @inferred(logccdf(Log10Normal(0.0, 0.0), BigInt(0))) == big(0.0)
+    @test @inferred(logccdf(Log10Normal(0.0, 0.0), BigInt(-1))) == big(0.0)
+    @test @inferred(logccdf(Log10Normal(0.0, 0.0), BigFloat(1))) == big(-Inf)
+    @test @inferred(logccdf(Log10Normal(0.0, 0.0), BigFloat(0))) == big(0.0)
+    @test @inferred(logccdf(Log10Normal(0.0, 0.0), BigFloat(-1))) == big(0.0)
+    @test isnan_type(BigFloat, @inferred(logccdf(Log10Normal(0.0, 0.0), BigFloat(NaN))))
+
+    # quantile
+    @test @inferred(quantile(Log10Normal(1.0, 0.0), 0.0f0)) === 0.0
+    @test @inferred(quantile(Log10Normal(1.0, 0.0f0), 1.0)) === Inf
+    @test @inferred(quantile(Log10Normal(1.0f0, 0.0), 0.5)) ===  exp10(1)
+    @test isnan_type(Float64, @inferred(quantile(Log10Normal(1.0f0, 0.0), NaN)))
+    @test @inferred(quantile(Log10Normal(1.0f0, 0.0f0), 0.0f0)) === 0.0f0
+    @test @inferred(quantile(Log10Normal(1.0f0, 0.0f0), 1.0f0)) === Inf32
+    @test @inferred(quantile(Log10Normal(1.0f0, 0.0f0), 0.5f0)) === exp10(1.0f0)
+    @test isnan_type(Float32, @inferred(quantile(Log10Normal(1.0f0, 0.0f0), NaN32)))
+    @test @inferred(quantile(Log10Normal(1//1, 0//1), 1//2)) === exp10(1)
+
+    # cquantile
+    @test @inferred(cquantile(Log10Normal(1.0, 0.0), 0.0f0)) === Inf
+    @test @inferred(cquantile(Log10Normal(1.0, 0.0f0), 1.0)) === 0.0
+    @test @inferred(cquantile(Log10Normal(1.0f0, 0.0), 0.5)) === exp10(1)
+    @test isnan_type(Float64, @inferred(cquantile(Log10Normal(1.0f0, 0.0), NaN)))
+    @test @inferred(cquantile(Log10Normal(1.0f0, 0.0f0), 0.0f0)) === Inf32
+    @test @inferred(cquantile(Log10Normal(1.0f0, 0.0f0), 1.0f0)) === 0.0f0
+    @test @inferred(cquantile(Log10Normal(1.0f0, 0.0f0), 0.5f0)) === exp10(1.0f0)
+    @test isnan_type(Float32, @inferred(cquantile(Log10Normal(1.0f0, 0.0f0), NaN32)))
+    @test @inferred(cquantile(Log10Normal(1//1, 0//1), 1//2)) === exp10(1)
+
+    # gradlogpdf
+    @test @inferred(gradlogpdf(Log10Normal(0.0, 1.0), 1.0)) === -1.0
+    # @test @inferred(gradlogpdf(Log10Normal(0.0, 1.0), 5^(-2*log(2)-log(5)) * exp(-log(2)^2))) ≈ 0.0 atol=1e-12
+    @test @inferred(gradlogpdf(Log10Normal(0.0, 1.0), 0.0)) === 0.0
+    @test @inferred(gradlogpdf(Log10Normal(0.0, 1.0), -0.5)) === 0.0
+
+    @test @inferred(gradlogpdf(Log10Normal(0.0, 1.0), 1.0f0)) === -1.0
+    @test @inferred(gradlogpdf(Log10Normal(0.0f0, 1.0f0), 1.0)) === -1.0
+    @test @inferred(gradlogpdf(Log10Normal(0.0f0, 1.0f0), 1.0f0)) === -1.0f0
+
+    @test isnan_type(Float64, @inferred(logccdf(Log10Normal(0.0, 1.0), NaN)))
+    @test isnan_type(Float64, @inferred(logccdf(Log10Normal(NaN, 1.0), 1.0f0)))
+    @test isnan_type(Float64, @inferred(logccdf(Log10Normal(NaN, 1.0), 0.0f0)))
+    @test isnan_type(Float64, @inferred(logccdf(Log10Normal(NaN, 1.0), -1.0f0)))
+
+    @test isnan_type(Float32, @inferred(logccdf(Log10Normal(NaN32, 1.0f0), 1.0f0)))
+    @test isnan_type(Float32, @inferred(logccdf(Log10Normal(NaN32, 1.0f0), 0.0f0)))
+    @test isnan_type(Float32, @inferred(logccdf(Log10Normal(NaN32, 1.0f0), -1.0f0)))
+
+    @test @inferred(gradlogpdf(Log10Normal(0 // 1, 1 // 1), 1 // 1)) === -1.0
+    @test @inferred(gradlogpdf(Log10Normal(0 // 1, 1 // 1), 0 // 1)) === 0.0
+    @test @inferred(gradlogpdf(Log10Normal(0 // 1, 1 // 1), -1 // 1)) === 0.0
+    @test isnan_type(Float64, @inferred(gradlogpdf(Log10Normal(0 // 1, 1 // 1), NaN)))
+
+    @test @inferred(gradlogpdf(Log10Normal(0.0, 1.0), BigInt(1))) == big(-1.0)
+    @test @inferred(gradlogpdf(Log10Normal(0.0, 1.0), BigInt(0))) == big(0.0)
+    @test @inferred(gradlogpdf(Log10Normal(0.0, 1.0), BigInt(-1))) == big(0.0)
+    @test @inferred(gradlogpdf(Log10Normal(0.0, 1.0), BigFloat(1))) == big(-1.0)
+    @test @inferred(gradlogpdf(Log10Normal(0.0, 1.0), BigFloat(0))) == big(0.0)
+    @test @inferred(gradlogpdf(Log10Normal(0.0, 1.0), BigFloat(-1))) == big(0.0)
+    @test isnan_type(BigFloat, @inferred(gradlogpdf(Log10Normal(0.0, 1.0), BigFloat(NaN))))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,7 @@ const tests = [
     "cauchy",
     "uniform",
     "lognormal",
+    "log10normal",
     "mvnormal",
     "mvlognormal",
     "types",


### PR DESCRIPTION
The existing lognormal distribution in Distributions.jl is nice, but for my work I also require a lognormal distribution defined in base 10; e.g., if X ~ Normal(a,b); 10^x ~ Log10Normal(a,b). This is relatively common in astrophysical applications and it seems there are implementations of this in other software ecosystems for applications like risk modelling, so I think it is a worthwhile addition. 

I did my best on the statistical quantities (e.g., skewness, kurtosis) but I'm not a statistician and have never computed these before. 

I based my tests on those already existing for the lognormal distribution. I added a doc entry in docs/src/univariate.md including a plot of the PDF. 

Please let me know if you require any revisions or additions to merge.