### PR TITLE
Fix deprecation of `Product`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.65"
+version = "0.25.66"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/multivariate/product.jl
+++ b/src/multivariate/product.jl
@@ -17,16 +17,17 @@ struct Product{
     V<:AbstractVector{T},
 } <: MultivariateDistribution{S}
     v::V
-    function Product(v::V) where
-        V<:AbstractVector{T} where
-        T<:UnivariateDistribution{S} where
-        S<:ValueSupport
-        Base.depwarn(
-            "`Product(v)` is deprecated, please use `product_distribution(v)`",
-            :Product,
-        )
-        return new{S, T, V}(v)
+    function Product{S,T,V}(v::V) where {S<:ValueSupport,T<:UnivariateDistribution{S},V<:AbstractVector{T}}
+        return new{S,T,V}(v)
     end
+end
+
+function Product(v::V) where {S<:ValueSupport,T<:UnivariateDistribution{S},V<:AbstractVector{T}}
+    Base.depwarn(
+        "`Product(v)` is deprecated, please use `product_distribution(v)`",
+        :Product,
+    )
+    return Product{S, T, V}(v)
 end
 
 length(d::Product) = length(d.v)
@@ -51,6 +52,6 @@ maximum(d::Product) = map(maximum, d.v)
 # will be removed when `Product` is removed
 # it will return a `ProductDistribution` then which is already the default for
 # higher-dimensional arrays and distributions
-function product_distribution(dists::V) where {S<:ValueSupport,T<:UnivariateDistribution{S},V<:AbstractVector{S}}
+function product_distribution(dists::V) where {S<:ValueSupport,T<:UnivariateDistribution{S},V<:AbstractVector{T}}
     return Product{S,T,V}(dists)
 end

--- a/src/multivariate/product.jl
+++ b/src/multivariate/product.jl
@@ -48,9 +48,9 @@ insupport(d::Product, x::AbstractVector) = all(insupport.(d.v, x))
 minimum(d::Product) = map(minimum, d.v)
 maximum(d::Product) = map(maximum, d.v)
 
-# TODO: remove deprecation when `Product` is removed
+# will be removed when `Product` is removed
 # it will return a `ProductDistribution` then which is already the default for
 # higher-dimensional arrays and distributions
-Base.@deprecate product_distribution(
-    dists::AbstractVector{<:UnivariateDistribution}
-) Product(dists)
+function product_distribution(dists::V) where {S<:ValueSupport,T<:UnivariateDistribution{S},V<:AbstractVector{S}}
+    return Product{S,T,V}(dists)
+end

--- a/src/product.jl
+++ b/src/product.jl
@@ -24,7 +24,7 @@ function ProductDistribution(dists::AbstractArray{<:Distribution{ArrayLikeVariat
     return ProductDistribution{M + N,M,typeof(dists)}(dists)
 end
 
-function ProductDistribution(dists::Tuple{Vararg{<:Distribution{ArrayLikeVariate{M}},N}}) where {M,N}
+function ProductDistribution(dists::NTuple{N,Distribution{ArrayLikeVariate{M}}}) where {M,N}
     return ProductDistribution{M + 1,M,typeof(dists)}(dists)
 end
 
@@ -33,10 +33,10 @@ _product_valuesupport(dists) = mapreduce(value_support ∘ typeof, promote_type,
 _product_eltype(dists) = mapreduce(eltype, promote_type, dists)
 
 # type-stable and faster implementations for tuples
-function _product_valuesupport(dists::Tuple{Vararg{<:Distribution}})
+function _product_valuesupport(dists::NTuple{<:Any,Distribution})
     return __product_promote_type(value_support, typeof(dists))
 end
-function _product_eltype(dists::Tuple{Vararg{<:Distribution}})
+function _product_eltype(dists::NTuple{<:Any,Distribution})
     return __product_promote_type(eltype, typeof(dists))
 end
 
@@ -54,7 +54,7 @@ function _product_size(dists::AbstractArray{<:Distribution{<:ArrayLikeVariate{M}
     size_dists = size(dists)
     return ntuple(i -> i <= M ? size_d[i] : size_dists[i-M], Val(M + N))
 end
-function _product_size(dists::Tuple{Vararg{<:Distribution{<:ArrayLikeVariate{M}},N}}) where {M,N}
+function _product_size(dists::NTuple{N,Distribution{<:ArrayLikeVariate{M}}}) where {M,N}
     size_d = size(first(dists))
     all(size(d) == size_d for d in dists) || error("all distributions must be of the same size")
     return ntuple(i -> i <= M ? size_d[i] : N, Val(M + 1))

--- a/test/product.jl
+++ b/test/product.jl
@@ -92,7 +92,7 @@ end
 @testset "Testing iid product distributions" begin
     Random.seed!(123456)
     N = 11
-    d = Product(Fill(Laplace(0.0, 2.3), N))
+    d = @test_deprecated(Product(Fill(Laplace(0.0, 2.3), N)))
     @test N == length(unique(rand(d)));
     @test mean(d) === Fill(0.0, N)
     @test cov(d) === Diagonal(Fill(var(Laplace(0.0, 2.3)), N))

--- a/test/product.jl
+++ b/test/product.jl
@@ -39,7 +39,7 @@ end
     ubound = rand(N)
     ds = Uniform.(-ubound, ubound)
     x = rand.(ds)
-    d_product = @test_deprecated(product_distribution(ds))
+    d_product = product_distribution(ds)
     @test d_product isa Product
     # Check that methods for `Product` are consistent.
     @test length(d_product) == length(ds)
@@ -70,7 +70,7 @@ end
         support = fill(a, N)
         ds = DiscreteNonParametric.(support, Ref([0.5, 0.5]))
         x = rand.(ds)
-        d_product = @test_deprecated(product_distribution(ds))
+        d_product = product_distribution(ds)
         @test d_product isa Product
         # Check that methods for `Product` are consistent.
         @test length(d_product) == length(ds)


### PR DESCRIPTION
Fixes #1589.

With this PR (and `julia --depwarn=yes`):
```julia
julia> product_distribution(fill(Weibull(), 5))
Product{Continuous, Weibull{Float64}, Vector{Weibull{Float64}}}(v=Weibull{Float64}[Weibull{Float64}(α=1.0, θ=1.0), Weibull{Float64}(α=1.0, θ=1.0), Weibull{Float64}(α=1.0, θ=1.0), Weibull{Float64}(α=1.0, θ=1.0), Weibull{Float64}(α=1.0, θ=1.0)])

julia> Product(fill(Weibull(), 5))
┌ Warning: Product(v) is deprecated, please use product_distribution(v)
│   caller = top-level scope at REPL[5]:1
└ @ Core REPL[5]:1
Product{Continuous, Weibull{Float64}, Vector{Weibull{Float64}}}(v=Weibull{Float64}[Weibull{Float64}(α=1.0, θ=1.0), Weibull{Float64}(α=1.0, θ=1.0), Weibull{Float64}(α=1.0, θ=1.0), Weibull{Float64}(α=1.0, θ=1.0), Weibull{Float64}(α=1.0, θ=1.0)])
```