### PR TITLE
Clarify definitions of inverse CDF functions

### DIFF
--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -382,7 +382,7 @@ logccdf(d::UnivariateDistribution, x::Real) = log(ccdf(d, x))
 """
     quantile(d::UnivariateDistribution, q::Real)
 
-Evaluate the generalized inverse cumulative distribution function at `q`.
+Evaluate the (generalized) inverse cumulative distribution function at `q`.
 
 For a given `0 ≤ q ≤ 1`, `quantile(d, q)` is the smallest value `x` in the support of `d`
 for which `cdf(d, x) ≥ q`.
@@ -401,7 +401,7 @@ cquantile(d::UnivariateDistribution, p::Real) = quantile(d, 1.0 - p)
 """
     invlogcdf(d::UnivariateDistribution, lp::Real)
 
-The generalized inverse function of [`logcdf`](@ref).
+The (generalized) inverse function of [`logcdf`](@ref).
 
 For a given `lp ≤ 0`, `invlogcdf(d, lp)` is the smallest value `x` in the support of `d` for
 which `logcdf(d, x) ≥ lp`.
@@ -411,7 +411,7 @@ invlogcdf(d::UnivariateDistribution, lp::Real) = quantile(d, exp(lp))
 """
     invlogccdf(d::UnivariateDistribution, lp::Real)
 
-The generalized inverse function of [`logccdf`](@ref).
+The (generalized) inverse function of [`logccdf`](@ref).
 
 For a given `lp ≤ 0`, `invlogccdf(d, lp)` is the smallest value `x` in the support of `d`
 for which `logccdf(d, x) ≤ lp`.

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -183,7 +183,7 @@ std(d::UnivariateDistribution) = sqrt(var(d))
     median(d::UnivariateDistribution)
 
 Return the median value of distribution `d`. The median is the smallest `x` in the support
-of `d` such that `cdf(d, x) ≥ 1/2`.
+of `d` for which `cdf(d, x) ≥ 1/2`.
 Corresponding to this definition as 1/2-quantile, a fallback is provided calling the `quantile` function.
 """
 median(d::UnivariateDistribution) = quantile(d, 1//2)

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -182,7 +182,8 @@ std(d::UnivariateDistribution) = sqrt(var(d))
 """
     median(d::UnivariateDistribution)
 
-Return the median value of distribution `d`. The median is the smallest `x` such that `cdf(d, x) ≥ 1/2`.
+Return the median value of distribution `d`. The median is the smallest `x` in the support
+of `d` such that `cdf(d, x) ≥ 1/2`.
 Corresponding to this definition as 1/2-quantile, a fallback is provided calling the `quantile` function.
 """
 median(d::UnivariateDistribution) = quantile(d, 1//2)
@@ -381,7 +382,10 @@ logccdf(d::UnivariateDistribution, x::Real) = log(ccdf(d, x))
 """
     quantile(d::UnivariateDistribution, q::Real)
 
-Evaluate the inverse cumulative distribution function at `q`.
+Evaluate the generalized inverse cumulative distribution function at `q`.
+
+For a given `0 ≤ q ≤ 1`, `quantile(d, q)` is the smallest value `x` in the support of `d`
+for which `cdf(d, x) ≥ q`.
 
 See also: [`cquantile`](@ref), [`invlogcdf`](@ref), and [`invlogccdf`](@ref).
 """
@@ -397,14 +401,20 @@ cquantile(d::UnivariateDistribution, p::Real) = quantile(d, 1.0 - p)
 """
     invlogcdf(d::UnivariateDistribution, lp::Real)
 
-The inverse function of logcdf.
+The generalized inverse function of [`logcdf`](@ref).
+
+For a given `lp ≤ 0`, `invlogcdf(d, lp)` is the smallest value `x` in the support of `d` for
+which `logcdf(d, x) ≥ lp`.
 """
 invlogcdf(d::UnivariateDistribution, lp::Real) = quantile(d, exp(lp))
 
 """
     invlogccdf(d::UnivariateDistribution, lp::Real)
 
-The inverse function of logccdf.
+The generalized inverse function of [`logccdf`](@ref).
+
+For a given `lp ≤ 0`, `invlogccdf(d, lp)` is the smallest value `x` in the support of `d`
+for which `logccdf(d, x) ≤ lp`.
 """
 invlogccdf(d::UnivariateDistribution, lp::Real) = quantile(d, -expm1(lp))
 


### PR DESCRIPTION
Fixes #1813 by updating docstrings as proposed in https://github.com/JuliaStats/Distributions.jl/issues/1813#issuecomment-1872989317:
- documents in what sense `quantile` and friends invert `cdf` and friends
- documents that inputs to `quantile` and friends are probabilities in `[0, 1]` or log-probabilities in `(-Inf, 0]`. (inputs outside of this range would then lead to undefined behavior)