### PR TITLE
GammaIPSampler rand: avoid recursion

### DIFF
--- a/src/samplers/gamma.jl
+++ b/src/samplers/gamma.jl
@@ -205,7 +205,7 @@ end
 GammaIPSampler(d::Gamma) = GammaIPSampler(d,GammaMTSampler)
 
 function rand(rng::AbstractRNG, s::GammaIPSampler)
-    x = rand(rng, s.s)
+    x = rand(rng, GammaGDSampler(s.s))
     e = randexp(rng)
     x*exp(s.nia*e)
 end


### PR DESCRIPTION
The recursion here seems to prevent Julia from inferring that `rand(::FixedRNG, ::Gamma)` terminates, preventing constant folding.

Eliminating it is as simple as short-circuiting to GammaGDSampler. This is correct because the shape parameter here is one more than with the original Gamma distribution, so it must be greater than one, assuming it was positive to begin with.

Note that I'm not an expert and in fact I'm having much trouble with passing Probability&Statistics, so there might be something I'm not taking into account.