### PR TITLE
Improve type stability for truncated normal moments

### DIFF
--- a/src/truncated/normal.jl
+++ b/src/truncated/normal.jl
@@ -27,7 +27,7 @@ modes(d::Truncated{Normal{T},Continuous}) where {T <: Real} = [mode(d)]
 # do not export. Used in mean
 # computes mean of standard normal distribution truncated to [a, b]
 function _tnmom1(a, b)
-    mid = middle(a, b)
+    mid = float(middle(a, b))
     if !(a ≤ b)
         return oftype(mid, NaN)
     elseif a == b
@@ -41,7 +41,7 @@ function _tnmom1(a, b)
     a′ = a * invsqrt2
     b′ = b * invsqrt2
     if a ≤ 0 ≤ b
-        m = expm1(-Δ) * exp(-a^2 / 2) / (erf(a′) - erf(b′))
+        m = expm1(-Δ) * exp(-a^2 / 2) / erf(b′, a′)
     elseif 0 < a < b
         z = exp(-Δ) * erfcx(b′) - erfcx(a′)
         iszero(z) && return mid
@@ -53,7 +53,7 @@ end
 # do not export. Used in var
 # computes 2nd moment of standard normal distribution truncated to [a, b]
 function _tnmom2(a::Real, b::Real)
-    mid = middle(a, b)
+    mid = float(middle(a, b))
     if !(a ≤ b)
         return oftype(mid, NaN)
     elseif a == b
@@ -68,11 +68,9 @@ function _tnmom2(a::Real, b::Real)
     a′ = a * invsqrt2
     b′ = b * invsqrt2
     if a ≤ 0 ≤ b
-        ea = sqrthalfπ * erf(a′)
-        eb = sqrthalfπ * erf(b′)
-        fa = ea - a * exp(-a^2 / 2)
-        fb = eb - b * exp(-b^2 / 2)
-        return (fb - fa) / (eb - ea)
+        eb_ea = sqrthalfπ * erf(a′, b′)
+        fb_fa = eb_ea + a * exp(-a^2 / 2) - b * exp(-b^2 / 2)
+        return fb_fa / eb_ea
     else # 0 ≤ a ≤ b
         exΔ = exp((a - b) * mid)
         ea = sqrthalfπ * erfcx(a′)

--- a/test/truncated/normal.jl
+++ b/test/truncated/normal.jl
@@ -28,6 +28,16 @@ rng = MersenneTwister(123)
     # https://github.com/JuliaStats/Distributions.jl/issues/624
     @test rand(truncated(Normal(+Inf, 1), 0, 1)) ≈ 1
     @test rand(truncated(Normal(-Inf, 1), 0, 1)) ≈ 0
+    # Type stability
+    for T in (Float32, Float64)
+        t = truncated(Normal(T(1.5), T(4.1)), 0, 1)
+        μ = @inferred mean(t)
+        σ = @inferred std(t)
+        @test μ ≈ 0.50494725270783081889610661619986770485973643194141
+        @test μ isa T
+        @test σ ≈ 0.28836356398830993140576947440881738258157196701554
+        @test σ isa T
+    end
 end
 @testset "Truncated normal $trunc" begin
     trunc = truncated(Normal(0, 1), -2, 2)


### PR DESCRIPTION
The internal functions used for computing the mean and variance of the truncated normal distribution were implemented using literals like `√2`, which are always `Float64`. However, some branches of the functions based the return type off of the types of the arguments, which needn't be `Float64`. This led to some instability that can be seen via `@code_warntype`. For example, the inferred result of `_tnmom1` for `Float32` inputs was `Union{Float32,Float64}`.

We can instead use the irrational constants defined for square roots of pi and 2 and ratios thereof in order to avoid promoting to `Float64` unnecessarily. This makes the return type concretely inferrable and provides a small performance improvement, about 12% better (-7ns) for `mean` and 14% better (-20ns) for `var` on my machine as compared to current master.