### PR TITLE
Create a compact `show` for `MvNormal`.

### DIFF
--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -245,8 +245,10 @@ distrname(d::ZeroMeanIsoNormal) = "ZeroMeanIsoNormal"
 distrname(d::ZeroMeanDiagNormal) = "ZeroMeanDiagNormal"
 distrname(d::ZeroMeanFullNormal) = "ZeroMeanFullNormal"
 
-Base.show(io::IO, d::MvNormal) =
+Base.show(io::IO, ::MIME"text/plain", d::MvNormal) =
     show_multline(io, d, [(:dim, length(d)), (:μ, mean(d)), (:Σ, cov(d))])
+Base.show(io::IO, d::MvNormal) =
+    print(io, "MvNormal($(d.μ), $(d.Σ))")
 
 ### Basic statistics
 


### PR DESCRIPTION
```
julia> using LinearAlgebra, Distributions

julia> dist = MvNormal(I(2)) # plaintext unchanged
MvNormal{Bool, PDMats.PDiagMat{Bool, Vector{Bool}}, FillArrays.Falses{1, Tuple{Base.OneTo{Int64}}}}(
dim: 2
μ: Zeros{Bool}(2)
Σ: Bool[1 0; 0 1]
)

julia> "$dist" # added compact representation
"MvNormal(Zeros{Bool}(2), Bool[1 0; 0 1])"
```