### PR TITLE
Use a faster implementation of AliasTables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["JuliaStats"]
 version = "0.25.107"
 
 [deps]
+AliasTables = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 DensityInterface = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
@@ -30,6 +31,7 @@ DistributionsDensityInterfaceExt = "DensityInterface"
 DistributionsTestExt = "Test"
 
 [compat]
+AliasTables = "1"
 Aqua = "0.8"
 Calculus = "0.5"
 ChainRulesCore = "1"

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -27,6 +27,8 @@ import PDMats: dim, PDMat, invquad
 using SpecialFunctions
 using Base.MathConstants: eulergamma
 
+import AliasTables
+
 export
     # re-export Statistics
     mean, median, quantile, std, var, cov, cor,

--- a/src/samplers/aliastable.jl
+++ b/src/samplers/aliastable.jl
@@ -1,22 +1,8 @@
+using AliasTables
 struct AliasTable <: Sampleable{Univariate,Discrete}
-    accept::Vector{Float64}
-    alias::Vector{Int}
+    at::AliasTables.AliasTable{UInt64, Int}
+    AliasTable(probs::AbstractVector{<:Real}) = new(AliasTables.AliasTable(probs))
 end
-ncategories(s::AliasTable) = length(s.alias)
-
-function AliasTable(probs::AbstractVector)
-    n = length(probs)
-    n > 0 || throw(ArgumentError("The input probability vector is empty."))
-    accp = Vector{Float64}(undef, n)
-    alias = Vector{Int}(undef, n)
-    StatsBase.make_alias_table!(probs, 1.0, accp, alias)
-    AliasTable(accp, alias)
-end
-
-function rand(rng::AbstractRNG, s::AliasTable)
-    i = rand(rng, 1:length(s.alias)) % Int
-    # using `ifelse` improves performance here: github.com/JuliaStats/Distributions.jl/pull/1831/
-    ifelse(rand(rng) < s.accept[i],  i, s.alias[i])
-end
-
+ncategories(s::AliasTable) = length(s.at)
+rand(rng::AbstractRNG, s::AliasTable) = rand(rng, s.at)
 show(io::IO, s::AliasTable) = @printf(io, "AliasTable with %d entries", ncategories(s))

--- a/src/samplers/aliastable.jl
+++ b/src/samplers/aliastable.jl
@@ -1,4 +1,3 @@
-using AliasTables
 struct AliasTable <: Sampleable{Univariate,Discrete}
     at::AliasTables.AliasTable{UInt64, Int}
     AliasTable(probs::AbstractVector{<:Real}) = new(AliasTables.AliasTable(probs))

--- a/src/samplers/multinomial.jl
+++ b/src/samplers/multinomial.jl
@@ -53,7 +53,7 @@ function _rand!(rng::AbstractRNG, s::MultinomialSampler,
                 x::AbstractVector{<:Real})
     n = s.n
     k = length(s)
-    if n^2 > k
+    if k < n/50+2
         multinom_rand!(rng, n, s.prob, x)
     else
         # Use an alias table

--- a/src/samplers/multinomial.jl
+++ b/src/samplers/multinomial.jl
@@ -53,7 +53,7 @@ function _rand!(rng::AbstractRNG, s::MultinomialSampler,
                 x::AbstractVector{<:Real})
     n = s.n
     k = length(s)
-    if k < n/50+2
+    if n^2 > k
         multinom_rand!(rng, n, s.prob, x)
     else
         # Use an alias table

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -31,9 +31,11 @@ import Distributions:
         @testset "p=$p" for p in Any[[1.0], [0.3, 0.7], [0.2, 0.3, 0.4, 0.1]]
             test_samples(S(p), Categorical(p), n_tsamples)
             test_samples(S(p), Categorical(p), n_tsamples, rng=rng)
+            @test ncategories(S(p)) == length(p)
         end
     end
 
+    @test string(AliasTable(Float16[1,2,3])) == "AliasTable with 3 entries"
 
     ## Binomial samplers
 

--- a/test/univariate/discrete/categorical.jl
+++ b/test/univariate/discrete/categorical.jl
@@ -124,4 +124,17 @@ end
     @test Categorical([0.5, 0.5]) ≈ Categorical([0.5f0, 0.5f0])
 end
 
+@testset "issue #832" begin
+    priorities = collect(1:1000) .* 1.
+    priorities[1:50] .= 1e8
+
+    at = Distributions.AliasTable(priorities)
+    iat = rand(at, 16)
+
+    # failure rate of a single sample is sum(51:1000)/50e8 = 9.9845e-5
+    # failure rate of 4 out of 16 samples is 1-cdf(Binomial(16, 9.9845e-5), 3) = 1.8074430840897548e-13
+    # this test should randomly fail with a probability of 1.8074430840897548e-13
+    @test count(==(1e8), priorities[iat]) >= 13
+end
+
 end

--- a/test/univariate/discrete/categorical.jl
+++ b/test/univariate/discrete/categorical.jl
@@ -125,7 +125,7 @@ end
 end
 
 @testset "issue #832" begin
-    priorities = collect(1:1000) .* 1.
+    priorities = collect(Float64, 1:1000)
     priorities[1:50] .= 1e8
 
     at = Distributions.AliasTable(priorities)

--- a/test/univariate/discrete/categorical.jl
+++ b/test/univariate/discrete/categorical.jl
@@ -93,9 +93,9 @@ end
 end
 
 @testset "reproducibility across julia versions" begin
-    d= Categorical([0.1, 0.2, 0.7])
+    d = Categorical([0.1, 0.2, 0.7])
     rng = StableRNGs.StableRNG(600)
-    @test rand(rng, d, 10) == [2, 1, 3, 3, 2, 3, 3, 3, 3, 3]
+    @test rand(rng, d, 10) == [3, 1, 1, 2, 3, 2, 3, 3, 2, 3]
 end
 
 @testset "comparisons" begin


### PR DESCRIPTION
[AliasTables.jl](https://aliastables.lilithhafner.com/dev/) provides a high performance, high precision alias table implementation. This PR switches from the use of StatsBase implementation details to the public API of the AliasTables package. After making that switch, I also re-tuned the sampling threshold for `Multinomial` so that it selects the right algorithm more appropriately.

Benchmarks using [Chairmarks.jl](https://chairmarks.lilithhafner.com) ("a => b" means I got the result "a" when running on master and the result "b" when running on PR branch):

Multinomial sampling (some multinomial changes backed out of this PR, see https://github.com/JuliaStats/Distributions.jl/pull/1848#discussion_r1562783233, #1834. The multinomial bnechamrks here are as of 1c3530ce040119d42a0ae057def22f9538f2acd8)

```julia
julia> using Chairmarks

julia> @b Distributions.Multinomial(100, normalize(rand(100))) rand(_, 100)
420.086 μs (6 allocs: 81.672 KiB) => 17.250 μs (4 allocs: 81.172 KiB)

julia> @b Distributions.Multinomial(100000, normalize(rand(100))) rand(_, 100)
577.754 μs (6 allocs: 81.672 KiB) => 549.170 μs (4 allocs: 81.172 KiB)

julia> @b Distributions.Multinomial(100, normalize(rand(1000))) rand(_, 100)
1.515 ms (6 allocs: 813.047 KiB) => 37.750 μs (4 allocs: 805.359 KiB)

julia> @b Distributions.Multinomial(1000, normalize(rand(1000))) rand(_, 1000)
43.298 ms (6 allocs: 7.660 MiB) => 2.326 ms (4 allocs: 7.653 MiB)
```

AliasTable sampling (same benchmarks as #1831)

```julia
julia> @b Distributions.AliasTable(normalize(rand(10))) rand
6.916 ns => 2.633 ns

julia> @b Distributions.AliasTable(normalize(rand(100))) rand
9.717 ns => 2.713 ns

julia> @b Distributions.AliasTable(normalize(rand(100_000))) rand
11.408 ns => 2.874 ns
```

AliasTable construction

```julia
julia> @b normalize(rand(100_000)) Distributions.AliasTable # Regression
1.218 ms (8 allocs: 3.052 MiB) => 1.949 ms (4 allocs: 2.763 MiB) 

julia> @b normalize(rand(100)) Distributions.AliasTable
936.609 ns (4 allocs: 3.500 KiB) => 901.031 ns (2 allocs: 3.000 KiB)

julia> @b normalize(rand(10)) Distributions.AliasTable # Regression
117.140 ns (4 allocs: 576 bytes) => 165.119 ns (2 allocs: 480 bytes)
```

However, these constructor time comparisons are not apples to apples. The old ones give the wrong answer without normalization (see #832) while the new ones do not require normalization (fixes #832).

The new version is slow largely because of unreasonably strict precision guarantees in the normalization code. I can add an option (which could be on by default for Distributions.jl) for faster and less precise construction. However, I haven not added this lower precision option because I doubt construction time is typically a limiting factor in AliasTable sampling speed (one would have to generate the weights at a rate of less than 20ns/weight for that to be an issue)

The new version is also faster (and more precise) for integer inputs (not including the old runtimes because the old algorithm produced incorrect answers)

```julia
julia> @b rand(1:1000, 10) Distributions.AliasTable
91.000 ns (2 allocs: 480 bytes)

julia> @b rand(1:1000, 100) Distributions.AliasTable
596.056 ns (2 allocs: 3.000 KiB)

julia> @b rand(1:1000, 100_000) Distributions.AliasTable
1.027 ms (4 allocs: 2.763 MiB)
```

The sampling assembly is now branch-less and shorter

Before
```
julia> @code_native debuginfo=:none rand(Random.default_rng(), at)
        .text
        .file   "rand"
        .globl  julia_rand_13388                // -- Begin function julia_rand_13388
        .p2align        2
        .type   julia_rand_13388,@function
julia_rand_13388:                       // @julia_rand_13388
; Function Signature: rand(Random.TaskLocalRNG, Distributions.AliasTable)
// %bb.0:                               // %top
        //DEBUG_VALUE: rand:s <- [DW_OP_deref] [$x0+0]
        //DEBUG_VALUE: rand:s <- [DW_OP_deref] [$x0+0]
        sub     sp, sp, #96
        stp     x29, x30, [sp, #48]             // 16-byte Folded Spill
        str     x21, [sp, #64]                  // 8-byte Folded Spill
        stp     x20, x19, [sp, #80]             // 16-byte Folded Spill
        add     x29, sp, #48
        str     xzr, [sp, #32]
        str     xzr, [sp, #24]
        str     xzr, [sp, #16]
        //APP
        mrs     x8, TPIDR_EL0
        //NO_APP
        ldr     x20, [x8, #16]
        mov     w8, #4
        str     x8, [sp, #16]
        ldr     x8, [x20]
        str     x8, [sp, #24]
        add     x8, sp, #16
        str     x8, [x20]
        ldr     x21, [x0, #8]
        ldr     x8, [x21, #16]
        cmp     x8, #0
        b.le    .LBB0_4
// %bb.1:                               // %L17
        mov     x19, x0
        //DEBUG_VALUE: rand:s <- [DW_OP_deref] [$x19+0]
        mov     w9, #1
        stp     x9, x8, [sp]
        mov     x0, sp
        bl      j_rand_13402
        ldp     x8, x9, [x20, #-56]
        ldp     x10, x11, [x20, #-40]
        add     x12, x11, x8
        ror     x12, x12, #41
        add     x12, x12, x8
        eor     x10, x10, x8
        eor     x11, x11, x9
        eor     x13, x10, x9
        eor     x8, x11, x8
        eor     x9, x10, x9, lsl #17
        ror     x10, x11, #19
        stp     x8, x13, [x20, #-56]
        stp     x9, x10, [x20, #-40]
        lsr     x8, x12, #11
        ucvtf   d0, x8
        mov     x8, #4368491638549381120
        fmov    d1, x8
        fmul    d0, d0, d1
        ldr     x8, [x19]
        ldr     x9, [x8]
        sub     x8, x0, #1
        ldr     d1, [x9, x8, lsl #3]
        fcmp    d0, d1
        b.mi    .LBB0_3
// %bb.2:                               // %L75
        ldr     x9, [x21]
        ldr     x0, [x9, x8, lsl #3]
.LBB0_3:                                // %L95
        ldr     x8, [sp, #24]
        str     x8, [x20]
        ldp     x20, x19, [sp, #80]             // 16-byte Folded Reload
        ldr     x21, [sp, #64]                  // 8-byte Folded Reload
        ldp     x29, x30, [sp, #48]             // 16-byte Folded Reload
        add     sp, sp, #96
        ret
.LBB0_4:                                // %L14
        adrp    x0, ".Ljl_global#13395.jit"
        add     x0, x0, :lo12:".Ljl_global#13395.jit"
        bl      j_ArgumentError_13394
        mov     x19, x0
        str     x0, [sp, #32]
        ldr     x0, [x20, #16]
        mov     x20, #36592
        movk    x20, #43617, lsl #16
        movk    x20, #65534, lsl #32
        mov     w1, #752
        mov     w2, #16
        mov     x3, #36592
        movk    x3, #43617, lsl #16
        movk    x3, #65534, lsl #32
        bl      ijl_gc_pool_alloc_instrumented
        stp     x20, x19, [x0, #-8]
        bl      ijl_throw
.Lfunc_end0:
        .size   julia_rand_13388, .Lfunc_end0-julia_rand_13388
                                        // -- End function
.set ".L+Core.ArgumentError#13397.jit", 281469245296368
        .size   ".L+Core.ArgumentError#13397.jit", 8
.set ".Ljl_global#13395.jit", 281469267606560
        .size   ".Ljl_global#13395.jit", 8
        .section        ".note.GNU-stack","",@progbits
```

After
```
julia> @code_native debuginfo=:none rand(Random.default_rng(), at)
        .text
        .file   "rand"
        .globl  julia_rand_8708                 // -- Begin function julia_rand_8708
        .p2align        2
        .type   julia_rand_8708,@function
julia_rand_8708:                        // @julia_rand_8708
; Function Signature: rand(Random.TaskLocalRNG, Distributions.AliasTable)
// %bb.0:                               // %top
        //DEBUG_VALUE: rand:s <- [DW_OP_deref] [$x0+0]
        //DEBUG_VALUE: rand:s <- [DW_OP_deref] [$x0+0]
        stp     x29, x30, [sp, #-16]!           // 16-byte Folded Spill
        mov     x29, sp
        //APP
        mrs     x8, TPIDR_EL0
        //NO_APP
        ldr     x8, [x8, #16]
        ldp     x9, x10, [x8, #-56]
        ldp     x11, x12, [x8, #-40]
        add     x13, x12, x9
        ror     x13, x13, #41
        eor     x11, x11, x9
        eor     x12, x12, x10
        eor     x14, x11, x10
        eor     x10, x11, x10, lsl #17
        ror     x11, x12, #19
        eor     x12, x12, x9
        stp     x12, x14, [x8, #-56]
        stp     x10, x11, [x8, #-40]
        ldp     x10, x8, [x0]
        ldp     x11, x8, [x8]
        clz     x12, x11
        add     x12, x12, #1
        add     x9, x13, x9
        and     x10, x10, x9
        lsr     x9, x9, x12
        cmp     x11, #1
        mov     w11, #1
        csinc   x9, x11, x9, ls
        add     x8, x8, x9, lsl #4
        ldp     x11, x8, [x8, #-16]
        cmp     x10, x11
        csel    x8, x8, xzr, lo
        add     x0, x8, x9
        ldp     x29, x30, [sp], #16             // 16-byte Folded Reload
        ret
.Lfunc_end0:
        .size   julia_rand_8708, .Lfunc_end0-julia_rand_8708
                                        // -- End function
        .section        ".note.GNU-stack","",@progbits
```

For how this speedup is possible, see https://aliastables.lilithhafner.com/dev/#Implementation-details.