### PR TITLE
Fix Wrong quantiles calculated for some Truncated #1726

### DIFF
--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -146,7 +146,7 @@ end
 
 ### evaluation
 
-quantile(d::Truncated, p::Real) = quantile(d.untruncated, d.lcdf + p * d.tp)
+quantile(d::Truncated, p::T) where {T<:Real} = min(T(d.upper), quantile(d.untruncated, d.lcdf + p * d.tp))
 
 function pdf(d::Truncated, x::Real)
     result = pdf(d.untruncated, x) / d.tp

--- a/src/truncate.jl
+++ b/src/truncate.jl
@@ -146,7 +146,11 @@ end
 
 ### evaluation
 
-quantile(d::Truncated, p::T) where {T<:Real} = min(T(d.upper), quantile(d.untruncated, d.lcdf + p * d.tp))
+function quantile(d::Truncated, p::Real)
+    x = quantile(d.untruncated, d.lcdf + p * d.tp)
+    min_x, max_x = extrema(d)
+    return clamp(x, oftype(x, min_x), oftype(x, max_x))
+end
 
 function pdf(d::Truncated, x::Real)
     result = pdf(d.untruncated, x) / d.tp

--- a/test/truncate.jl
+++ b/test/truncate.jl
@@ -197,3 +197,20 @@ end
     x = rand(d, 10_000)
     @test mean(x) ≈ 0.5 atol=0.05
 end
+
+@testset "quantile examples (#1726)" begin
+  d_narrow = truncated(Normal(0, 0.01), -1, 1.2)
+
+  # prior to patch #1727 this was offering either ±Inf
+  @test quantile(d_narrow, 1) ≤ d_narrow.upper && quantile(d_narrow, 1) ≈ d_narrow.upper
+  @test quantile(d_narrow, 0) ≥ d_narrow.lower && quantile(d_narrow, 0) ≈ d_narrow.lower
+
+  @test isa(quantile(d_narrow, ForwardDiff.Dual(0., 0.)), ForwardDiff.Dual)
+
+  d = truncated(Normal(0, 2), 0, 1)
+
+  # prior to patch #1727 this was offering 1.0000000000000002 > 1.
+  @test quantile(d, 1) ≤ d.upper && quantile(d, 1) ≈ d.upper
+
+  @test isa(quantile(d, ForwardDiff.Dual(1.,0.)), ForwardDiff.Dual)
+end


### PR DESCRIPTION
As described in
[#1726](https://github.com/JuliaStats/Distributions.jl/issues/1726), there occur small numbers-big number problems while evaluating quantiles on `Truncated`.

This Fix uses the knowledge on the upper bound of `Truncated` to properly limit the output.