### PR TITLE
Fix `eachvariate` with zero variates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.104"
+version = "0.25.105"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/eachvariate.jl
+++ b/src/eachvariate.jl
@@ -7,7 +7,7 @@ end
 
 function EachVariate{V}(x::AbstractArray{<:Real,M}) where {V,M}
     ax = ntuple(i -> axes(x, i + V), Val(M - V))
-    T = typeof(view(x, ntuple(i -> i <= V ? Colon() : firstindex(x, i), Val(M))...))
+    T = Base.promote_op(view, typeof(x), ntuple(i -> i <= V ? Colon : eltype(axes(x, i)), Val(M))...)
     return EachVariate{V,typeof(x),typeof(ax),T,M-V}(x, ax)
 end
 

--- a/test/eachvariate.jl
+++ b/test/eachvariate.jl
@@ -1,10 +1,22 @@
+using Distributions
 using ChainRulesTestUtils
 using ChainRulesTestUtils: FiniteDifferences
+
+using Random
+using Test
 
 # Without this, `to_vec` will also include the `axes` field of `EachVariate`.
 function FiniteDifferences.to_vec(xs::Distributions.EachVariate{V}) where {V}
     vals, vals_from_vec = FiniteDifferences.to_vec(xs.parent)
     return vals, x -> Distributions.EachVariate{V}(vals_from_vec(x))
+end
+
+# MWE in #1817
+struct FooEachvariate <: Sampleable{Multivariate, Continuous} end
+Base.length(::FooEachvariate) = 3
+Base.eltype(::FooEachvariate) = Float64
+function Distributions._rand!(rng::AbstractRNG, ::FooEachvariate, x::AbstractVector{<:Real})
+    return rand!(rng, x)
 end
 
 @testset "eachvariate.jl" begin
@@ -13,5 +25,20 @@ end
         test_rrule(Distributions.EachVariate{1}, xs)
         test_rrule(Distributions.EachVariate{2}, xs)
         test_rrule(Distributions.EachVariate{3}, xs)
+    end
+
+    @testset "No variates (#1817)" begin
+        @test size(Distributions.eachvariate(rand(0), Univariate)) == (0,)
+        @test size(Distributions.eachvariate(rand(3, 0, 1), Univariate)) == (3, 0, 1)
+        @test size(Distributions.eachvariate(rand(3, 2, 0), Univariate)) == (3, 2, 0)
+
+        @test size(Distributions.eachvariate(rand(4, 0), Multivariate)) == (0,)
+        @test size(Distributions.eachvariate(rand(4, 0, 2), Multivariate)) == (0, 2)
+        @test size(Distributions.eachvariate(rand(4, 5, 0), Multivariate)) == (5, 0)
+        @test size(Distributions.eachvariate(rand(4, 5, 0, 2), Multivariate)) == (5, 0, 2)
+
+        draws = @inferred(rand(FooEachvariate(), 0))
+        @test draws isa Matrix{Float64}
+        @test size(draws) == (3, 0)
     end
 end


### PR DESCRIPTION
Currently, the constructor of `Distributions.EachVariate` fails when there are zero variates (along at least one dimension). The PR fixes this problem similar to the approach taken for `Slices` in https://github.com/JuliaLang/julia/blob/38b81562d79dfa44816bd3ce5b249cad87904587/base/slicearray.jl#L43C1-L43C1.

Fixes #1817.