### PR TITLE
microoptimization on rand(::AliasTable)

### DIFF
--- a/src/samplers/aliastable.jl
+++ b/src/samplers/aliastable.jl
@@ -15,6 +15,7 @@ end
 
 function rand(rng::AbstractRNG, s::AliasTable)
     i = rand(rng, 1:length(s.alias)) % Int
+    # using `ifelse` improves performance here: github.com/JuliaStats/Distributions.jl/pull/1831/
     ifelse(rand(rng) < s.accept[i],  i, s.alias[i])
 end
 

--- a/src/samplers/aliastable.jl
+++ b/src/samplers/aliastable.jl
@@ -15,9 +15,7 @@ end
 
 function rand(rng::AbstractRNG, s::AliasTable)
     i = rand(rng, 1:length(s.alias)) % Int
-    u = rand(rng)
-    @inbounds r = u < s.accept[i] ? i : s.alias[i]
-    r
+    ifelse(rand(rng) < s.accept[i],  i, s.alias[i])
 end
 
 show(io::IO, s::AliasTable) = @printf(io, "AliasTable with %d entries", ncategories(s))


### PR DESCRIPTION
doesn't necessary improve all the CI benchmarks, but I think those are kind of artificial. on all of my actual use cases I've tried, it's faster to use an `ifelse` and omit the `@inbounds`


status quo:
```
julia> @benchmark rand($rng, s) setup=(s = AliasTable(normalize(rand(10), 1)))
BenchmarkTools.Trial: 10000 samples with 999 evaluations.
 Range (min … max):   7.132 ns … 33.909 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     11.679 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   11.606 ns ±  1.195 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                              ▁ ▂▂ ▃▄▆▁▇▆▂▇▇▂▇█▃▆▅▅ ▃▃         
  ▁▁▁▁▁▁▁▁▁▁▂▂▂▁▂▂▂▃▃▃▄▄▃▄▆▆▅▇█▆██▇███████████████████▆██▄▅▅▃ ▄
  7.13 ns         Histogram: frequency by time        13.8 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark rand($rng, s) setup=(s = AliasTable(normalize(rand(100), 1)))
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  11.125 ns … 28.416 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     13.083 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   13.056 ns ±  0.507 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                                  ▂    ▁ █▁▁▁▁ ▇               
  ▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▃▃▃▃▃▃▃▅▄▅▅▅▆█▇▇▇██████████▇▇▆▆▆▅▇▄▃▃▃▃▃ ▄
  11.1 ns         Histogram: frequency by time          14 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark rand($rng, s) setup=(s = AliasTable(normalize(rand(100_000), 1)))
BenchmarkTools.Trial: 2899 samples with 1000 evaluations.
 Range (min … max):  12.042 ns … 49.917 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     12.917 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   13.013 ns ±  1.244 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                        ▂▃ ▅▇ ▇█▇ ▆▆ █▆ ▅▂ ▃                   
  ▂▁▂▁▁▂▁▂▃▁▂▄▁▄▄▁▆▆▁▇█▁██▁██▁███▁██▁██▁██▁██▁▇▆▁▅▄▁▅▃▁▃▃▁▂▂▂ ▄
  12 ns           Histogram: frequency by time        13.7 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```





PR:
```
julia> @benchmark rand($rng, s) setup=(s = AliasTable(normalize(rand(10), 1)))
BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  5.458 ns … 41.708 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     5.583 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.612 ns ±  0.571 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                  ▂       █▁       ▂                          
  ▂▁▁▁▁▁▁▁▂▁▁▁▁▁▁▁█▁▁▁▁▁▁▁██▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▄▁▁▁▁▁▁▁▃▁▁▁▁▁▁▁▂ ▂
  5.46 ns        Histogram: frequency by time        5.75 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark rand($rng, s) setup=(s = AliasTable(normalize(rand(100), 1)))

BenchmarkTools.Trial: 10000 samples with 1000 evaluations.
 Range (min … max):  5.500 ns … 23.375 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     5.584 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.621 ns ±  0.487 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                     █        ▂                               
  ▂▁▁▁▁▁▁▁▁▃▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▃▁▁▁▁▁▁▁▁▁▂▁▁▁▁▁▁▁▁▂ ▂
  5.5 ns         Histogram: frequency by time        5.75 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark rand($rng, s) setup=(s = AliasTable(normalize(rand(100_000), 1)))
BenchmarkTools.Trial: 2874 samples with 1000 evaluations.
 Range (min … max):  6.000 ns … 42.375 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     6.125 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   6.140 ns ±  0.764 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                  █       ▇                                   
  ▂▁▁▁▁▁▁▁▄▁▁▁▁▁▁▁█▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▅▁▁▁▁▁▁▁▃▁▁▁▁▁▁▁▃▁▁▁▁▁▁▁▂ ▂
  6 ns           Histogram: frequency by time        6.29 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```