### PR TITLE
Fix typo in Gumbel `gradlogpdf`

### DIFF
--- a/src/univariate/continuous/gumbel.jl
+++ b/src/univariate/continuous/gumbel.jl
@@ -102,4 +102,4 @@ logcdf(d::Gumbel, x::Real) = -exp(-zval(d, x))
 
 quantile(d::Gumbel, p::Real) = d.μ - d.θ * log(-log(p))
 
-gradlogpdf(d::Gumbel, x::Real) = - (1 + exp((d.μ - x) / d.θ)) / d.θ
+gradlogpdf(d::Gumbel, x::Real) = (-1 + exp(-zval(d, x))) / d.θ

--- a/src/univariate/continuous/gumbel.jl
+++ b/src/univariate/continuous/gumbel.jl
@@ -102,4 +102,4 @@ logcdf(d::Gumbel, x::Real) = -exp(-zval(d, x))
 
 quantile(d::Gumbel, p::Real) = d.μ - d.θ * log(-log(p))
 
-gradlogpdf(d::Gumbel, x::Real) = (-1 + exp(-zval(d, x))) / d.θ
+gradlogpdf(d::Gumbel, x::Real) = expm1(-zval(d, x)) / d.θ

--- a/test/gradlogpdf.jl
+++ b/test/gradlogpdf.jl
@@ -9,7 +9,7 @@ using Test
 @test isapprox(gradlogpdf(Chisq(7.0), 12.0)       , -0.29166666666666663, atol=1.0e-8)
 @test isapprox(gradlogpdf(Exponential(2.0), 7.0)  , -0.5                , atol=1.0e-8)
 @test isapprox(gradlogpdf(Gamma(9.0, 0.5), 11.0)  , -1.2727272727272727 , atol=1.0e-8)
-@test isapprox(gradlogpdf(Gumbel(3.5, 1.0), 4.0)  , -1.6065306597126334 , atol=1.0e-8)
+@test isapprox(gradlogpdf(Gumbel(3.5, 1.0), 4.0)  , -0.3934693402873666 , atol=1.0e-8)
 @test isapprox(gradlogpdf(Laplace(7.0), 34.0)     , -1.0                , atol=1.0e-8)
 @test isapprox(gradlogpdf(Logistic(-6.0), 1.0)    , -0.9981778976111987 , atol=1.0e-8)
 @test isapprox(gradlogpdf(LogNormal(5.5), 2.0)    ,  1.9034264097200273 , atol=1.0e-8)


### PR DESCRIPTION
The implementation of `gradlogpdf` for the Gumbel distribution has a sign error.

```julia
julia> using Distributions, ForwardDiff

julia> gradlogpdf(Gumbel(3.5, 1.0), 4.0)
-1.6065306597126334

julia> ForwardDiff.derivative(x->logpdf(Gumbel(3.5, 1.0), x), 4.0)
-0.3934693402873666

julia> Distributions.gradlogpdf(d::Gumbel, x::Real) = (-1 + exp((d.μ - x) / d.θ)) / d.θ

julia> gradlogpdf(Gumbel(3.5, 1.0), 4.0)
-0.3934693402873666
```