### PR TITLE
Add missing univariate dists to documentation

### DIFF
--- a/docs/src/univariate.md
+++ b/docs/src/univariate.md
@@ -418,6 +418,13 @@ plotdensity((-8, 5), SkewedExponentialPower, (0, 1, 0.7, 0.7)) # hide
 ```
 
 ```@docs
+SkewNormal
+```
+```@example plotdensity
+plotdensity((-4, 4), SkewNormal, (0, 1, -1)) # hide
+```
+
+```@docs
 StudentizedRange
 SymTriangularDist
 ```

--- a/docs/src/univariate.md
+++ b/docs/src/univariate.md
@@ -492,6 +492,7 @@ NegativeBinomial
 Poisson
 PoissonBinomial
 Skellam
+Soliton
 ```
 
 ### Vectorized evaluation

--- a/src/univariate/continuous/skewnormal.jl
+++ b/src/univariate/continuous/skewnormal.jl
@@ -7,9 +7,9 @@ location `ξ`, scale `ω`, and shape `α`, it has the probability density functi
 
 ```math
 f(x; \\xi, \\omega, \\alpha) =
-\\frac{2}{\\omega \\sqrt{2 \\pi}} e^{-\\frac{(x-\\xi)^2}{2\\omega^2}}
+\\frac{2}{\\omega \\sqrt{2 \\pi}} \\exp{\\bigg(-\\frac{(x-\\xi)^2}{2\\omega^2}\\bigg)}
 \\int_{-\\infty}^{\\alpha\\left(\\frac{x-\\xi}{\\omega}\\right)}
-\\frac{1}{\\sqrt{2 \\pi}}  e^{-\\frac{t^2}{2}}\\ dt
+\\frac{1}{\\sqrt{2 \\pi}}  \\exp{\\bigg(-\\frac{t^2}{2}\\bigg)} \\, \\mathrm{d}t
 ```
 
 External links

--- a/src/univariate/continuous/skewnormal.jl
+++ b/src/univariate/continuous/skewnormal.jl
@@ -1,11 +1,23 @@
 """
-SkewNormal(ξ, ω, α)
-    The *skew normal distribution* is a continuous probability distribution
-    that generalises the normal distribution to allow for non-zero skewness.
+    SkewNormal(ξ, ω, α)
+
+The *skew normal distribution* is a continuous probability distribution that
+generalises the normal distribution to allow for non-zero skewness. Given a
+location `ξ`, scale `ω`, and shape `α`, it has the probability density function
+
+```math
+f(x; \\xi, \\omega, \\alpha) =
+\\frac{2}{\\omega \\sqrt{2 \\pi}} e^{-\\frac{(x-\\xi)^2}{2\\omega^2}}
+\\int_{-\\infty}^{\\alpha\\left(\\frac{x-\\xi}{\\omega}\\right)}
+\\frac{1}{\\sqrt{2 \\pi}}  e^{-\\frac{t^2}{2}}\\ dt
+```
+
 External links
+
 * [Skew normal distribution on Wikipedia](https://en.wikipedia.org/wiki/Skew_normal_distribution)
 * [Discourse](https://discourse.julialang.org/t/skew-normal-distribution/21549/7)
 * [SkewDist.jl](https://github.com/STOR-i/SkewDist.jl)
+
 """
 struct SkewNormal{T<:Real} <: ContinuousUnivariateDistribution
     ξ::T


### PR DESCRIPTION
This PR improves the SkewNormal docs a bit and adds it, along with the Soliton distribution to the documentation. Hopefully this will make them a bit more visible to users of the library.