### PR TITLE
Add transforms for genericmvtdist

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.68"
+version = "0.25.69"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/multivariate/mvtdist.jl
+++ b/src/multivariate/mvtdist.jl
@@ -1,7 +1,13 @@
 # Multivariate t-distribution
 
 ## Generic multivariate t-distribution class
-
+"""
+Multivariate Student-T distribution support affine transformations:
+```julia
+d = GenericMvTDist(ν, μ, Σ)
+c + B * d    # == GenericMvTDist(d.df, B * μ + c, B * Σ * B')
+```
+"""
 abstract type AbstractMvTDist <: ContinuousMultivariateDistribution end
 
 struct GenericMvTDist{T<:Real, Cov<:AbstractPDMat, Mean<:AbstractVector} <: AbstractMvTDist
@@ -172,3 +178,11 @@ function _rand!(rng::AbstractRNG, d::GenericMvTDist, x::AbstractMatrix{T}) where
     x .= x ./ sqrt.(y ./ d.df) .+ d.μ
     x
 end
+
+### Affine transformations
+# Base.:+(d::GenericMvTDist, c::AbstractVector) = mvtdist(d.df, d.μ + c, d.Σ)
+# Base.:+(c::AbstractVector, d::GenericMvTDist) = d + c
+# Base.:-(d::GenericMvTDist, c::AbstractVector) = mvtdist(d.df, d.μ - c, d.Σ)
+
+# Base.:*(B::AbstractMatrix, d::GenericMvTDist) = mvtdist(d.df, B * d.μ, X_A_Xt(d.Σ, B))
+# Base.:*(B::GenericMvTDist, d::AbstractMatrix) = mvtdist(d.df, B * d.μ, X_A_Xt(d.Σ, B))

--- a/src/multivariate/mvtdist.jl
+++ b/src/multivariate/mvtdist.jl
@@ -180,9 +180,9 @@ function _rand!(rng::AbstractRNG, d::GenericMvTDist, x::AbstractMatrix{T}) where
 end
 
 ### Affine transformations
-# Base.:+(d::GenericMvTDist, c::AbstractVector) = mvtdist(d.df, d.μ + c, d.Σ)
-# Base.:+(c::AbstractVector, d::GenericMvTDist) = d + c
-# Base.:-(d::GenericMvTDist, c::AbstractVector) = mvtdist(d.df, d.μ - c, d.Σ)
+Base.:+(d::GenericMvTDist, c::AbstractVector) = mvtdist(d.df, d.μ + c, d.Σ)
+Base.:+(c::AbstractVector, d::GenericMvTDist) = d + c
+Base.:-(d::GenericMvTDist, c::AbstractVector) = mvtdist(d.df, d.μ - c, d.Σ)
 
-# Base.:*(B::AbstractMatrix, d::GenericMvTDist) = mvtdist(d.df, B * d.μ, X_A_Xt(d.Σ, B))
-# Base.:*(B::GenericMvTDist, d::AbstractMatrix) = mvtdist(d.df, B * d.μ, X_A_Xt(d.Σ, B))
+Base.:*(B::AbstractMatrix, d::GenericMvTDist) = mvtdist(d.df, B * d.μ, X_A_Xt(d.Σ, B))
+Base.:*(B::GenericMvTDist, d::AbstractMatrix) = mvtdist(d.df, B * d.μ, X_A_Xt(d.Σ, B))

--- a/test/multivariate/mvtdist.jl
+++ b/test/multivariate/mvtdist.jl
@@ -86,4 +86,50 @@ end
     x = rand(X_implicit)
     @test logpdf(X_implicit, x) ≈ logpdf(X_expicit, x)
 end
+
+@testset "MvNormal affine tranformations" begin
+    @testset "moment identities" begin
+        for n in 1:5                       # dimension
+            # distribution
+            μ = randn(n)
+            ν = 4
+            for Σ in (randn(n, n) |> A -> A*A',  # dense
+                      Diagonal(abs2.(randn(n)))) # diagonal
+                d = GenericMvTDist(ν, μ, PDMat(Σ))
+                
+                # random arrays for transformations
+                c = randn(n)
+                m = rand(1:n)
+                B = randn(m, n)
+                b = randn(n)
+
+                d_c = d + c
+                c_d = c + d
+                @test mean(d_c) == mean(c_d) == μ + c
+                @test cov(c_d) == cov(d_c) == cov(d)
+
+                d_c = d - c
+                @test mean(d_c) == μ - c
+                @test scale(d_c) == scale(d)
+
+                B_d = B * d
+                @test B_d isa GenericMvTDist
+                @test length(B_d) == m
+                @test mean(B_d) == B * μ
+                @test scale(B_d) ≈ B * Σ * B'
+
+                d_trans = B * (d + c)
+                d_trans == GenericMvTDist(ν, B * (μ + c), PDMat(X_A_Xt(d.Σ, B)))
+            end
+        end
+    end
+
+    @testset "dimension mismatch errors" begin
+        d4 = GenericMvTDist(4.5, zeros(4), PDMat(Diagonal(ones(4))))
+        o3 = ones(3)
+        @test_throws DimensionMismatch d4 + o3
+        @test_throws DimensionMismatch o3 + d4
+        @test_throws DimensionMismatch ones(3, 3) * d4
+    end
+end
 end


### PR DESCRIPTION
Solves #1607 

Similar to MvNormal, extends * + and - to the GenericMvTDist. This will allow for transformations of the form: 

```
[1,2] + Diagonal([2,2]) * GenericMvTDist(4.5, zeros(2,), PDMat(I(2)))
Distributions.MvTDist(
df: 4.5
dim: 2
μ: [1.0, 2.0]
Σ: [4.0 0.0; 0.0 4.0]
)
```

However, as discussed in the issue, I was unclear whether to use some of the other machinry in Distributions. Tests are essentially copied from the ones for MvNormal with appropriate changes. 

These changes don't effect the degress of freedom: see e.g. [here](http://users.isy.liu.se/en/rt/roth/student.pdf)