### PR TITLE
Fix type bug in `Uniform`

### DIFF
--- a/src/univariate/continuous/uniform.jl
+++ b/src/univariate/continuous/uniform.jl
@@ -151,7 +151,7 @@ Base.:*(c::Real, d::Uniform) = Uniform(minmax(c * d.a, c * d.b)...)
 
 #### Sampling
 
-rand(rng::AbstractRNG, d::Uniform) = d.a + (d.b - d.a) * rand(rng)
+rand(rng::AbstractRNG, d::Uniform{T}) where {T} = d.a + (d.b - d.a) * rand(rng, T)
 
 _rand!(rng::AbstractRNG, d::Uniform, A::AbstractArray{<:Real}) =
     A .= Base.Fix1(quantile, d).(rand!(rng, A))


### PR DESCRIPTION
Fixed the bug where `rand(Uniform{T})` returned a `Float64` instead of `T`.