### PR TITLE
Add vectorized rand for Normal dist

### DIFF
--- a/src/univariate/continuous/normal.jl
+++ b/src/univariate/continuous/normal.jl
@@ -107,6 +107,9 @@ Base.:*(c::Real, d::Normal) = Normal(c * d.μ, abs(c) * d.σ)
 
 rand(rng::AbstractRNG, d::Normal{T}) where {T} = d.μ + d.σ * randn(rng, float(T))
 
+rand!(rng::AbstractRNG, d::Normal, A::AbstractArray{<:Real}) = 
+    A .= randn!(rng, A) .* d.σ .+ d.μ
+
 #### Fitting
 
 struct NormalStats <: SufficientStats

--- a/src/univariate/continuous/normal.jl
+++ b/src/univariate/continuous/normal.jl
@@ -107,8 +107,7 @@ Base.:*(c::Real, d::Normal) = Normal(c * d.μ, abs(c) * d.σ)
 
 rand(rng::AbstractRNG, d::Normal{T}) where {T} = d.μ + d.σ * randn(rng, float(T))
 
-rand!(rng::AbstractRNG, d::Normal, A::AbstractArray{<:Real}) = 
-    A .= randn!(rng, A) .* d.σ .+ d.μ
+rand!(rng::AbstractRNG, d::Normal, A::AbstractArray{<:Real}) = A .= muladd.(d.σ, randn!(rng, A), d.μ)
 
 #### Fitting
 


### PR DESCRIPTION
In the same spirit as #1269, but requires #1679 to be effective.

Before this and #1679:
```julia
julia> @time randn(n);
  0.002643 seconds (2 allocations: 9.419 MiB)

julia> @time randn(n);
  0.002520 seconds (2 allocations: 9.419 MiB)
  
julia> @time rand(Normal(0,1), n);
  0.008471 seconds (2 allocations: 9.419 MiB)

julia> @time rand(Normal(0,1), n);
  0.008220 seconds (2 allocations: 9.419 MiB)
```

After this and #1679:
```julia
julia> @time randn(n);
  0.002543 seconds (2 allocations: 9.419 MiB)

julia> @time randn(n);
  0.002482 seconds (2 allocations: 9.419 MiB)

julia> @time rand(Normal(0,1), n);
  0.002880 seconds (2 allocations: 9.419 MiB)

julia> @time rand(Normal(0,1), n);
  0.002934 seconds (2 allocations: 9.419 MiB)
```

Like #1269, this also improves compatibility with CUDA by replacing indexing with broadcasting; this does not require #1679:

```julia
using CUDA
using Random
using Distributions

CUDA.allowscalar(false);

v = CuArray{Float64}(undef, 1234567);

randn!(v); # works

rand!(CURAND.default_rng(), Normal(0,1), v); # doesn't work currently
```

```julia
julia> @time randn!(v);
  0.000065 seconds (5 allocations: 192 bytes)

julia> @time randn!(v);
  0.000065 seconds (5 allocations: 192 bytes)

julia> @time rand!(CURAND.default_rng(), Normal(0,1), v);
  0.000111 seconds (49 allocations: 2.672 KiB)

julia> @time rand!(CURAND.default_rng(), Normal(0,1), v);
  0.000103 seconds (49 allocations: 2.672 KiB)
```
  