### PR TITLE
accept `Number` in `Exponential`

### DIFF
--- a/src/univariate/continuous/exponential.jl
+++ b/src/univariate/continuous/exponential.jl
@@ -21,13 +21,18 @@ External links
 * [Exponential distribution on Wikipedia](http://en.wikipedia.org/wiki/Exponential_distribution)
 
 """
-struct Exponential{T<:Real} <: ContinuousUnivariateDistribution
+struct Exponential{T<:Number} <: ContinuousUnivariateDistribution
     θ::T        # note: scale not rate
     Exponential{T}(θ::T) where {T} = new{T}(θ)
 end
 
-function Exponential(θ::Real; check_args::Bool=true)
-    @check_args Exponential (θ, θ > zero(θ))
+function Exponential(θ::Number; check_args::Bool=true)
+    @check_args(
+        Exponential, 
+        (!(θ isa Complex), "Complex not allowed for θ"),
+        (isreal(θ), "θ must be a real number"),
+        (θ, θ > zero(θ)),
+    )
     return Exponential{typeof(θ)}(θ)
 end
 
@@ -37,7 +42,7 @@ Exponential() = Exponential{Float64}(1.0)
 @distr_support Exponential 0.0 Inf
 
 ### Conversions
-convert(::Type{Exponential{T}}, θ::S) where {T <: Real, S <: Real} = Exponential(T(θ))
+convert(::Type{Exponential{T}}, θ::S) where {T <: Number, S <: Number} = Exponential(T(θ))
 function Base.convert(::Type{Exponential{T}}, d::Exponential) where {T<:Real}
     return Exponential(T(d.θ))
 end


### PR DESCRIPTION
This is a start on #1684, with `Exponential` as an example to start the discussion, I'm not personally across the problems this may cause so this PR is a request for input and feedback on that.

The idea is to loosen the type of `θ` to be `Number`, and add a check for `Complex` numbers so those errors are avoided. More or different checks may be required.

I'm not totally satisfied with the combination of `!(θ isa Complex)` and `isreal(θ)` checks, but the idea is to make sure that even wrapped numbers are internally `Real`.