### PR TITLE
Handle truncation endpoints equal to support endpoints

### DIFF
--- a/test/truncate.jl
+++ b/test/truncate.jl
@@ -146,7 +146,16 @@ for bound in (-2, 1)
     @test truncated(Normal(); lower=nothing, upper=bound) == d_nothing
     @test extrema(d_nothing) == promote(-Inf, bound)
 end
-@test truncated(Normal()) === Normal()
+@testset "no-op truncation" begin
+    @test truncated(Normal()) === Normal()
+    @test truncated(Normal(), -Inf, Inf) === Normal()
+    @test truncated(Poisson(), 0, Inf) === Poisson()
+    @test truncated(Kumaraswamy(), -1, 2) === Kumaraswamy()
+end
+@testset "equivalent truncations" begin
+    @test truncated(Beta(), -1, 0.5) === truncated(Beta(), 0, 0.5) === truncated(Beta(), nothing, 0.5)
+    @test truncated(Beta(), 0.5, 2) === truncated(Beta(), 0.5, 1) === truncated(Beta(), 0.5, nothing)
+end
 
 ## main
 


### PR DESCRIPTION
Consider `truncated(Normal(), -Inf, Inf)`. Currently, this returns a `Truncated`-wrapped `Normal`. However, truncating a normal distribution to ±∞ is... not actually truncating it at all. We handle this case when the bounds are specified as `nothing` and return the untruncated distribution, but not when one or both bounds are equal to or beyond the respective bounds of the support. If we recode `lower <= minimum(d)` and/or `upper >= maximum(d)` to `nothing`, we're able to avoid a `Truncated` wrapper in more cases. And when we do make a `Truncated`, equivalent truncations can now compare equal and hit the same code paths for dispatch on the truncation using `nothing` as appropriate.

Two things to note with this implementation:
- `truncated(d::D, a, b)` is no longer type stable since it can now return either a `D` or a `Truncated{D}` whereas before it only returned a `D` if `a === b === nothing`.
- Nonsensical truncation, e.g. `truncated(Poisson(), -10, -1)`, still works and is still nonsensical.