### PR TITLE
Fix argument checks for BetaBinomial

### DIFF
--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -27,7 +27,7 @@ struct BetaBinomial{T<:Real} <: DiscreteUnivariateDistribution
 end
 
 function BetaBinomial(n::Integer, α::T, β::T; check_args::Bool=true) where {T <: Real}
-    @check_args BetaBinomial (n, n >= zero(n)) (α, α >= zero(α)) (β, β >= zero(β))
+    @check_args BetaBinomial (n, n >= zero(n)) (α, α > zero(α)) (β, β > zero(β))
     return BetaBinomial{T}(n, α, β)
 end
 

--- a/test/univariate/discrete/betabinomial.jl
+++ b/test/univariate/discrete/betabinomial.jl
@@ -29,8 +29,8 @@ using Test
                     @test @inferred(BetaBinomial(n, α, β)) isa BetaBinomial{ST}
                     @test @inferred(BetaBinomial(n, α, β; check_args=true)) isa BetaBinomial{ST}
                 else
-                    @test_throws ArgumentError BetaBinomial(n, α, β)
-                    @test_throws ArgumentError BetaBinomial(n, α, β; check_args=true)
+                    @test_throws DomainError BetaBinomial(n, α, β)
+                    @test_throws DomainError BetaBinomial(n, α, β; check_args=true)
                 end
 
                 @test @inferred(BetaBinomial(n, α, β; check_args=false)) isa BetaBinomial{ST}

--- a/test/univariate/discrete/betabinomial.jl
+++ b/test/univariate/discrete/betabinomial.jl
@@ -1,14 +1,40 @@
 using Distributions
 using Test
 
-@testset "Log of Beta-binomial distribution" begin
-    d = BetaBinomial(50, 0.2, 0.6)
+@testset "betabinomial.jl" begin
+    @testset "logpdf" begin
+        d = BetaBinomial(50, 0.2, 0.6)
 
-    for k in 1:50
-        p  = pdf(d, k)
-        lp = logpdf(d, k)
-        @test lp ≈ log(p)
-        @test insupport(d, k)
+        for k in 1:50
+            p  = @inferred(pdf(d, k))
+            lp = @inferred(logpdf(d, k))
+            @test lp ≈ log(p)
+        end
     end
-    @test !insupport(d, 51)
+
+    @testset "support" begin
+        d = BetaBinomial(50, 0.2, 0.6)
+
+        for k in 1:50
+            @test insupport(d, k)
+        end
+        @test !insupport(d, 51)
+    end
+
+    @testset "checks" begin
+        for T in (Int, Float64), S in (Int, Float64)
+            ST = float(promote_type(S, T))
+            for n in (-1, 0, 3), α in (S(-1), S(0), S(1)), β in (T(-1), T(0), T(1))
+                if n >= 0 && α > 0 && β > 0
+                    @test @inferred(BetaBinomial(n, α, β)) isa BetaBinomial{ST}
+                    @test @inferred(BetaBinomial(n, α, β; check_args=true)) isa BetaBinomial{ST}
+                else
+                    @test_throws ArgumentError BetaBinomial(n, α, β)
+                    @test_throws ArgumentError BetaBinomial(n, α, β; check_args=true)
+                end
+
+                @test @inferred(BetaBinomial(n, α, β; check_args=false)) isa BetaBinomial{ST}
+            end
+        end
+    end
 end


### PR DESCRIPTION
Letting α = 0 or β=0 results in many methods (pdf, quantile, rand) failing. Per Wikipedia, α and β should be positive.  https://en.wikipedia.org/wiki/Beta-binomial_distribution.