### PR TITLE
Update docstring of NegativeBinomial

### DIFF
--- a/src/univariate/discrete/negativebinomial.jl
+++ b/src/univariate/discrete/negativebinomial.jl
@@ -25,8 +25,6 @@ failprob(d)     # Get the failure rate, i.e. 1 - p
 External links:
 
 * [Negative binomial distribution on Wolfram](https://reference.wolfram.com/language/ref/NegativeBinomialDistribution.html)
-Note: The definition of the negative binomial distribution in Wolfram is different from the [Wikipedia definition](http://en.wikipedia.org/wiki/Negative_binomial_distribution). In Wikipedia, `r` is the number of failures and `k` is the number of successes.
-
 """
 struct NegativeBinomial{T<:Real} <: DiscreteUnivariateDistribution
     r::T


### PR DESCRIPTION
Remove note about different notation in [Wikipedia](https://en.wikipedia.org/wiki/Negative_binomial_distribution) (no longer true).