### PR TITLE
Add alternate LogNormal constructor for arbitrary base

### DIFF
--- a/docs/src/univariate.md
+++ b/docs/src/univariate.md
@@ -317,6 +317,9 @@ LogNormal
 ```@example plotdensity
 plotdensity((0, 5), LogNormal, (0, 1)) # hide
 ```
+```@example plotdensity
+plotdensity((0, 5), LogNormal, (0, 1, 5)) # hide
+```
 
 ```@docs
 LogUniform

--- a/src/univariate/continuous/lognormal.jl
+++ b/src/univariate/continuous/lognormal.jl
@@ -10,10 +10,21 @@ f(x; \\mu, \\sigma) = \\frac{1}{x \\sqrt{2 \\pi \\sigma^2}}
 \\quad x > 0
 ```
 
+The log normal distribution is transformable between different log bases. For example, if ``X \\sim \\operatorname{Normal}(\\mu, \\sigma)``, then ``\\exp(X)`` is log-normally distributed, and more generally ``B^X`` is also log-normally distributed. In this more general case, the probability density function is
+
+```math
+f(x; \\mu, \\sigma, B) = \\frac{1}{x \\log(B) \\sqrt{2 \\pi \\sigma^2}}
+\\exp \\left( - \\frac{(\\log(B,x) - \\mu)^2}{2 \\sigma^2} \\right),
+\\quad x > 0, \\quad B > 0
+```
+
+where ``B`` is the base to which ``μ`` and ``σ`` are defined. A log normal distribution defined with a general base ``B``, denoted ``\\operatorname{LogNormal}(\\mu,\\sigma,B)``, is transformable to natural base ``e`` through the transformation ``Y \\sim \\operatorname{LogNormal}(\\mu,\\sigma,B) \\sim \\operatorname{LogNormal}(\\mu \\times \\log(B),\\sigma \\times \\log(B),e)``. If you provide a base to the constructor through the three-argument call ``\\operatorname{LogNormal}(\\mu,\\sigma,B)``, it will be transformed to natural base internally.
+
 ```julia
 LogNormal()          # Log-normal distribution with zero log-mean and unit scale
-LogNormal(μ)         # Log-normal distribution with log-mean mu and unit scale
-LogNormal(μ, σ)      # Log-normal distribution with log-mean mu and scale sig
+LogNormal(μ)         # Log-normal distribution with log-mean μ and unit scale
+LogNormal(μ, σ)      # Log-normal distribution with log-mean μ and scale σ
+LogNormal(μ, σ, B)   # Log-normal distribution with log-base-B-mean μ and scale σ
 
 params(d)            # Get the parameters, i.e. (μ, σ)
 meanlogx(d)          # Get the mean of log(X), i.e. μ
@@ -40,6 +51,13 @@ end
 LogNormal(μ::Real, σ::Real; check_args::Bool=true) = LogNormal(promote(μ, σ)...; check_args=check_args)
 LogNormal(μ::Integer, σ::Integer; check_args::Bool=true) = LogNormal(float(μ), float(σ); check_args=check_args)
 LogNormal(μ::Real=0.0) = LogNormal(μ, one(μ); check_args=false)
+
+# for arbitrary base
+function LogNormal(μ::Real, σ::Real, B::Real; check_args::Bool=true)
+    @check_args LogNormal (B, B ≥ zero(B))
+    lb = log(B)
+    LogNormal(promote(μ * lb, σ * lb)...; check_args=check_args)
+end
 
 @distr_support LogNormal 0.0 Inf
 

--- a/test/lognormal.jl
+++ b/test/lognormal.jl
@@ -10,6 +10,17 @@ isnan_type(::Type{T}, v) where {T} = isnan(v) && v isa T
     d = LogNormal(0, 1)
     @test convert(LogNormal{Float64}, d) === d
     @test convert(LogNormal{Float32}, d) isa LogNormal{Float32}
+    # test three-argument constructor
+    d = LogNormal(0, 1, 10)
+    @test convert(LogNormal{Float64}, d) === d
+    @test convert(LogNormal{Float32}, d) isa LogNormal{Float32}
+    @test LogNormal(0, 1, 10.0) isa LogNormal{Float64}
+    @test LogNormal(0, 1, 10.0f0) isa LogNormal{Float32}
+    @test LogNormal(0, Float16(1), 10.0f0) isa LogNormal{Float32}
+    @test pdf(d,1.0) == inv(log(10)*sqrt(2π))
+    d = LogNormal(2.0, 0.2, 10)
+    @test pdf(d,100.0) == inv(100.0*log(10)*sqrt(2π)*0.2)
+    @test pdf(d,150.0) ≈ inv(150.0*log(10)*sqrt(2π)*0.2) * exp( -0.5 * (log10(150.0) - 2.0)^2 / 0.2^2 )
 
     @test logpdf(LogNormal(0, 0), 1) === Inf
     @test logpdf(LogNormal(), Inf) === -Inf


### PR DESCRIPTION
As discussed in [#1586](https://github.com/JuliaStats/Distributions.jl/pull/1586), this PR adds a new constructor for the LogNormal distribution that takes logB-mean \mu and scale \sigma in an arbitrary base B and converts it to a natural base-e LogNormal distribution. I added a few tests for type stability and PDF accuracy along with documentation for the new constructor.

I wasn't sure whether I should change the call signature in the documentation to something like `LogNormal(\sigma,\mu [,B])` but I tried to follow the correct style when updating the docs. Let me know what revisions you'd like to see