### PR TITLE
Fix mini typos in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Julia package for probability distributions and associated functions. Particul
 * Moments (e.g mean, variance, skewness, and kurtosis), entropy, and other properties
 * Probability density/mass functions (pdf) and their logarithm (logpdf)
 * Moment generating functions and characteristic functions
-* Sampling from population or from a distribution
+* Sampling a population or a distribution
 * Maximum likelihood estimation
 
 **Note:** The functionalities related to conjugate priors have been moved to the [ConjugatePriors package](https://github.com/JuliaStats/ConjugatePriors.jl).
@@ -32,7 +32,7 @@ Also, for casual conversation and quick questions, there are the channels `#help
 
 ### Reporting issues
 
-* If you need help or an explanation how to use *Distributions* ask in the forum (https://discourse.julialang.org) or, for informal questions, visit the chat (https://julialang.slack.com).
+* If you need help or an explanation of how to use *Distributions* ask in the forum (https://discourse.julialang.org) or, for informal questions, visit the chat (https://julialang.slack.com).
 
 If you have a bug linked with *Distributions*, check that it has
 not been reported yet on the issues of the repository.
@@ -42,8 +42,8 @@ which you can get with this command in the Julia REPL:
 julia> ]status Distributions
 ```
 
-Be exhaustive in your report, give the summary of the bug,
-a Minimal Working Example (MWE), what happens and what you
+Be exhaustive in your report, summarize the bug, and provide:
+a Minimal Working Example (MWE), what happens, and what you
 expected to happen.
 
 ### Workflow with Git and GitHub
@@ -61,7 +61,7 @@ the following are required for contributions to be accepted:
 1. Docstrings must be added to all interface and non-trivial functions.
 2. Tests validating the modified behavior in the `test` folder. If new test files are added, do not forget to add them in `test/runtests.jl`. Cover possible edge cases. Run the tests locally before submitting the PR.
 3. At the end of the tests, `Test.detect_ambiguities(Distributions)` is run to check method ambiguities. Verify that your modified code did not yield method ambiguities.
-4. Make according modifications to the `docs` folder, build the documentation locally and verify that your modifications display correctly and did not yield warnings. To build the documentation locally, you first need to instantiate the `docs/` project:
+4. Make corresponding modifications to the `docs` folder, build the documentation locally and verify that your modifications display correctly and did not yield warnings. To build the documentation locally, you first need to instantiate the `docs/` project:
 
        julia --project=docs/
        pkg> instantiate

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Julia package for probability distributions and associated functions. Particul
 * Moments (e.g mean, variance, skewness, and kurtosis), entropy, and other properties
 * Probability density/mass functions (pdf) and their logarithm (logpdf)
 * Moment generating functions and characteristic functions
-* Sampling a population or a distribution
+* Sampling from a population or from a distribution
 * Maximum likelihood estimation
 
 **Note:** The functionalities related to conjugate priors have been moved to the [ConjugatePriors package](https://github.com/JuliaStats/ConjugatePriors.jl).

--- a/docs/src/extends.md
+++ b/docs/src/extends.md
@@ -15,7 +15,7 @@ Unlike full-fledged distributions, a sampler, in general, only provides limited 
 
 ### Univariate Sampler
 
-To implement a univariate sampler, one can define a sub-type (say `Spl`) of `Sampleable{Univariate,S}` (where `S` can be `Discrete` or `Continuous`), and provide a `rand` method, as
+To implement a univariate sampler, one can define a subtype (say `Spl`) of `Sampleable{Univariate,S}` (where `S` can be `Discrete` or `Continuous`), and provide a `rand` method, as
 
 ```julia
 function rand(rng::AbstractRNG, s::Spl)
@@ -27,7 +27,7 @@ The package already implements a vectorized version of `rand!` and `rand` that r
 
 ### Multivariate Sampler
 
-To implement a multivariate sampler, one can define a sub-type of `Sampleable{Multivariate,S}`, and provide both `length` and `_rand!` methods, as
+To implement a multivariate sampler, one can define a subtype of `Sampleable{Multivariate,S}`, and provide both `length` and `_rand!` methods, as
 
 ```julia
 Base.length(s::Spl) = ... # return the length of each sample
@@ -80,7 +80,7 @@ Remember that each *column* of A is a sample.
 
 ### Matrix-variate Sampler
 
-To implement a multivariate sampler, one can define a sub-type of `Sampleable{Multivariate,S}`, and provide both `size` and `_rand!` methods, as
+To implement a multivariate sampler, one can define a subtype of `Sampleable{Multivariate,S}`, and provide both `size` and `_rand!` methods, as
 
 ```julia
 Base.size(s::Spl) = ... # the size of each matrix sample

--- a/docs/src/extends.md
+++ b/docs/src/extends.md
@@ -1,21 +1,21 @@
 # Create New Samplers and Distributions
 
-Whereas this package already provides a large collection of common distributions out of box, there are still occasions where you want to create new distributions (*e.g* your application requires a special kind of distributions, or you want to contribute to this package).
+Whereas this package already provides a large collection of common distributions out of the box, there are still occasions where you want to create new distributions (*e.g.* your application requires a special kind of distribution, or you want to contribute to this package).
 
 Generally, you don't have to implement every API method listed in the documentation. This package provides a series of generic functions that turn a small number of internal methods into user-end API methods. What you need to do is to implement this small set of internal methods for your distributions.
 
-By default, `Discrete` sampleables have support of type `Int` while `Continuous` sampleables have support of type `Float64`. If this assumption does not hold for your new distribution or sampler, or its `ValueSupport` is neither `Discrete` nor `Continuous`, you should implement the `eltype` method in addition to the other methods listed below.
+By default, `Discrete` sampleables have the support of type `Int` while `Continuous` sampleables have the support of type `Float64`. If this assumption does not hold for your new distribution or sampler, or its `ValueSupport` is neither `Discrete` nor `Continuous`, you should implement the `eltype` method in addition to the other methods listed below.
 
-**Note:** the methods need to be implemented are different for distributions of different variate forms.
+**Note:** The methods that need to be implemented are different for distributions of different variate forms.
 
 
 ## Create a Sampler
 
-Unlike a full fledged distributions, a sampler, in general, only provides limited functionalities, mainly to support sampling.
+Unlike full-fledged distributions, a sampler, in general, only provides limited functionalities, mainly to support sampling.
 
 ### Univariate Sampler
 
-To implement a univariate sampler, one can define a sub type (say `Spl`) of `Sampleable{Univariate,S}` (where `S` can be `Discrete` or `Continuous`), and provide a `rand` method, as
+To implement a univariate sampler, one can define a sub-type (say `Spl`) of `Sampleable{Univariate,S}` (where `S` can be `Discrete` or `Continuous`), and provide a `rand` method, as
 
 ```julia
 function rand(rng::AbstractRNG, s::Spl)
@@ -27,7 +27,7 @@ The package already implements a vectorized version of `rand!` and `rand` that r
 
 ### Multivariate Sampler
 
-To implement a multivariate sampler, one can define a sub type of `Sampleable{Multivariate,S}`, and provide both `length` and `_rand!` methods, as
+To implement a multivariate sampler, one can define a sub-type of `Sampleable{Multivariate,S}`, and provide both `length` and `_rand!` methods, as
 
 ```julia
 Base.length(s::Spl) = ... # return the length of each sample
@@ -68,7 +68,7 @@ rand(rng::AbstractRNG, s::Sampleable{Multivariate,S}, n::Int) where {S<:ValueSup
     _rand!(rng, s, Matrix{eltype(S)}(length(s), n))
 ```
 
-If there is a more efficient method to generate multiple vector samples in batch, one should provide the following method
+If there is a more efficient method to generate multiple vector samples in a batch, one should provide the following method
 
 ```julia
 function _rand!(rng::AbstractRNG, s::Spl, A::DenseMatrix{T}) where T<:Real
@@ -80,7 +80,7 @@ Remember that each *column* of A is a sample.
 
 ### Matrix-variate Sampler
 
-To implement a multivariate sampler, one can define a sub type of `Sampleable{Multivariate,S}`, and provide both `size` and `_rand!` method, as
+To implement a multivariate sampler, one can define a sub-type of `Sampleable{Multivariate,S}`, and provide both `size` and `_rand!` methods, as
 
 ```julia
 Base.size(s::Spl) = ... # the size of each matrix sample
@@ -104,7 +104,7 @@ sampler(d::Distribution)
 
 A univariate distribution type should be defined as a subtype of `DiscreteUnivarateDistribution` or `ContinuousUnivariateDistribution`.
 
-Following methods need to be implemented for each univariate distribution type:
+The following methods need to be implemented for each univariate distribution type:
 
 - [`rand(::AbstractRNG, d::UnivariateDistribution)`](@ref)
 - [`sampler(d::Distribution)`](@ref)
@@ -134,7 +134,7 @@ You may refer to the source file `src/univariates.jl` to see details about how g
 
 A multivariate distribution type should be defined as a subtype of `DiscreteMultivarateDistribution` or `ContinuousMultivariateDistribution`.
 
-Following methods need to be implemented for each multivariate distribution type:
+The following methods need to be implemented for each multivariate distribution type:
 
 - [`length(d::MultivariateDistribution)`](@ref)
 - [`sampler(d::Distribution)`](@ref)
@@ -142,7 +142,7 @@ Following methods need to be implemented for each multivariate distribution type
 - [`Distributions._rand!(::AbstractRNG, d::MultivariateDistribution, x::AbstractArray)`](@ref)
 - [`Distributions._logpdf(d::MultivariateDistribution, x::AbstractArray)`](@ref)
 
-Note that if there exists faster methods for batch evaluation, one should override `_logpdf!` and `_pdf!`.
+Note that if there exist faster methods for batch evaluation, one should override `_logpdf!` and `_pdf!`.
 
 Furthermore, the generic `loglikelihood` function repeatedly calls `_logpdf`. If there is
 a better way to compute the log-likelihood, one should override `loglikelihood`.
@@ -158,7 +158,7 @@ It is also recommended that one also implements the following statistics functio
 
 A multivariate distribution type should be defined as a subtype of `DiscreteMatrixDistribution` or `ContinuousMatrixDistribution`.
 
-Following methods need to be implemented for each matrix-variate distribution type:
+The following methods need to be implemented for each matrix-variate distribution type:
 
 - [`size(d::MatrixDistribution)`](@ref)
 - [`rand(d::MatrixDistribution)`](@ref)

--- a/docs/src/fit.md
+++ b/docs/src/fit.md
@@ -10,7 +10,7 @@ This statement fits a distribution of type `D` to a given dataset `x`, where `x`
 
 !!! note
 
-    One can use as first argument simply the distribution name, like `Binomial`,
+    One can use as the first argument simply the distribution name, like `Binomial`,
     or a concrete distribution with a type parameter, like `Normal{Float64}` or
     `Exponential{Float32}`.  However, in the latter case the type parameter of
     the distribution will be ignored:
@@ -61,7 +61,7 @@ The `fit_mle` method has been implemented for the following distributions:
 - [`MvNormal`](@ref)
 - [`Dirichlet`](@ref)
 
-For most of these distributions, the usage is as described above. For a few special distributions that require additional information for estimation, we have to use modified interface:
+For most of these distributions, the usage is as described above. For a few special distributions that require additional information for estimation, we have to use a modified interface:
 
 ```julia
 fit_mle(Binomial, n, x)        # n is the number of trials in each experiment
@@ -76,7 +76,7 @@ fit_mle(Categorical, x, w)
 
 ## Sufficient Statistics
 
-For many distributions, estimation can be based on (sum of) sufficient statistics computed from a dataset. To simplify implementation, for such distributions, we implement `suffstats` method instead of `fit_mle` directly:
+For many distributions, the estimation can be based on (sum of) sufficient statistics computed from a dataset. To simplify implementation, for such distributions, we implement `suffstats` method instead of `fit_mle` directly:
 
 ```julia
 ss = suffstats(D, x)        # ss captures the sufficient statistics of x

--- a/docs/src/mixture.md
+++ b/docs/src/mixture.md
@@ -1,6 +1,6 @@
 # Mixture Models
 
-A [mixture model](http://en.wikipedia.org/wiki/Mixture_model) is a probabilistic distribution that combines a set of *component* to represent the overall distribution. Generally, the probability density/mass function is given by a convex combination of the pdf/pmf of individual components, as
+A [mixture model](http://en.wikipedia.org/wiki/Mixture_model) is a probabilistic distribution that combines a set of *components* to represent the overall distribution. Generally, the probability density/mass function is given by a convex combination of the pdf/pmf of individual components, as
 
 ```math
 f_{mix}(x; \Theta, \pi) = \sum_{k=1}^K \pi_k f(x; \theta_k)
@@ -27,7 +27,7 @@ const MultivariateMixture  = AbstractMixtureModel{Multivariate}
 
 **Remarks:**
 
-- We introduce `AbstractMixtureModel` as a base type, which allows one to define a mixture model with different internal implementation, while still being able to leverage the common methods defined for `AbstractMixtureModel`.
+- We introduce `AbstractMixtureModel` as a base type, which allows one to define a mixture model with different internal implementations, while still being able to leverage the common methods defined for `AbstractMixtureModel`.
 
 ```@docs
 AbstractMixtureModel
@@ -105,5 +105,5 @@ rand!(::AbstractMixtureModel, ::AbstractArray)
 
 ## Estimation
 
-There are a number of methods for estimating of mixture models from data, and this problem remains an open research topic.
+There are several methods for the estimation of mixture models from data, and this problem remains an open research topic.
 This package does not provide facilities for estimating mixture models. One can resort to other packages, *e.g.* [*GaussianMixtures.jl*](https://github.com/davidavdav/GaussianMixtures.jl), for this purpose.

--- a/docs/src/multivariate.md
+++ b/docs/src/multivariate.md
@@ -35,7 +35,7 @@ pdf(::MultivariateDistribution, ::AbstractArray)
 logpdf(::MultivariateDistribution, ::AbstractArray)
 loglikelihood(::MultivariateDistribution, ::AbstractVector{<:Real})
 ```
-**Note:** For multivariate distributions, the pdf value is usually very small or large, and therefore direct evaluation of the pdf may cause numerical problems. It is generally advisable to perform probability computation on a log scale.
+**Note:** For multivariate distributions, the pdf value is usually very small or large, and therefore direct evaluation of the pdf may cause numerical problems. It is generally advisable to perform probability computation in log scale.
 
 
 ### Sampling

--- a/docs/src/multivariate.md
+++ b/docs/src/multivariate.md
@@ -11,7 +11,7 @@ const ContinuousMultivariateDistribution = Distribution{Multivariate, Continuous
 
 ## Common Interface
 
-The methods listed as below are implemented for each multivariate distribution, which provides a consistent interface to work with multivariate distributions.
+The methods listed below are implemented for each multivariate distribution, which provides a consistent interface to work with multivariate distributions.
 
 ### Computation of statistics
 
@@ -35,7 +35,7 @@ pdf(::MultivariateDistribution, ::AbstractArray)
 logpdf(::MultivariateDistribution, ::AbstractArray)
 loglikelihood(::MultivariateDistribution, ::AbstractVector{<:Real})
 ```
-**Note:** For multivariate distributions, the pdf value is usually very small or large, and therefore direct evaluating the pdf may cause numerical problems. It is generally advisable to perform probability computation in log-scale.
+**Note:** For multivariate distributions, the pdf value is usually very small or large, and therefore direct evaluation of the pdf may cause numerical problems. It is generally advisable to perform probability computation on a log scale.
 
 
 ### Sampling
@@ -45,7 +45,7 @@ rand(rng::AbstractRNG, ::MultivariateDistribution)
 rand!(rng::AbstractRNG, d::MultivariateDistribution, x::AbstractArray)
 ```
 
-**Note:** In addition to these common methods, each multivariate distribution has its own special methods, as introduced below.
+**Note:** In addition to these common methods, each multivariate distribution has its special methods, as introduced below.
 
 
 ## Distributions
@@ -98,7 +98,7 @@ scale!{D<:Distributions.AbstractMvLogNormal}(::Type{D},s::Symbol,m::AbstractVect
 params{D<:Distributions.AbstractMvLogNormal}(::Type{D},m::AbstractVector,S::AbstractMatrix)
 ```
 
-## Internal Methods (for creating you own multivariate distribution)
+## Internal Methods (for creating your own multivariate distribution)
 
 ```@docs
 Distributions._logpdf(d::MultivariateDistribution, x::AbstractArray)

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -23,7 +23,7 @@ Base.rand(::Distributions.Sampleable)
 Distributions.VariateForm
 ```
 
-The `VariateForm` sub-types defined in `Distributions.jl` are:
+The `VariateForm` subtypes defined in `Distributions.jl` are:
 
 **Type** | **A single sample** | **Multiple samples**
 --- | --- |---
@@ -51,7 +51,7 @@ Distributions.Continuous
 
 Multiple samples are often organized into an array, depending on the variate form.
 
-The basic functionalities that a sampleable object provides is to *retrieve information about the samples it generates* and to *draw samples*. Particularly, the following functions are provided for sampleable objects:
+The basic functionalities that a sampleable object provides are to *retrieve information about the samples it generates* and to *draw samples*. Particularly, the following functions are provided for sampleable objects:
 
 ```@docs
 length(::Sampleable)
@@ -64,7 +64,7 @@ rand!(::AbstractRNG, ::Sampleable, ::AbstractArray)
 
 ## Distributions
 
-We use `Distribution`, a subtype of `Sampleable` as defined below, to capture probabilistic distributions. In addition to being sampleable, a *distribution* typically comes with an explicit way to combine its domain, probability density functions, among many other quantities.
+We use `Distribution`, a subtype of `Sampleable` as defined below, to capture probabilistic distributions. In addition to being sampleable, a *distribution* typically comes with an explicit way to combine its domain, probability density function, and many other quantities.
 
 ```julia
 abstract type Distribution{F<:VariateForm,S<:ValueSupport} <: Sampleable{F,S} end

--- a/docs/src/univariate.md
+++ b/docs/src/univariate.md
@@ -11,7 +11,7 @@ const ContinuousUnivariateDistribution = Distribution{Univariate, Continuous}
 
 ## Common Interface
 
-A series of methods are implemented for each univariate distribution, which provide
+A series of methods is implemented for each univariate distribution, which provides
 useful functionalities such as moment computation, pdf evaluation, and sampling
 (*i.e.* random number generation).
 
@@ -488,7 +488,7 @@ Skellam
 
 ### Vectorized evaluation
 
-Vectorized computation and inplace vectorized computation have been deprecated.
+Vectorized computation and in-place vectorized computation have been deprecated.
 
 ## Index
 

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -220,7 +220,7 @@ export
 
     invscale,           # Inverse scale parameter
     sqmahal,            # squared Mahalanobis distance to Gaussian center
-    sqmahal!,           # inplace evaluation of sqmahal
+    sqmahal!,           # in-place evaluation of sqmahal
     location,           # get the location parameter
     location!,          # provide storage for the location parameter (used in multivariate distribution mvlognormal)
     mean,               # mean of distribution

--- a/src/univariate/continuous/skewedexponentialpower.jl
+++ b/src/univariate/continuous/skewedexponentialpower.jl
@@ -74,7 +74,7 @@ function m_k(d::SkewedExponentialPower, k::Integer)
         loggamma(inv_p) + log(abs((-1)^k * α^(1 + k) + (1 - α)^(1 + k)))
 end
 
-# needed for odd moments on log-scale
+# needed for odd moments on a logscale
 sgn(d::SkewedExponentialPower) = d.α > 1//2 ? -1 : 1
 
 mean(d::SkewedExponentialPower) = d.α == 1//2 ? float(d.μ) : sgn(d)*exp(m_k(d, 1)) + d.μ

--- a/src/univariate/continuous/skewedexponentialpower.jl
+++ b/src/univariate/continuous/skewedexponentialpower.jl
@@ -74,7 +74,7 @@ function m_k(d::SkewedExponentialPower, k::Integer)
         loggamma(inv_p) + log(abs((-1)^k * α^(1 + k) + (1 - α)^(1 + k)))
 end
 
-# needed for odd moments on a log scale
+# needed for odd moments in log scale
 sgn(d::SkewedExponentialPower) = d.α > 1//2 ? -1 : 1
 
 mean(d::SkewedExponentialPower) = d.α == 1//2 ? float(d.μ) : sgn(d)*exp(m_k(d, 1)) + d.μ

--- a/src/univariate/continuous/skewedexponentialpower.jl
+++ b/src/univariate/continuous/skewedexponentialpower.jl
@@ -74,7 +74,7 @@ function m_k(d::SkewedExponentialPower, k::Integer)
         loggamma(inv_p) + log(abs((-1)^k * α^(1 + k) + (1 - α)^(1 + k)))
 end
 
-# needed for odd moments on a logscale
+# needed for odd moments on a log scale
 sgn(d::SkewedExponentialPower) = d.α > 1//2 ? -1 : 1
 
 mean(d::SkewedExponentialPower) = d.α == 1//2 ? float(d.μ) : sgn(d)*exp(m_k(d, 1)) + d.μ

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -102,7 +102,7 @@ isprobvec(p::AbstractVector{<:Real}) =
 # get a type wide enough to represent all a distributions's parameters
 # (if the distribution is parametric)
 # if the distribution is not parametric, we need this to be a float so that
-# inplace pdf calculations, etc. allocate storage correctly
+# in-place pdf calculations, etc. allocate storage correctly
 @inline partype(::Distribution) = Float64
 
 # because X == X' keeps failing due to floating point nonsense


### PR DESCRIPTION
As part of the JuliaCon hackathon, I have run all the docs through Grammarly. In case of ambiguity (eg, inplace vs in-place), I have googled for the more popular spelling (often picked based on Wikipedia).

There were no changes to active code, ie, only comments or docs were changed.

Examples:
- log-scale --> on a log scale
- inplace --> in-place
- sub type (was inconsistently used) --> subtype

I'm happy to withdraw this PR if it's not helpful.