### PR TITLE
Dirac: Implement location, scale, affine transformation

### DIFF
--- a/src/univariate/discrete/dirac.jl
+++ b/src/univariate/discrete/dirac.jl
@@ -18,7 +18,7 @@ External links:
 
 * [Dirac measure on Wikipedia](http://en.wikipedia.org/wiki/Dirac_measure)
 """
-struct Dirac{T} <: DiscreteUnivariateDistribution
+struct Dirac{T<:Real} <: DiscreteUnivariateDistribution
     value::T
 end
 
@@ -28,6 +28,9 @@ insupport(d::Dirac, x::Real) = x == d.value
 minimum(d::Dirac) = d.value
 maximum(d::Dirac) = d.value
 support(d::Dirac) = (d.value,)
+
+location(d::Dirac) = d.value
+scale(d::Dirac{T}) where {T} = one(T)
 
 #### Properties
 mean(d::Dirac) = d.value
@@ -52,6 +55,11 @@ quantile(d::Dirac{T}, p::Real) where {T} = 0 <= p <= 1 ? d.value : T(NaN)
 mgf(d::Dirac, t) = exp(t * d.value)
 cgf(d::Dirac, t) = t*d.value
 cf(d::Dirac, t) = cis(t * d.value)
+
+#### Affine transformation
+Base.:+(d::Dirac, c::Real) = Dirac(d.value + c)
+Base.:+(a::Dirac, b::Dirac) = Dirac(a.value + b.value)
+Base.:*(c::Real, d::Dirac) = error("Rescaling of Dirac is prohibited.")
 
 #### Sampling
 

--- a/src/univariate/discrete/dirac.jl
+++ b/src/univariate/discrete/dirac.jl
@@ -59,7 +59,7 @@ cf(d::Dirac, t) = cis(t * d.value)
 #### Affine transformation
 Base.:+(d::Dirac, c::Real) = Dirac(d.value + c)
 Base.:+(a::Dirac, b::Dirac) = Dirac(a.value + b.value)
-Base.:*(c::Real, d::Dirac) = error("Rescaling of Dirac is prohibited.")
+Base.:*(c::Real, d::Dirac) = Dirac(c * d.value)
 
 #### Sampling
 


### PR DESCRIPTION
closes #1731

* location implemented
* scale implemented (= one)
* shifting = :+ implemented

* Scaling = :*, errors

Widening the Dirac cannot be done in a type stable way. Dirac can be interpreted as limit of some distributions in the limit σ^2 -> 0.0 (e.g. Normal, Uniform, Cosine). Falling back to one of these is arbitrarily and not type stable. Therefore it's up to the user what to do when recaling (= lowering certainty) needs to be done.

Adding two Dirac distributions is allowed. The sum of Dirac distributed random variables is interpreted as the sum of their values. This result can be obtained by either interpretation as certain bare numbers or by convolution.

resolves #1695

Type T is reduced to T<:Real to be consistent with other distributions. Non-scalar values are no longer allowed as arguments.
This is a **potentially breaking** change, if user code relied on unintended behaviour.