### PR TITLE
Return -Inf in logpdf of LKJCholesky when out of support

### DIFF
--- a/src/cholesky/lkjcholesky.jl
+++ b/src/cholesky/lkjcholesky.jl
@@ -136,7 +136,7 @@ function logkernel(d::LKJCholesky, R::LinearAlgebra.Cholesky)
 end
 
 function logpdf(d::LKJCholesky, R::LinearAlgebra.Cholesky)
-    insupport(d, R) || throw(DomainError(R, "provided point is not in the support"))
+    insupport(d, R) || return oftype(_logpdf(d, LinearAlgebra.Cholesky(zeros(eltype(R.factors), d.d, d.d), R.uplo, R.info)), -Inf)
     return _logpdf(d, R)
 end
 

--- a/src/cholesky/lkjcholesky.jl
+++ b/src/cholesky/lkjcholesky.jl
@@ -136,7 +136,7 @@ function logkernel(d::LKJCholesky, R::LinearAlgebra.Cholesky)
 end
 
 function logpdf(d::LKJCholesky, R::LinearAlgebra.Cholesky)
-    insupport(d, R) || throw(ArgumentError("provided point is not in the support"))
+    insupport(d, R) || throw(DomainError(R, "provided point is not in the support"))
     return _logpdf(d, R)
 end
 

--- a/src/cholesky/lkjcholesky.jl
+++ b/src/cholesky/lkjcholesky.jl
@@ -136,8 +136,8 @@ function logkernel(d::LKJCholesky, R::LinearAlgebra.Cholesky)
 end
 
 function logpdf(d::LKJCholesky, R::LinearAlgebra.Cholesky)
-    insupport(d, R) || return oftype(_logpdf(d, LinearAlgebra.Cholesky(zeros(eltype(R.factors), d.d, d.d), R.uplo, R.info)), -Inf)
-    return _logpdf(d, R)
+    lp = _logpdf(d, R)
+    return insupport(d, R) ? lp : oftype(lp, -Inf)
 end
 
 _logpdf(d::LKJCholesky, R::LinearAlgebra.Cholesky) = logkernel(d, R) + d.logc0

--- a/src/matrix/lkj.jl
+++ b/src/matrix/lkj.jl
@@ -195,8 +195,6 @@ function lkj_onion_loginvconst(d::Integer, η::T) where {T <: Real}
     for k in 3:d - 1
         sumlogs += (h * k) * logπ + loggamma(η + h * (d - 1 - k))
     end
-    α = η + h * d - 1
-    loginvconst = (2η + d - 3)*logtwo + logbeta(α, α) + sumlogs - (d - 2) * loggamma(η + h * (d - 1))
     return loginvconst
 end
 

--- a/src/matrix/lkj.jl
+++ b/src/matrix/lkj.jl
@@ -188,7 +188,8 @@ end
 
 function lkj_onion_loginvconst(d::Integer, η::T) where {T <: Real}
     #  Equation (17) in LKJ (2009 JMA)
-    h = convert(float(T), 0.5)
+    T = float(Base.promote_typeof(d, η))
+    h = T(1//2)
     sumlogs = logπ + loggamma(η + h * (d - 3))
     sumlogs = ifelse(d >= 3, sumlogs, zero(sumlogs))
     for k in 3:d - 1

--- a/src/matrix/lkj.jl
+++ b/src/matrix/lkj.jl
@@ -100,12 +100,13 @@ params(d::LKJ) = (d.d, d.η)
 #  -----------------------------------------------------------------------------
 
 function lkj_logc0(d::Integer, η::Real)
+    T = float(Base.promote_typeof(d, η))
     d > 1 || return zero(η)
     if isone(η)
         if iseven(d)
-            logc0 = -lkj_onion_loginvconst_uniform_even(d)
+            logc0 = -lkj_onion_loginvconst_uniform_even(d, T)
         else
-            logc0 = -lkj_onion_loginvconst_uniform_odd(d)
+            logc0 = -lkj_onion_loginvconst_uniform_odd(d, T)
         end
     else
         logc0 = -lkj_onion_loginvconst(d, η)
@@ -198,23 +199,27 @@ function lkj_onion_loginvconst(d::Integer, η::Real)
     return loginvconst
 end
 
-function lkj_onion_loginvconst_uniform_odd(d::Integer)
+function lkj_onion_loginvconst_uniform_odd(d::Integer, ::Type{T} = Float64) where {T}
     #  Theorem 5 in LKJ (2009 JMA)
-    sumlogs = 0.0
+    sumlogs = zero(T)
     for k in 1:div(d - 1, 2)
-        sumlogs += loggamma(2k)
+        sumlogs += loggamma(T(2k))
     end
-    loginvconst = 0.25(d^2 - 1)*logπ + sumlogs - 0.25(d - 1)^2*logtwo - (d - 1)*loggamma(0.5(d + 1))
+    h = T(1//2)
+    q = T(1//4)
+    loginvconst = q*(d^2 - 1)*logπ + sumlogs - q*(d - 1)^2*logtwo - (d - 1)*loggamma(h*(d + 1))
     return loginvconst
 end
 
-function lkj_onion_loginvconst_uniform_even(d::Integer)
+function lkj_onion_loginvconst_uniform_even(d::Integer, ::Type{T} = Float64) where {T}
     #  Theorem 5 in LKJ (2009 JMA)
-    sumlogs = 0.0
+    sumlogs = zero(T)
     for k in 1:div(d - 2, 2)
-        sumlogs += loggamma(2k)
+        sumlogs += loggamma(T(2k))
     end
-    loginvconst = 0.25d*(d - 2)*logπ + 0.25(3d^2 - 4d)*logtwo + d*loggamma(0.5d) + sumlogs - (d - 1)*loggamma(d)
+    h = T(1//2)
+    q = T(1//4)
+    return q*d*(d - 2)*logπ + q*(3d^2 - 4d)*logtwo + d*loggamma(h*d) + sumlogs - (d - 1)*loggamma(T(d))
 end
 
 function lkj_vine_loginvconst(d::Integer, η::Real)

--- a/src/matrix/lkj.jl
+++ b/src/matrix/lkj.jl
@@ -199,27 +199,24 @@ function lkj_onion_loginvconst(d::Integer, η::Real)
     return loginvconst
 end
 
-function lkj_onion_loginvconst_uniform_odd(d::Integer, ::Type{T} = Float64) where {T}
+function lkj_onion_loginvconst_uniform_odd(d::Integer, ::Type{T}) where {T <: Real}
     #  Theorem 5 in LKJ (2009 JMA)
-    sumlogs = zero(T)
-    for k in 1:div(d - 1, 2)
-        sumlogs += loggamma(T(2k))
-    end
     h = T(1//2)
-    q = T(1//4)
-    loginvconst = q*(d^2 - 1)*logπ + sumlogs - q*(d - 1)^2*logtwo - (d - 1)*loggamma(h*(d + 1))
+    loginvconst = (d - 1) * ((d + 1) * (T(logπ) / 4) - (d - 1) * (T(logtwo) / 4) - loggamma(h * (d + 1)))
+    for k in 2:2:(d - 1)
+        loginvconst += loggamma(T(k))
+    end
     return loginvconst
 end
 
-function lkj_onion_loginvconst_uniform_even(d::Integer, ::Type{T} = Float64) where {T}
+function lkj_onion_loginvconst_uniform_even(d::Integer, ::Type{T}) where {T <: Real}
     #  Theorem 5 in LKJ (2009 JMA)
-    sumlogs = zero(T)
-    for k in 1:div(d - 2, 2)
-        sumlogs += loggamma(T(2k))
-    end
     h = T(1//2)
-    q = T(1//4)
-    return q*d*(d - 2)*logπ + q*(3d^2 - 4d)*logtwo + d*loggamma(h*d) + sumlogs - (d - 1)*loggamma(T(d))
+    loginvconst = d * ((d - 2) * (T(logπ) / 4) + (3 * d - 4) * (T(logtwo) / 4) + loggamma(h * d)) - (d - 1) * loggamma(T(d))
+    for k in 2:2:(d - 2)
+        loginvconst += loggamma(k)
+    end
+    return loginvconst
 end
 
 function lkj_vine_loginvconst(d::Integer, η::Real)

--- a/src/matrix/lkj.jl
+++ b/src/matrix/lkj.jl
@@ -186,7 +186,7 @@ end
 #  for 1 / c₀, even if they say that it is not.
 #  -----------------------------------------------------------------------------
 
-function lkj_onion_loginvconst(d::Integer, η::T) where {T <: Real}
+function lkj_onion_loginvconst(d::Integer, η::Real)
     #  Equation (17) in LKJ (2009 JMA)
     T = float(Base.promote_typeof(d, η))
     h = T(1//2)

--- a/src/matrix/lkj.jl
+++ b/src/matrix/lkj.jl
@@ -190,10 +190,10 @@ function lkj_onion_loginvconst(d::Integer, η::T) where {T <: Real}
     #  Equation (17) in LKJ (2009 JMA)
     T = float(Base.promote_typeof(d, η))
     h = T(1//2)
-    sumlogs = logπ + loggamma(η + h * (d - 3))
-    sumlogs = ifelse(d >= 3, sumlogs, zero(sumlogs))
-    for k in 3:d - 1
-        sumlogs += (h * k) * logπ + loggamma(η + h * (d - 1 - k))
+    α = η + h * d - 1
+    loginvconst = (2*η + d - 3)*oftype(T, logtwo) + (oftype(T, logπ) / 4) * (d * (d - 1) - 2) + logbeta(α, α) - (d - 2) * loggamma(η + h * (d - 1))
+    for k in 2:(d - 1)
+        loginvconst += loggamma(η + h * (d - 1 - k))
     end
     return loginvconst
 end

--- a/src/matrix/lkj.jl
+++ b/src/matrix/lkj.jl
@@ -186,14 +186,15 @@ end
 #  for 1 / c₀, even if they say that it is not.
 #  -----------------------------------------------------------------------------
 
-function lkj_onion_loginvconst(d::Integer, η::Real)
+function lkj_onion_loginvconst(d::Integer, η::T) where {T <: Real}
     #  Equation (17) in LKJ (2009 JMA)
     sumlogs = zero(η)
+    h = convert(float(T), 0.5)
     for k in 2:d - 1
-        sumlogs += 0.5k*logπ + loggamma(η + 0.5(d - 1 - k))
+        sumlogs += h * k * logπ + loggamma(η + h * (d - 1 - k))
     end
-    α = η + 0.5d - 1
-    loginvconst = (2η + d - 3)*logtwo + logbeta(α, α) + sumlogs - (d - 2) * loggamma(η + 0.5(d - 1))
+    α = η + h * d - 1
+    loginvconst = (2η + d - 3)*logtwo + logbeta(α, α) + sumlogs - (d - 2) * loggamma(η + h * (d - 1))
     return loginvconst
 end
 

--- a/src/matrix/lkj.jl
+++ b/src/matrix/lkj.jl
@@ -188,10 +188,10 @@ end
 
 function lkj_onion_loginvconst(d::Integer, η::T) where {T <: Real}
     #  Equation (17) in LKJ (2009 JMA)
-    sumlogs = zero(η)
     h = convert(float(T), 0.5)
-    for k in 2:d - 1
-        sumlogs += h * k * logπ + loggamma(η + h * (d - 1 - k))
+    sumlogs = (h * 2) * logπ + loggamma(η + h * (d - 3))
+    for k in 3:d - 1
+        sumlogs += (h * k) * logπ + loggamma(η + h * (d - 1 - k))
     end
     α = η + h * d - 1
     loginvconst = (2η + d - 3)*logtwo + logbeta(α, α) + sumlogs - (d - 2) * loggamma(η + h * (d - 1))

--- a/src/matrix/lkj.jl
+++ b/src/matrix/lkj.jl
@@ -190,7 +190,7 @@ function lkj_onion_loginvconst(d::Integer, η::T) where {T <: Real}
     #  Equation (17) in LKJ (2009 JMA)
     h = convert(float(T), 0.5)
     sumlogs = logπ + loggamma(η + h * (d - 3))
-    sumlogs = ifelse(2 <= d - 1, sumlogs, zero(sumlogs))
+    sumlogs = ifelse(d >= 3, sumlogs, zero(sumlogs))
     for k in 3:d - 1
         sumlogs += (h * k) * logπ + loggamma(η + h * (d - 1 - k))
     end

--- a/src/matrix/lkj.jl
+++ b/src/matrix/lkj.jl
@@ -191,7 +191,7 @@ function lkj_onion_loginvconst(d::Integer, η::Real)
     T = float(Base.promote_typeof(d, η))
     h = T(1//2)
     α = η + h * d - 1
-    loginvconst = (2*η + d - 3)*oftype(T, logtwo) + (oftype(T, logπ) / 4) * (d * (d - 1) - 2) + logbeta(α, α) - (d - 2) * loggamma(η + h * (d - 1))
+    loginvconst = (2*η + d - 3)*T(logtwo) + (T(logπ) / 4) * (d * (d - 1) - 2) + logbeta(α, α) - (d - 2) * loggamma(η + h * (d - 1))
     for k in 2:(d - 1)
         loginvconst += loggamma(η + h * (d - 1 - k))
     end

--- a/test/cholesky/lkjcholesky.jl
+++ b/test/cholesky/lkjcholesky.jl
@@ -143,8 +143,9 @@ using FiniteDifferences
             @test insupport(LKJCholesky(40, 2, 'U'), cholesky(rand(LKJ(40, 2))))
             @test insupport(LKJCholesky(40, 2), cholesky(rand(LKJ(40, 2))))
             @test !insupport(LKJCholesky(40, 2), cholesky(rand(LKJ(41, 2))))
-            @test @inferred(logpdf(LKJCholesky(40, 2), cholesky(rand(LKJ(41, 2))))) === -Inf
-            @test @inferred(logpdf(LKJCholesky(40, 2f0), cholesky(Float32.(rand(LKJ(41, 2)))))) === -Inf32
+           for (d, η) in ((2, 4), (2, 1), (3, 1)), T in (Float32, Float64)
+                @test @inferred(logpdf(LKJCholesky(40, T(2)), cholesky(T.(rand(LKJ(41, 2)))))) === T(-Inf)
+            end
             z = rand(LKJ(40, 1))
             z .+= exp(Symmetric(randn(size(z)))) .* 1e-8
             x = cholesky(z)

--- a/test/cholesky/lkjcholesky.jl
+++ b/test/cholesky/lkjcholesky.jl
@@ -142,6 +142,8 @@ using FiniteDifferences
             @test insupport(LKJCholesky(40, 2), cholesky(rand(LKJ(40, 2))))
             @test !insupport(LKJCholesky(40, 2), cholesky(rand(LKJ(41, 2))))
             @test logpdf(LKJCholesky(40, 2), cholesky(rand(LKJ(41, 2)))) == -Inf
+            @test @inferred(logpdf(LKJCholesky(40, 2), cholesky(rand(LKJ(41, 2))))) === -Inf
+            @test @inferred(logpdf(LKJCholesky(40, 2f0), cholesky(Float32.(rand(LKJ(41, 2)))))) === convert(Float32, -Inf)
             z = rand(LKJ(40, 1))
             z .+= exp(Symmetric(randn(size(z)))) .* 1e-8
             x = cholesky(z)

--- a/test/cholesky/lkjcholesky.jl
+++ b/test/cholesky/lkjcholesky.jl
@@ -141,7 +141,7 @@ using FiniteDifferences
             @test insupport(LKJCholesky(40, 2, 'U'), cholesky(rand(LKJ(40, 2))))
             @test insupport(LKJCholesky(40, 2), cholesky(rand(LKJ(40, 2))))
             @test !insupport(LKJCholesky(40, 2), cholesky(rand(LKJ(41, 2))))
-            @test_throws DomainError logpdf(LKJCholesky(40, 2), cholesky(rand(LKJ(41, 2))))
+            @test logpdf(LKJCholesky(40, 2), cholesky(rand(LKJ(41, 2)))) == -Inf
             z = rand(LKJ(40, 1))
             z .+= exp(Symmetric(randn(size(z)))) .* 1e-8
             x = cholesky(z)

--- a/test/cholesky/lkjcholesky.jl
+++ b/test/cholesky/lkjcholesky.jl
@@ -135,7 +135,7 @@ using FiniteDifferences
             @test m isa Cholesky{eltype(d)}
             @test Matrix(m) ≈ I
         end
-        @test_broken partype(LKJCholesky(2, 4f0)) <: Float32
+        @test partype(LKJCholesky(2, 4f0)) <: Float32
 
         @testset "insupport" begin
             @test insupport(LKJCholesky(40, 2, 'U'), cholesky(rand(LKJ(40, 2))))

--- a/test/cholesky/lkjcholesky.jl
+++ b/test/cholesky/lkjcholesky.jl
@@ -141,7 +141,6 @@ using FiniteDifferences
             @test insupport(LKJCholesky(40, 2, 'U'), cholesky(rand(LKJ(40, 2))))
             @test insupport(LKJCholesky(40, 2), cholesky(rand(LKJ(40, 2))))
             @test !insupport(LKJCholesky(40, 2), cholesky(rand(LKJ(41, 2))))
-            @test logpdf(LKJCholesky(40, 2), cholesky(rand(LKJ(41, 2)))) == -Inf
             @test @inferred(logpdf(LKJCholesky(40, 2), cholesky(rand(LKJ(41, 2))))) === -Inf
             @test @inferred(logpdf(LKJCholesky(40, 2f0), cholesky(Float32.(rand(LKJ(41, 2)))))) === convert(Float32, -Inf)
             z = rand(LKJ(40, 1))

--- a/test/cholesky/lkjcholesky.jl
+++ b/test/cholesky/lkjcholesky.jl
@@ -135,7 +135,9 @@ using FiniteDifferences
             @test m isa Cholesky{eltype(d)}
             @test Matrix(m) ≈ I
         end
-        @test partype(LKJCholesky(2, 4f0)) <: Float32
+        for (d, η) in ((2, 4), (2, 1), (3, 1)), T in (Float32, Float64)
+            @test @inferred(partype(LKJCholesky(d, T(η)))) === T
+        end
 
         @testset "insupport" begin
             @test insupport(LKJCholesky(40, 2, 'U'), cholesky(rand(LKJ(40, 2))))

--- a/test/cholesky/lkjcholesky.jl
+++ b/test/cholesky/lkjcholesky.jl
@@ -141,6 +141,7 @@ using FiniteDifferences
             @test insupport(LKJCholesky(40, 2, 'U'), cholesky(rand(LKJ(40, 2))))
             @test insupport(LKJCholesky(40, 2), cholesky(rand(LKJ(40, 2))))
             @test !insupport(LKJCholesky(40, 2), cholesky(rand(LKJ(41, 2))))
+            @test_throws DomainError logpdf(LKJCholesky(40, 2), cholesky(rand(LKJ(41, 2))))
             z = rand(LKJ(40, 1))
             z .+= exp(Symmetric(randn(size(z)))) .* 1e-8
             x = cholesky(z)

--- a/test/matrixvariates.jl
+++ b/test/matrixvariates.jl
@@ -454,11 +454,11 @@ function test_special(dist::Type{LKJ})
         η = 1.0
         lkj = LKJ(d, η)
         @test Distributions.lkj_vine_loginvconst(d, η) ≈ Distributions.lkj_onion_loginvconst(d, η)
-        @test Distributions.lkj_onion_loginvconst(d, η) ≈ Distributions.lkj_onion_loginvconst_uniform_odd(d)
+        @test Distributions.lkj_onion_loginvconst(d, η) ≈ Distributions.lkj_onion_loginvconst_uniform_odd(d, Float64)
         @test Distributions.lkj_vine_loginvconst(d, η) ≈ Distributions.lkj_vine_loginvconst_uniform(d)
         @test Distributions.lkj_onion_loginvconst(d, η) ≈ Distributions.lkj_loginvconst_alt(d, η)
         @test Distributions.lkj_onion_loginvconst(d, η) ≈ Distributions.corr_logvolume(d)
-        @test lkj.logc0 == -Distributions.lkj_onion_loginvconst_uniform_odd(d)
+        @test lkj.logc0 == -Distributions.lkj_onion_loginvconst_uniform_odd(d, Float64)
         #  =============
         #  even non-uniform
         #  =============
@@ -475,11 +475,11 @@ function test_special(dist::Type{LKJ})
         η = 1.0
         lkj = LKJ(d, η)
         @test Distributions.lkj_vine_loginvconst(d, η) ≈ Distributions.lkj_onion_loginvconst(d, η)
-        @test Distributions.lkj_onion_loginvconst(d, η) ≈ Distributions.lkj_onion_loginvconst_uniform_even(d)
+        @test Distributions.lkj_onion_loginvconst(d, η) ≈ Distributions.lkj_onion_loginvconst_uniform_even(d, Float64)
         @test Distributions.lkj_vine_loginvconst(d, η) ≈ Distributions.lkj_vine_loginvconst_uniform(d)
         @test Distributions.lkj_onion_loginvconst(d, η) ≈ Distributions.lkj_loginvconst_alt(d, η)
         @test Distributions.lkj_onion_loginvconst(d, η) ≈ Distributions.corr_logvolume(d)
-        @test lkj.logc0 == -Distributions.lkj_onion_loginvconst_uniform_even(d)
+        @test lkj.logc0 == -Distributions.lkj_onion_loginvconst_uniform_even(d, Float64)
     end
     @testset "check integrating constant as a volume" begin
         #  d = 2: Lebesgue measure of the set of correlation matrices is 2.


### PR DESCRIPTION
Given the docstrings of `DomainError` and `ArgumentError` shown below, I think a `DomainError` makes more sense here.

```julia
  DomainError(val)
  DomainError(val, msg)

  The argument val to a function or constructor is outside the valid domain.

  Examples
  ≡≡≡≡≡≡≡≡≡≡

  julia> sqrt(-1)
  ERROR: DomainError with -1.0:
  sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
  Stacktrace:
  [...]
```

```julia
  ArgumentError(msg)

  The parameters to a function call do not match a valid signature. Argument msg is a descriptive error string.
```