### PR TITLE
Add Generalized chi-squared distribution

### DIFF
--- a/docs/src/univariate.md
+++ b/docs/src/univariate.md
@@ -238,6 +238,13 @@ plotdensity((0, 18), Gamma, (7.5, 1)) # hide
 ```
 
 ```@docs
+GeneralizedChisq
+```
+```@example plotdensity
+plotdensity((-20, 20), GeneralizedChisq, ([1,-2], [1,2], [0,2], 10, 1)) # hide
+```
+
+```@docs
 GeneralizedExtremeValue
 ```
 ```@example plotdensity

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -97,6 +97,7 @@ export
     FullNormalCanon,
     Gamma,
     DiscreteNonParametric,
+    GeneralizedChisq,
     GeneralizedPareto,
     GeneralizedExtremeValue,
     Geometric,

--- a/src/univariate/continuous/generalizedchisq.jl
+++ b/src/univariate/continuous/generalizedchisq.jl
@@ -126,20 +126,6 @@ function quantile(d::GeneralizedChisq, p::Real)
     quantile_newton(d, p, x0)
 end
 
-function quantile_b(d::GeneralizedChisq, p::Real)
-    # search starting point meeting convergence criterion
-    x0 = mean(d)
-    error0, curv0, converges = GChisqComputations.newtonconvergence(d, p, x0)
-    if converges
-        return quantile_newton(d, p, x0)
-    else
-        (x1, x2), _, _ = GChisqComputations.definebracket(d, p, x0, error0, curv0, sqrt(var(d)))
-        xl, xr = (x1 < x2) ? (x1, x2) : (x2, x1)
-        return quantile_bisect(d, p, xl, xr)
-    end
-end
-
-
 function minimum(d::GeneralizedChisq{T}) where T
     d.σ > zero(T) || any(<(zero(T)), d.w) ? typemin(T) : d.μ
 end
@@ -200,7 +186,7 @@ module GChisqComputations
     where `θ` and `ρ` are the outputs of this function.
 
     Those terms are related to the characteristic function of the distribution as:
-        exp(θ*im)/ρ = exp(-ux*im)*cf(u) 
+        exp(θ*im)/ρ = exp(-u*x*im)*cf(u) 
 
     They can be also used to calculate the pdf as:
         f(x) = 1/π *∫cos(θ)/ρ du
@@ -244,13 +230,6 @@ module GChisqComputations
         end
         return integral/π
     end
-
-    # function dpdf(d::GeneralizedChisq{T}, x::Real) where T
-    #     # special case
-    #     iszero(d.σ) && !insupport(d, x) && return zero(T)
-    #     # general case
-    #     GChisqComputations.daviesdpdf(x, d.w, d.ν, d.λ, d.μ, d.σ)
-    # end
 
     # functions to look for starting point where
     # the Newton method for quantiles converges:

--- a/src/univariate/continuous/generalizedchisq.jl
+++ b/src/univariate/continuous/generalizedchisq.jl
@@ -1,0 +1,313 @@
+using Distributions, Random # remove
+import Distributions: sampler, cf, cdf, pdf, quadgk, quantile_newton, quantile_bisect # remove
+
+"""
+    GeneralizedChisq(w, ν, λ, μ, σ)
+
+The *Generalized chi-squared distribution* is the distribution of a sum of independent noncentral chi-squared variables and a normal variable:
+
+```math
+\\xi =\\sum_{i}w_{i}y_{i}+x,\\quad y_{i}\\sim \\chi '^{2}(\\nu_{i},\\lambda _{i}),\\quad x\\sim N(\\mu,\\sigma^{2}).
+```
+
+```julia
+GeneralizedChisq(w, ν, λ, μ, σ)
+
+```
+
+External links
+
+* [Generalized chi-squared distribution on Wikipedia](https://en.wikipedia.org/wiki/Generalized_chi-squared_distribution)
+
+"""
+struct GeneralizedChisq{T<:Real, V<:AbstractVector{<:Real}} <: ContinuousUnivariateDistribution
+    w::V
+    ν::V
+    λ::V
+    μ::T
+    σ::T
+
+    function GeneralizedChisq{T, V}(w, ν, λ, μ, σ; check_args::Bool=true) where {T, V}
+        # @check_args GeneralizedChisq (ν, all(ν .> 0)) (σ, σ ≥ zero(σ)) (length(w) == length(ν) == length(λ))
+        new{T, V}(w, ν, λ, μ, σ)
+    end
+end
+
+# Manage parameter types, ensuring that the parameters of normal are floats.
+
+function GeneralizedChisq(w, ν, λ, μ::Tμ, σ::Tσ; check_args...) where {Tμ<:Real, Tσ<:Real}
+    V = promote_type(typeof(w), typeof(ν), typeof(λ))
+    T = promote_type(Tμ, Tσ, eltype(w), eltype(ν), eltype(λ))
+    GeneralizedChisq{T, V}(w, ν, λ, μ, σ...; check_args...)
+end
+
+GeneralizedChisq(w, ν, λ, μ::Integer, σ::Integer; check_args...) = GeneralizedChisq(w, ν, λ, float(μ), float(σ); check_args...)
+
+Base.eltype(::GeneralizedChisq{T,V}) where {T,V} = T
+
+"""
+    GeneralizedChisqSampler
+
+Sampler of a generalized chi-squared distribution,
+created by `sampler(::GeneralizedChisq)`.
+"""
+struct GeneralizedChisqSampler{T<:Real, SC<:Sampleable{Univariate, Continuous}, SN<:Sampleable{Univariate, Continuous}} <: Sampleable{Univariate, Continuous}
+    μ::T
+    nchisqsamplers::Vector{Tuple{T, SC}}
+    normalsampler::SN # (zero-mean, since μ is defined apart)
+    skipnormal::Bool  # Normal needs not be sampled if σ == 0
+end
+
+## Required functions
+
+# sampler that predefines the distributions for batch sampling
+function sampler(d::GeneralizedChisq{T}) where T
+    μ = d.μ
+    nchisqsamplers = [(d.w[i], sampler(NoncentralChisq(d.ν[i], d.λ[i]))) for i in eachindex(d.w)]
+    normalsampler = sampler(Normal(zero(T), d.σ)) # zero-mean
+    skipnormal = iszero(d.σ)
+    GeneralizedChisqSampler(μ, nchisqsamplers, normalsampler, skipnormal)
+end
+
+function rand(rng::AbstractRNG, s::GeneralizedChisqSampler)
+    result = s.μ
+    for (w, ncs) in s.nchisqsamplers
+        result += w * rand(rng, ncs)
+    end
+    if !s.skipnormal
+        result += rand(rng, s.normalsampler)
+    end
+    return result
+end
+
+rand(rng::AbstractRNG, d::GeneralizedChisq) = rand(rng, sampler(d))
+
+# cdf algorithm derived from https://github.com/abhranildas/gx2, by Abhranil Das.
+function cdf(d::GeneralizedChisq{T}, x::Real) where T
+    # special cases
+    if iszero(d.σ)
+        (x < minimum(d)) && return zero(T)
+        (x > maximum(d)) && return one(T)
+        if all(==(first(d.w)), d.w)
+            iszero(first(d.w)) && return cdf(Normal(d.μ, d.σ), x)
+            nchisq = NoncentralChisq{T}(sum(d.ν), sum(d.λ))
+            (first(d.w) > zero(T)) && return cdf(nchisq, (x - d.μ)/first(d.w))
+            (first(d.w) < zero(T)) && return ccdf(nchisq, (x - d.μ)/first(d.w))
+        end
+    end
+    # general case
+    GChisqComputations.daviescdf(d, x)
+end
+
+function pdf(d::GeneralizedChisq{T}, x::Real) where T
+    # special cases
+    if iszero(d.σ)
+        !insupport(d, x) && return zero(T)
+        if all(==(first(d.w)), d.w)
+            iszero(first(d.w)) && return pdf(Normal(d.μ, d.σ), x)
+            nchisq = NoncentralChisq{T}(sum(d.ν), sum(d.λ))
+            return pdf(nchisq, (x - d.μ)/first(d.w)) / abs(first(d.w))
+        end
+    end
+    # general case
+    GChisqComputations.daviespdf(d, x)
+end
+
+logpdf(d::GeneralizedChisq, x::Real) = log(pdf(d, x))
+
+function quantile(d::GeneralizedChisq, p::Real)
+    # search starting point meeting convergence criterion
+    x0 = mean(d)
+    error0, curv0, converges = GChisqComputations.newtonconvergence(d, p, x0)
+    if !converges
+        bracket = GChisqComputations.definebracket(d, p, x0, error0, curv0, sqrt(var(d)))
+        x0 = GChisqComputations.searchnewtonconvergence(d, p, bracket...)
+    end
+    quantile_newton(d, p, x0)
+end
+
+function quantile_b(d::GeneralizedChisq, p::Real)
+    # search starting point meeting convergence criterion
+    x0 = mean(d)
+    error0, curv0, converges = GChisqComputations.newtonconvergence(d, p, x0)
+    if converges
+        return quantile_newton(d, p, x0)
+    else
+        (x1, x2), _, _ = GChisqComputations.definebracket(d, p, x0, error0, curv0, sqrt(var(d)))
+        xl, xr = (x1 < x2) ? (x1, x2) : (x2, x1)
+        return quantile_bisect(d, p, xl, xr)
+    end
+end
+
+
+function minimum(d::GeneralizedChisq{T}) where T
+    d.σ > zero(T) || any(<(zero(T)), d.w) ? typemin(T) : d.μ
+end
+
+function maximum(d::GeneralizedChisq{T}) where T
+    d.σ > zero(T) || any(>(zero(T)), d.w) ? typemax(T) : d.μ
+end
+
+insupport(d::GeneralizedChisq, x::Real) = minimum(d) ≤ x ≤ maximum(d)
+
+## Recommended functions
+
+mean(d::GeneralizedChisq) = d.μ + sum(d.w[i] * (d.ν[i] + d.λ[i]) for i in eachindex(d.w))
+var(d::GeneralizedChisq) = d.σ^2 + 2 * sum(d.w[i]^2 * (d.ν[i] + 2*d.λ[i]) for i in eachindex(d.w))
+
+# modes(d::GeneralizedChisq)
+# mode(d::GeneralizedChisq)
+# skewness(d::GeneralizedChisq)
+# kurtosis(d::GeneralizedChisq, ::Bool)
+# entropy(d::GeneralizedChisq, ::Real)
+# mgf(d::GeneralizedChisq, ::Any)
+cf(d::GeneralizedChisq, t) = GChisqComputations.cf_explicit(d, t)
+
+module GChisqComputations
+    import ..Normal, ..NoncentralChisq, ..GeneralizedChisq
+    import ..cf, ..cdf, ..insupport
+    import ..quadgk
+
+    # Characteristic function - explicit formula
+    function cf_explicit(d, t)
+        arg = im * d.μ * t
+        denom = Complex(one(d.μ) * one(t)) # unit with stable type in later operations
+        for i in eachindex(d.w)
+            arg += im * d.w[i] * d.λ[i] * t / (1 - 2im * d.w[i] * t)
+            denom *= (1 - 2im * d.w[i] * t)^(d.ν[i]/2)
+        end
+        arg -= d.σ^2 * t^2 / 2
+        return exp(arg) / denom
+    end
+
+    # Characteristic function - by inheritance
+    function cf_inherit(d::GeneralizedChisq{T}, t) where T
+        result = exp(im * d.μ * t)
+        for i in eachindex(d.w)
+            result *= cf(NoncentralChisq{T}(d.ν[i], d.λ[i]), d.w[i] * t)
+        end
+        if !iszero(d.σ)
+            result *= cf(Normal(zero(d.μ), d.σ), t)
+        end
+        return result
+    end
+
+    #=
+    Terms of the formula (13) in Davies (1980) to calculate
+    the cdf of a generalized chi-squared distribution, as: 
+        F(x) = 1/2 - 1/π *∫sin(θ)/(u*ρ)du
+
+    where `θ` and `ρ` are the outputs of this function.
+
+    Those terms are related to the characteristic function of the distribution as:
+        exp(θ*im)/ρ = exp(-ux*im)*cf(u) 
+
+    They can be also used to calculate the pdf as:
+        f(x) = 1/π *∫cos(θ)/ρ du
+
+    And its derivative as:
+        f'(x) = 1/π *∫u*sin(θ)/ρ du
+    =#
+    function daviesterms(d::GeneralizedChisq{T}, u, x) where {T<:Real}
+        θ = -T(u*(x - d.μ))
+        ρ = exp(T(u*d.σ)^2 / 2)
+        for i in eachindex(d.w)
+            wi, νi, λi = T(d.w[i]), T(d.ν[i]), T(d.λ[i])
+            τ  = 1 + 4 * wi^2 * u^2
+            θ += νi*atan(2*wi*u)/2 + (λi*wi*u)/τ
+            ρ *= τ^(νi/4) * exp(2λi*wi^2*u^2/τ)
+        end
+        return θ, ρ
+	end
+
+    function daviescdf(d, x)
+        integral, _ = quadgk(0, Inf) do u
+            θ, ρ = daviesterms(d, u, x)
+            return sin(θ)/(u*ρ)
+        end
+        return 1/2 - integral/π
+    end
+
+    function daviespdf(d, x)
+        integral, _ = quadgk(0, Inf) do u
+            θ, ρ = daviesterms(d, u, x)
+            return cos(θ)/ρ
+        end
+        return integral/π
+    end
+
+    # derivative of pdf
+    function daviesdpdf(d, x)
+        integral, _ = quadgk(0, Inf) do u
+            θ, ρ = daviesterms(d, u, x)
+            return u*sin(θ)/ρ
+        end
+        return integral/π
+    end
+
+    # function dpdf(d::GeneralizedChisq{T}, x::Real) where T
+    #     # special case
+    #     iszero(d.σ) && !insupport(d, x) && return zero(T)
+    #     # general case
+    #     GChisqComputations.daviesdpdf(x, d.w, d.ν, d.λ, d.μ, d.σ)
+    # end
+
+    # functions to look for starting point where
+    # the Newton method for quantiles converges:
+    # sign(F(x) - q) == sign(f'(x))
+
+    # Convergence criterion:
+    function newtonconvergence(d::GeneralizedChisq{T}, p, x) where T
+        error = cdf(d, x) - T(p)
+        # out of bounds
+        iszero(d.σ) && !insupport(d, x) && return error, zero(T), false
+        # general case
+        curvature = daviesdpdf(d, x)
+        converges = sign(error) == sign(curvature)
+        return error, curvature, converges
+    end
+
+    # Bracket containing solution for q, with x as one of the ends
+    function definebracket(d::GeneralizedChisq{T}, p, x, errorx, curvx, initialwidth) where T
+        # set direction of span and initialize bracket
+        span = (errorx < 0) ? abs(initialwidth) : -abs(initialwidth)
+        xbis = x + span
+        errorxbis, curvxbis, _ = newtonconvergence(d, p, xbis)
+        # greedier search if the bracket does not contain the solution
+        iterations = 0
+        while sign(errorxbis) == sign(errorx)
+            iterations += 1
+            span *= 2*errorxbis / (errorx - errorxbis)
+            x, errorx, curvx = xbis, errorxbis, curvxbis
+            xbis = x + span
+            errorxbis, curvxbis, _ = newtonconvergence(d, p, xbis)
+        end
+        @debug "Iterations to define bracket" iterations
+        # bracket end out of bounds
+        if !insupport(d, xbis)
+            xbis = d.μ
+        end
+        return (x, xbis), (errorx, errorxbis), (curvx, curvxbis)
+    end
+
+    # Bisect bracket until convergence point is reached
+    function searchnewtonconvergence(d, p, (x,xbis), (errorx, errorxbis), (curvx, curvxbis))
+        iterations = 0
+        while true
+            iterations += 1
+            # Assumes that the first point is *outside* the region of convergence
+            if sign(errorxbis) == sign(curvxbis)
+                @debug "Iterations to find convergence point" iterations
+                return xbis
+            end
+            xmid = (x + xbis) / 2
+            errorxmid, curvxmid, _ = newtonconvergence(d, p, xmid)
+            # switch first point if the new end of the bracket is on the same side
+            if sign(errorxmid) == sign(errorx)
+                x, errorx, curvx = xbis, errorxbis, curvxbis
+            end
+            xbis, errorxbis, curvxbis = xmid, errorxmid, curvxmid
+        end
+    end
+
+end

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -682,6 +682,7 @@ const continuous_distributions = [
     "fdist",
     "frechet",
     "gamma", "erlang",
+    "generalizedchisq",
     "pgeneralizedgaussian", # GeneralizedGaussian depends on Gamma
     "generalizedpareto",
     "generalizedextremevalue",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,6 +75,7 @@ const tests = [
     "univariate/continuous/erlang",
     "univariate/continuous/exponential",
     "univariate/continuous/gamma",
+    "univariate/continuous/generalizedchisq.jl",
     "univariate/continuous/gumbel",
     "univariate/continuous/lindley",
     "univariate/continuous/logistic",

--- a/test/univariate/continuous/generalizedchisq.jl
+++ b/test/univariate/continuous/generalizedchisq.jl
@@ -1,41 +1,94 @@
 using Distributions
-import Distributions.quadgk
-using Tests
+using Test
 using Random
 
 @testset "Generalized chi-squared" begin
     rng = Random.MersenneTwister(0)
-    # check types of corner cases
-    gx2 = GeneralizedChisq([1,1], [1,1], [0,1], 10, 1)
-    @test typeof(gx2.μ) <: AbstractFloat
-    gx2 = GeneralizedChisq([1,1], [1,1], BigFloat[0,1], 10, 1)
-    @test typeof(gx2.μ) <: BigFloat
-    gx2 = GeneralizedChisq(Int[], Int[], Int[], 0, 1.0)
-    @test typeof(gx2.μ) == typeof(1.0)
-    # test sampler
-    # test maximum-minimum
-    # test cf, cdf, pdf
+    Computations = Distributions.GChisqComputations
+    quadgk = Distributions.quadgk
+    # General case
     gx2 = GeneralizedChisq([1,-1], [1,2], [1.5, 1.5], 10, 1)
-    @test let t = 10 + randn()
-        cf(gx2, t) ≈ GChisqComputations.cf_inherit(gx2, t)
+    @test eltype(gx2) == typeof(gx2.μ) <: AbstractFloat
+    @test minimum(gx2) == -Inf
+    @test maximum(gx2) == Inf
+    @test insupport(gx2, rand(gx2))
+    @test let t = randn()
+        cf(gx2, t) ≈ Computations.cf_inherit(gx2, t)
     end
     @test cdf(gx2, 15) - cdf(gx2, 5) ≈ first(quadgk(x->pdf(gx2, x), 5, 15))
-    @test pdf(gx2, 15) - pdf(gx2, 5) ≈ first(quadgk(x->GChisqComputations.daviesdpdf(gx2, x), 5, 15))
-    # test search of convergence for starting point of quantile
-    for p in 0.1:0.1:0.9, x in 0:15
-        println(x, ", ", p, ", ", GChisqComputations.newtonconvergence(gx2, p, x))
+    @test pdf(gx2, 15) - pdf(gx2, 5) ≈ first(quadgk(x->Computations.daviesdpdf(gx2, x), 5, 15))
+    @testset for p in 0:0.05:1
+        q = quantile(gx2, p)
+        @test cdf(gx2, q) ≈ p
     end
-    for p in 0.0:0.05:1.0
-        println(p, ", ", GChisqComputations.newtonconvergence(gx2, p, gx2.μ))
+    # Other types
+    gx2 = GeneralizedChisq([1,1], [1,1], BigFloat[0,1], 10, 1)
+    @test eltype(gx2) == typeof(gx2.μ) <: BigFloat
+    # [Don't test with BigFloat]
+    gx2 = GeneralizedChisq([1,1], [1,1], [0,1], 10, 1f0)
+    @test eltype(gx2) == typeof(gx2.μ) <: Float32
+    @test insupport(gx2, rand(gx2))
+    # Special cases:
+    # σ == 0, positive weights
+    gx2 = GeneralizedChisq([1,1], [1,2], [0,1], 10, 0)
+    @test all(≥(10), rand(gx2, 10))
+    @test minimum(gx2) == 10
+    @test let t = randn()
+        cf(gx2, t) ≈ Computations.cf_inherit(gx2, t)
     end
-    # using BenchmarkTools
-    for p in 0.05:0.05:0.9
-        qn = quantile(gx2, p)
-        tn = @elapsed quantile(gx2, p)
-        qb = quantile_b(gx2, p)
-        tb = @elapsed quantile_b(gx2, p)
-        println(p, ", ", qn, ", ", tn, ", ", cdf(gx2, qn))
-        println(p, ", ", qb, ", ", tb, ", ", cdf(gx2, qb))
-        println()
+    @test cdf(gx2, 15) - cdf(gx2, 5) ≈ first(quadgk(x->pdf(gx2, x), 5, 15)) ≈ first(quadgk(x->pdf(gx2, x), 10, 15))
+    @testset for p in 0:0.05:1
+        q = quantile(gx2, p)
+        @test cdf(gx2, q) ≈ p
+    end
+    # σ == 0, negative weights
+    gx2 = GeneralizedChisq([-1,-1], [1,2], [0,1], 10, 0)
+    @test all(≤(10), rand(gx2, 10))
+    @test maximum(gx2) == 10
+    @test let t = randn()
+        cf(gx2, t) ≈ Computations.cf_inherit(gx2, t)
+    end
+    @test cdf(gx2, 15) - cdf(gx2, 5) ≈ first(quadgk(x->pdf(gx2, x), 5, 15)) ≈ first(quadgk(x->pdf(gx2, x), 5, 10))
+    @testset for p in 0:0.05:1
+        q = quantile(gx2, p)
+        @test cdf(gx2, q) ≈ p
+    end
+    # All zero weights
+    gx2 = GeneralizedChisq([0,0], [1,2], [0,1], 10, 1)
+    gx2b = GeneralizedChisq(Int[], Int[], Int[], 10, 1)
+    normalequiv = Normal(gx2.μ, gx2.σ)
+    @test let t = randn()
+        cf(gx2, t) ≈ cf(gx2b, t) ≈ Computations.cf_inherit(gx2, t) ≈ cf(normalequiv, t)
+    end
+    let x = 10 + randn()
+        @test cdf(gx2, x) ≈ cdf(gx2b, x) ≈ Computations.daviescdf(gx2, x) ≈ cdf(normalequiv, x)
+        @test pdf(gx2, x) ≈ pdf(gx2b, x) ≈ Computations.daviespdf(gx2, x) ≈ pdf(normalequiv, x)
+    end
+    @testset for p in 0:0.05:1
+        q = quantile(gx2, p)
+        @test q == quantile(gx2, p)
+        @test cdf(gx2, q) ≈ cdf(gx2b, q) ≈ p
+    end
+    # delta at μ
+    gx2 = GeneralizedChisq([0,0], [1,2], [0,1], 10, 0)
+    gx2b = GeneralizedChisq(Int[], Int[], Int[], 10, 0)
+    @test let t = randn()
+        cf(gx2, t) ≈ cf(gx2b, t) ≈ Computations.cf_inherit(gx2, t)
+    end
+    let x = 9
+        @test cdf(gx2, x) == cdf(gx2b, x) == 0
+        @test pdf(gx2, x) == pdf(gx2b, x) == 0
+    end
+    let x = 10
+        @test cdf(gx2, x) == cdf(gx2b, x) == 1
+        @test pdf(gx2, x) == pdf(gx2b, x) == Inf
+    end
+    let x = 11
+        @test cdf(gx2, x) == cdf(gx2b, x) == 1
+        @test pdf(gx2, x) == pdf(gx2b, x) == 0
+    end
+    @testset for p in 0:0.05:1
+        q = quantile(gx2, p)
+        @test q == quantile(gx2, p) == 10
     end
 end

--- a/test/univariate/continuous/generalizedchisq.jl
+++ b/test/univariate/continuous/generalizedchisq.jl
@@ -1,0 +1,41 @@
+using Distributions
+import Distributions.quadgk
+using Tests
+using Random
+
+@testset "Generalized chi-squared" begin
+    rng = Random.MersenneTwister(0)
+    # check types of corner cases
+    gx2 = GeneralizedChisq([1,1], [1,1], [0,1], 10, 1)
+    @test typeof(gx2.μ) <: AbstractFloat
+    gx2 = GeneralizedChisq([1,1], [1,1], BigFloat[0,1], 10, 1)
+    @test typeof(gx2.μ) <: BigFloat
+    gx2 = GeneralizedChisq(Int[], Int[], Int[], 0, 1.0)
+    @test typeof(gx2.μ) == typeof(1.0)
+    # test sampler
+    # test maximum-minimum
+    # test cf, cdf, pdf
+    gx2 = GeneralizedChisq([1,-1], [1,2], [1.5, 1.5], 10, 1)
+    @test let t = 10 + randn()
+        cf(gx2, t) ≈ GChisqComputations.cf_inherit(gx2, t)
+    end
+    @test cdf(gx2, 15) - cdf(gx2, 5) ≈ first(quadgk(x->pdf(gx2, x), 5, 15))
+    @test pdf(gx2, 15) - pdf(gx2, 5) ≈ first(quadgk(x->GChisqComputations.daviesdpdf(gx2, x), 5, 15))
+    # test search of convergence for starting point of quantile
+    for p in 0.1:0.1:0.9, x in 0:15
+        println(x, ", ", p, ", ", GChisqComputations.newtonconvergence(gx2, p, x))
+    end
+    for p in 0.0:0.05:1.0
+        println(p, ", ", GChisqComputations.newtonconvergence(gx2, p, gx2.μ))
+    end
+    # using BenchmarkTools
+    for p in 0.05:0.05:0.9
+        qn = quantile(gx2, p)
+        tn = @elapsed quantile(gx2, p)
+        qb = quantile_b(gx2, p)
+        tb = @elapsed quantile_b(gx2, p)
+        println(p, ", ", qn, ", ", tn, ", ", cdf(gx2, qn))
+        println(p, ", ", qb, ", ", tb, ", ", cdf(gx2, qb))
+        println()
+    end
+end


### PR DESCRIPTION
This extends the collection of univariate continuous distributions with the Generalized chi-squared. All required methods are added, and some of the recommended ones, as indicated in https://juliastats.org/Distributions.jl/stable/extends/#Univariate-Distribution

**Some notes:**

1. I started considering [Abhranil Das' code for Matlab](https://github.com/abhranildas/gx2) (MIT-licensed) as reference, although progressively departed from it, so that eventually there is little in the Julia code that can be attributed to him. I have kept a comment where I mention the inspiration to define the `cdf` function, using Davies' algorithm to integrate the characteristic function. But I don't know if a more explicit attribution in the code or in the license should be made.
2. There are several auxiliary functions that should not be part of the API, and I have encapsulated all of them in the module `GChisqComputations`, after the example of the Chernoff distribution.
3. That module includes two functions to calculate the characteristic function: `cf_explicit` that implements the explicit formula, and `cf_inherit` that composes the results of `cf(::Normal)` and `cf(::NoncentralChisq)`. Both are equivalent, and the code of the second is clearer, but `cf(::GeneralizedChisq)` calls the first one, because in a few tests that I have done, it is slightly (but not much) faster.
4. `cdf` and `pdf` are calculated by integration, using the Gil-Pelaez theorem (the algorithm for the CDF is given in Davies' paper, and the algorithm for the PDF has been indirectly derived from it). The integration is done using QuadGK.jl, which was already in the dependencies of Distributions.jl. The default tolerances of `QuadGK.quadgk` made the calculation of `cdf` at the median very slow, because there the integral is zero. Since in the ends of the distribution the integral is `±π/2`, which is in the order of magnitude of the unit, I have used a fixed absolute tolerance of `eps(one(T))` for the integration in the calculation of the CDF. I have not, however, changed the defaults for the calculation of the PDF.
5. `quantile` is calculated using `Distributions.quantile_newton`. However, there is no analytic solution to find the mode, which is the recommended starting point, so this is searched using the following strategy: (1) start at the mean of the distribution, and use it if it meets the convergence criteria; (2) otherwise define a bracket between that point and another at one standard deviation from the mean, in the direction towards the target probability (and if the bracket does not contain the target probability, extend it until it does); (3) bisect the bracket until one of the ends meets the convergence criteria, and then use that as the starting point. This seems to work fine, but it's a self-made algorithm, and perhaps there is a more efficient one that might be used instead.