### PR TITLE
Fix `rand` for truncated normal with 0 variance

### DIFF
--- a/src/truncated/normal.jl
+++ b/src/truncated/normal.jl
@@ -143,9 +143,18 @@ function rand(rng::AbstractRNG, d::Truncated{Normal{T},Continuous}) where T <: R
     μ = mean(d0)
     σ = std(d0)
     if isfinite(μ)
-        a = (d.lower - μ) / σ
-        b = (d.upper - μ) / σ
-        z = randnt(rng, a, b, d.tp)
+        a, b = extrema(d)
+        if iszero(σ)
+            if a <= μ <= b
+                z = 0.0
+            else
+                return NaN
+            end
+        else
+            a′ = (a - μ) / σ
+            b′ = (b - μ) / σ
+            z = randnt(rng, a′, b′, d.tp)
+        end
         return μ + σ * z
     else
         return clamp(μ, d.lower, d.upper)

--- a/test/truncated/normal.jl
+++ b/test/truncated/normal.jl
@@ -45,7 +45,7 @@ end
         [(r = rand, r! = rand!),
          (r = ((d, n) -> rand(rng, d, n)), r! = ((d, X) -> rand!(rng, d, X)))]
         repeats = 1000000
-        
+
         @test abs(mean(func.r(trunc, repeats))) < 0.01
         @test abs(median(func.r(trunc, repeats))) < 0.01
         @test abs(var(func.r(trunc, repeats)) - var(trunc)) < 0.01
@@ -66,4 +66,12 @@ end
         @test isfinite(logpdf(trunc, x))
         @test isfinite(pdf(trunc, x))
     end
+end
+
+@testset "Degenerate truncated normal" begin
+    # https://github.com/JuliaStats/Distributions.jl/issues/1712
+    d = Normal(2, 0)
+    @test rand(truncated(d, 2, 2)) == 2    # a == μ == b
+    @test rand(truncated(d, 1, 3)) == 2    # a <= μ <= b
+    @test isnan(rand(truncated(d, 6, 9)))  # μ ∉ [a, b]
 end


### PR DESCRIPTION
Fixes #1712.