### PR TITLE
Make sure `qqbuild` does not drop min and max value

### DIFF
--- a/src/qq.jl
+++ b/src/qq.jl
@@ -18,7 +18,7 @@ end
 Generate a sequence of probability points of length `n`:
 
 ```math
-(k − 0.5)/n, \\; k ∈ 1, ..., n
+(k − 0.5)/n, \\qquad k \\in \\{1, \\ldots, n\\}
 ```
 
 ## References

--- a/src/qq.jl
+++ b/src/qq.jl
@@ -11,9 +11,26 @@ function qqbuild(x::AbstractVector, y::AbstractVector)
     return QQPair(qx, qy)
 end
 
+
+"""
+Generates a sequence of probability points of length `n`:
+
+``
+(k − a)/(n + 1 − 2a), k ∈ 1, ..., n
+``
+
+`a` should be ∈ [0,1]. See the references listed here:
+https://en.wikipedia.org/wiki/Q%E2%80%93Q_plot#Heuristics
+"""
+function ppoints(n, a=0.5)
+    start = (1-a)/(n + 1 - 2*a)
+    stop = (n-a)/(n + 1 - 2*a)
+    range(start, stop, length=n)
+end
+
 function qqbuild(x::AbstractVector, d::UnivariateDistribution)
     n = length(x)
-    grid = [(1 / (n - 1)):(1 / (n - 1)):(1.0 - (1 / (n - 1)));]
+    grid = ppoints(n)
     qx = quantile(x, grid)
     qd = quantile.(Ref(d), grid)
     return QQPair(qx, qd)
@@ -21,7 +38,7 @@ end
 
 function qqbuild(d::UnivariateDistribution, x::AbstractVector)
     n = length(x)
-    grid = [(1 / (n - 1)):(1 / (n - 1)):(1.0 - (1 / (n - 1)));]
+    grid = ppoints(x)
     qd = quantile.(Ref(d), grid)
     qx = quantile(x, grid)
     return QQPair(qd, qx)

--- a/src/qq.jl
+++ b/src/qq.jl
@@ -38,7 +38,7 @@ end
 
 function qqbuild(d::UnivariateDistribution, x::AbstractVector)
     n = length(x)
-    grid = ppoints(x)
+    grid = ppoints(n)
     qd = quantile.(Ref(d), grid)
     qx = quantile(x, grid)
     return QQPair(qd, qx)

--- a/src/qq.jl
+++ b/src/qq.jl
@@ -27,11 +27,7 @@ Generate a sequence of probability points of length `n`:
 
 https://en.wikipedia.org/wiki/Q%E2%80%93Q_plot#Heuristics
 """
-function ppoints(n, a=0.5)
-    start = (1-a)/(n + 1 - 2*a)
-    stop = (n-a)/(n + 1 - 2*a)
-    range(start, stop, length=n)
-end
+ppoints(n::Int, a::Real=0.5) = ((1:n) .- a) ./ (n + 1 - 2*a)
 
 function qqbuild(x::AbstractVector, d::UnivariateDistribution)
     n = length(x)

--- a/src/qq.jl
+++ b/src/qq.jl
@@ -12,34 +12,18 @@ function qqbuild(x::AbstractVector, y::AbstractVector)
 end
 
 
-"""
-    ppoints(n::Int, a::Real=0.5)
-
-Generate a sequence of probability points of length `n`:
-
-```math
-(k − a)/(n + 1 − 2a), k ∈ 1, ..., n
-```
-
-`a` should be a number in ``[0, 1]``.
-
-## References
-
-https://en.wikipedia.org/wiki/Q%E2%80%93Q_plot#Heuristics
-"""
-ppoints(n::Int, a::Real=0.5) = ((1:n) .- a) ./ (n + 1 - 2*a)
-
 function qqbuild(x::AbstractVector, d::UnivariateDistribution)
+    ## Follows Matlab's convention (https://ch.mathworks.com/help/stats/qqplot.html)
     n = length(x)
-    grid = ppoints(n)
-    qx = quantile(x, grid)
+    grid = ((1:n) .- 0.5) ./ n
     qd = quantile.(Ref(d), grid)
     return QQPair(qx, qd)
 end
 
 function qqbuild(d::UnivariateDistribution, x::AbstractVector)
+    ## Follows Matlab's convention (https://ch.mathworks.com/help/stats/qqplot.html)
     n = length(x)
-    grid = ppoints(n)
+    grid = ((1:n) .- 0.5) ./ n
     qd = quantile.(Ref(d), grid)
     qx = quantile(x, grid)
     return QQPair(qd, qx)

--- a/src/qq.jl
+++ b/src/qq.jl
@@ -13,13 +13,18 @@ end
 
 
 """
-Generates a sequence of probability points of length `n`:
+    ppoints(n::Int, a::Real=0.5)
 
-``
+Generate a sequence of probability points of length `n`:
+
+```math
 (k − a)/(n + 1 − 2a), k ∈ 1, ..., n
-``
+```
 
-`a` should be ∈ [0,1]. See the references listed here:
+`a` should be a number in ``[0, 1]``.
+
+## References
+
 https://en.wikipedia.org/wiki/Q%E2%80%93Q_plot#Heuristics
 """
 function ppoints(n, a=0.5)

--- a/src/qq.jl
+++ b/src/qq.jl
@@ -12,18 +12,36 @@ function qqbuild(x::AbstractVector, y::AbstractVector)
 end
 
 
+"""
+    ppoints(n::Int, a::Real=0.5)
+
+Generate a sequence of probability points of length `n`:
+
+```math
+(k − 0.5)/n, \\; k ∈ 1, ..., n
+```
+
+## References
+
+https://ch.mathworks.com/help/stats/probplot.html
+"""
+function ppoints(n::Int)
+    m = 2 * n
+    return (1:2:(m - 1)) ./ m
+end
+
+
 function qqbuild(x::AbstractVector, d::UnivariateDistribution)
-    ## Follows Matlab's convention (https://ch.mathworks.com/help/stats/qqplot.html)
     n = length(x)
-    grid = ((1:n) .- 0.5) ./ n
+    grid = ppoints(n)
+    qx = quantile(x, grid)
     qd = quantile.(Ref(d), grid)
     return QQPair(qx, qd)
 end
 
 function qqbuild(d::UnivariateDistribution, x::AbstractVector)
-    ## Follows Matlab's convention (https://ch.mathworks.com/help/stats/qqplot.html)
     n = length(x)
-    grid = ((1:n) .- 0.5) ./ n
+    grid = ppoints(n)
     qd = quantile.(Ref(d), grid)
     qx = quantile(x, grid)
     return QQPair(qd, qx)

--- a/src/qq.jl
+++ b/src/qq.jl
@@ -13,7 +13,7 @@ end
 
 
 """
-    ppoints(n::Int, a::Real=0.5)
+    ppoints(n::Int)
 
 Generate a sequence of probability points of length `n`:
 

--- a/test/qq.jl
+++ b/test/qq.jl
@@ -7,14 +7,26 @@ c = qqbuild(view(collect(1:20), 1:10), view(collect(1:20), 1:10))
 @test a.qx ≈ b.qx ≈ c.qx ≈ collect(1.0:10)
 @test a.qy ≈ b.qy ≈ c.qy ≈ collect(1.0:10)
 
+for a in [0, 0.5, 1]
+    pp = Distributions.ppoints(10, a)
+    @test length(pp) == 10
+    @test minimum(pp) >= 0
+    @test maximum(pp) <= 1
+end
+
 a = qqbuild(collect(1:10), Uniform(1,10))
 b = qqbuild(1:10, Uniform(1,10))
 c = qqbuild(view(collect(1:20), 1:10), Uniform(1,10))
-@test a.qx ≈ b.qx ≈ c.qx ≈ collect(2.0:9)
-@test a.qy ≈ b.qy ≈ c.qy ≈ collect(2.0:9)
+@test length(a.qy) == length(a.qx) == 10
+@test a.qx ≈ b.qx ≈ c.qx ≈ a.qy ≈ b.qy ≈ c.qy
 
 a = qqbuild(Uniform(1,10), collect(1:10))
 b = qqbuild(Uniform(1,10), 1:10)
 c = qqbuild(Uniform(1,10), view(collect(1:20), 1:10))
-@test a.qx ≈ b.qx ≈ c.qx ≈ collect(2.0:9)
-@test a.qy ≈ b.qy ≈ c.qy ≈ collect(2.0:9)
+@test length(a.qy) == length(a.qx) == 10
+@test a.qx ≈ b.qx ≈ c.qx ≈ a.qy ≈ b.qy ≈ c.qy
+
+for n in 0:3
+    a = qqbuild(rand(n), Uniform(0,1))
+    @test length(a.qy) == length(a.qx) == n
+end

--- a/test/qq.jl
+++ b/test/qq.jl
@@ -8,6 +8,11 @@ c = qqbuild(view(collect(1:20), 1:10), view(collect(1:20), 1:10))
 @test a.qy ≈ b.qy ≈ c.qy ≈ collect(1.0:10)
 
 
+pp = Distributions.ppoints(10)
+@test length(pp) == 10
+@test minimum(pp) >= 0
+@test maximum(pp) <= 1
+
 a = qqbuild(collect(1:10), Uniform(1,10))
 b = qqbuild(1:10, Uniform(1,10))
 c = qqbuild(view(collect(1:20), 1:10), Uniform(1,10))

--- a/test/qq.jl
+++ b/test/qq.jl
@@ -7,12 +7,6 @@ c = qqbuild(view(collect(1:20), 1:10), view(collect(1:20), 1:10))
 @test a.qx ≈ b.qx ≈ c.qx ≈ collect(1.0:10)
 @test a.qy ≈ b.qy ≈ c.qy ≈ collect(1.0:10)
 
-for a in [0, 0.5, 1]
-    pp = Distributions.ppoints(10, a)
-    @test length(pp) == 10
-    @test minimum(pp) >= 0
-    @test maximum(pp) <= 1
-end
 
 a = qqbuild(collect(1:10), Uniform(1,10))
 b = qqbuild(1:10, Uniform(1,10))


### PR DESCRIPTION
This fixes https://github.com/JuliaStats/Distributions.jl/issues/1378

The current behavior is dangerous because when `qqbuild` is used for QQ-plots (as 
`Plots.jl` and `Makie.jl` do) the most extreme outliers are not shown.

