### PR TITLE
Fix type unstable `Uniform`

### DIFF
--- a/src/univariate/continuous/uniform.jl
+++ b/src/univariate/continuous/uniform.jl
@@ -151,7 +151,7 @@ Base.:*(c::Real, d::Uniform) = Uniform(minmax(c * d.a, c * d.b)...)
 
 #### Sampling
 
-rand(rng::AbstractRNG, d::Uniform) = d.a + (d.b - d.a) * rand(rng)
+rand(rng::AbstractRNG, d::Uniform{T}) where {T<:Real} = d.a + (d.b - d.a) * rand(rng, T)
 
 _rand!(rng::AbstractRNG, d::Uniform, A::AbstractArray{<:Real}) =
     A .= quantile.(d, rand!(rng, A))


### PR DESCRIPTION
this fixes:
```julia
julia> dist = Uniform{Float32}(-0.1f0, 0.1f0)
Uniform{Float32}(a=-0.1f0, b=0.1f0)

julia> typeof(rand(dist))
Float64
```