### PR TITLE
Replace `GLOBAL_RNG` with `default_rng()`

### DIFF
--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -14,7 +14,7 @@ using LinearAlgebra, Printf
 import LinearAlgebra: dot, rank
 
 using Random
-import Random: GLOBAL_RNG, rand!, SamplerRangeInt
+import Random: default_rng, rand!, SamplerRangeInt
 
 import Statistics: mean, median, quantile, std, var, cov, cor
 import StatsBase: kurtosis, skewness, entropy, mode, modes,

--- a/src/cholesky/lkjcholesky.jl
+++ b/src/cholesky/lkjcholesky.jl
@@ -172,7 +172,7 @@ function Base.rand(rng::AbstractRNG, d::LKJCholesky, dims::Dims)
     return Rs
 end
 
-Random.rand!(d::LKJCholesky, R::LinearAlgebra.Cholesky) = Random.rand!(GLOBAL_RNG, d, R)
+Random.rand!(d::LKJCholesky, R::LinearAlgebra.Cholesky) = Random.rand!(default_rng(), d, R)
 function Random.rand!(rng::AbstractRNG, d::LKJCholesky, R::LinearAlgebra.Cholesky)
     return _lkj_cholesky_onion_sampler!(rng, d, R)
 end

--- a/src/functionals.jl
+++ b/src/functionals.jl
@@ -11,7 +11,7 @@ function expectation(g, distr::DiscreteUnivariateDistribution; epsilon::Real=1e-
     return sum(x -> pdf(distr, x) * g(x), minval:maxval)
 end
 
-function expectation(g, distr::MultivariateDistribution; nsamples::Int=100, rng::AbstractRNG=GLOBAL_RNG)
+function expectation(g, distr::MultivariateDistribution; nsamples::Int=100, rng::AbstractRNG=default_rng())
     nsamples > 0 || throw(ArgumentError("number of samples should be > 0"))
     # We use a function barrier to work around type instability of `sampler(dist)`
     return mcexpectation(rng, g, sampler(distr), nsamples)

--- a/src/genericrand.jl
+++ b/src/genericrand.jl
@@ -19,8 +19,8 @@ Generate `n` samples from `s`. The form of the returned object depends on the va
 Generate an array of samples from `s` whose shape is determined by the given
 dimensions.
 """
-rand(s::Sampleable, dims::Int...) = rand(GLOBAL_RNG, s, dims...)
-rand(s::Sampleable, dims::Dims) = rand(GLOBAL_RNG, s, dims)
+rand(s::Sampleable, dims::Int...) = rand(default_rng(), s, dims...)
+rand(s::Sampleable, dims::Dims) = rand(default_rng(), s, dims)
 rand(rng::AbstractRNG, s::Sampleable, dim1::Int, moredims::Int...) =
     rand(rng, s, (dim1, moredims...))
 
@@ -74,7 +74,7 @@ form as specified above. The rules are summarized as below:
   matrices with each element for a sample matrix.
 """
 function rand! end
-Base.@propagate_inbounds rand!(s::Sampleable, X::AbstractArray) = rand!(GLOBAL_RNG, s, X)
+Base.@propagate_inbounds rand!(s::Sampleable, X::AbstractArray) = rand!(default_rng(), s, X)
 Base.@propagate_inbounds function rand!(rng::AbstractRNG, s::Sampleable, X::AbstractArray)
     return _rand!(rng, s, X)
 end
@@ -134,7 +134,7 @@ Base.@propagate_inbounds function rand!(
     x::AbstractArray{<:AbstractArray{<:Real,N}},
     allocate::Bool,
 ) where {N}
-    return rand!(GLOBAL_RNG, s, x, allocate)
+    return rand!(default_rng(), s, x, allocate)
 end
 @inline function rand!(
     rng::AbstractRNG,

--- a/src/matrix/lkj.jl
+++ b/src/matrix/lkj.jl
@@ -124,7 +124,7 @@ function _rand!(rng::AbstractRNG, d::LKJ, R::AbstractMatrix)
     R .= _lkj_onion_sampler(d.d, d.η, rng)
 end
 
-function _lkj_onion_sampler(d::Integer, η::Real, rng::AbstractRNG = Random.GLOBAL_RNG)
+function _lkj_onion_sampler(d::Integer, η::Real, rng::AbstractRNG = Random.default_rng())
     #  Section 3.2 in LKJ (2009 JMA)
     #  1. Initialization
     R = ones(typeof(η), d, d)

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -14,7 +14,7 @@ __rand!(rng::AbstractRNG, args...) = rand!(rng, args...)
 
 """
     test_mvnormal(
-        g::AbstractMvNormal, n_tsamples::Int=10^6, rng::AbstractRNG=Random.GLOBAL_RNG
+        g::AbstractMvNormal, n_tsamples::Int=10^6, rng::AbstractRNG=Random.default_rng()
     )
 
 Test that `AbstractMvNormal` implements the expected API.

--- a/src/univariate/continuous/chernoff.jl
+++ b/src/univariate/continuous/chernoff.jl
@@ -213,7 +213,7 @@ kurtosis(d::Chernoff, excess::Bool) = kurtosis(d) + (excess ? 0.0 : 3.0)
 entropy(d::Chernoff) = -0.7515605300273104
 
 ### Random number generation
-rand(d::Chernoff) = rand(GLOBAL_RNG, d)
+rand(d::Chernoff) = rand(default_rng(), d)
 function rand(rng::AbstractRNG, d::Chernoff)                 # Ziggurat random number generator --- slow in the tails
     # constants needed for the Ziggurat algorithm
     A = 0.03248227216266608

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -143,7 +143,7 @@ function test_samples(s::Sampleable{Univariate, Discrete},      # the sampleable
         @assert cub[i] >= clb[i]
     end
 
-    # generate samples using RNG passed or global RNG
+    # generate samples using RNG passed or default RNG
     samples = ismissing(rng) ? rand(s, n) : rand(rng, s, n)
     @assert length(samples) == n
 


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/issues/48683 for some motivation on this.

`GLOBAL_RNG` can result in reduced performance when compared to the newer `default_rng()` in newer versions of Julia. `default_rng()` is present as early as Juliar 1.3, so switching to `default_rng()` should not be a major issue.

I actually first ran into this issue with `GLOBAL_RNG` while testing a faster vectorized method for `rand(Normal...)`. This pull request by itself does not impact performance significantly, but makes room for others like #1680 .