### PR TITLE
Fix failing tests on 1.11-beta

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,12 +2,12 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - master
   push:
     branches:
       - master
     tags: '*'
+  workflow_dispatch:
+  merge_group:
 
 concurrency:
   # Skip intermediate builds: always.

--- a/test/univariate/continuous/semicircle.jl
+++ b/test/univariate/continuous/semicircle.jl
@@ -1,5 +1,5 @@
 using Distributions
-using Random: MersenneTwister
+using StableRNGs
 using Test
 
 d = Semicircle(2.0)
@@ -39,8 +39,8 @@ d = Semicircle(2.0)
 @test quantile(d,  .5) ==   .0
 @test quantile(d, 1.0) == +2.0
 
-rng = MersenneTwister(0)
-for r in rand(rng, Uniform(0,10), 5)
+rng = StableRNG(123)
+@testset "r=$r" for r in rand(rng, Uniform(0,10), 5)
     N = 10^4
     semi = Semicircle(r)
     sample = rand(rng, semi, N)

--- a/test/univariate/continuous/semicircle.jl
+++ b/test/univariate/continuous/semicircle.jl
@@ -40,7 +40,7 @@ d = Semicircle(2.0)
 @test quantile(d, 1.0) == +2.0
 
 rng = StableRNG(123)
-@testset "r=$r" for r in rand(rng, Uniform(0,10), 5)
+@testset for r in rand(rng, Uniform(0,10), 5)
     N = 10^4
     semi = Semicircle(r)
     sample = rand(rng, semi, N)

--- a/test/univariate/locationscale.jl
+++ b/test/univariate/locationscale.jl
@@ -148,7 +148,7 @@ end
     rng = MersenneTwister(123)
 
     @testset "Normal" begin
-        @testset "_rng=$_rng, sign=$sign" for _rng in (missing, rng), sign in (1, -1)
+        @testset for _rng in (missing, rng), sign in (1, -1)
             test_location_scale_normal(_rng, 0.3, sign * 0.2, 0.1, 0.2)
             test_location_scale_normal(_rng, -0.3, sign * 0.1, -0.1, 0.3)
             test_location_scale_normal(_rng, 1.3, sign * 0.4, -0.1, 0.5)

--- a/test/univariate/locationscale.jl
+++ b/test/univariate/locationscale.jl
@@ -110,7 +110,7 @@ function test_location_scale(
             @test invlogccdf(dtest, log(0.5)) ≈ invlogccdf(dref, log(0.5))
             @test invlogccdf(dtest, log(0.8)) ≈ invlogccdf(dref, log(0.8))
 
-            r = Array{float(eltype(dtest))}(undef, 100000)
+            r = Array{float(eltype(dtest))}(undef, 200000)
             if ismissing(rng)
                 rand!(dtest, r)
             else
@@ -148,7 +148,7 @@ end
     rng = MersenneTwister(123)
 
     @testset "Normal" begin
-        for _rng in (missing, rng), sign in (1, -1)
+        @testset "_rng=$_rng, sign=$sign" for _rng in (missing, rng), sign in (1, -1)
             test_location_scale_normal(_rng, 0.3, sign * 0.2, 0.1, 0.2)
             test_location_scale_normal(_rng, -0.3, sign * 0.1, -0.1, 0.3)
             test_location_scale_normal(_rng, 1.3, sign * 0.4, -0.1, 0.5)
@@ -156,11 +156,11 @@ end
         test_location_scale_normal(rng, ForwardDiff.Dual(0.3), 0.2, 0.1, 0.2)
     end
     @testset "DiscreteNonParametric" begin
-        probs = normalize!(rand(10), 1)
-        for _rng in (missing, rng), sign in (1, -1)
-            test_location_scale_discretenonparametric(_rng, 1//3, sign * 1//2, 1:10, probs)
-            test_location_scale_discretenonparametric(_rng, -1//4, sign * 1//3, (-10):(-1), probs)
-            test_location_scale_discretenonparametric(_rng, 6//5, sign * 3//2, 15:24, probs)
+        _probs = normalize!(rand(10), 1)
+        @testset "_rng=$_rng, sign=$sign" for _rng in (missing, rng), sign in (1, -1)
+            test_location_scale_discretenonparametric(_rng, 1//3, sign * 1//2, 1:10, _probs)
+            test_location_scale_discretenonparametric(_rng, -1//4, sign * 1//3, (-10):(-1), _probs)
+            test_location_scale_discretenonparametric(_rng, 6//5, sign * 3//2, 15:24, _probs)
         end
     end
 

--- a/test/univariate/locationscale.jl
+++ b/test/univariate/locationscale.jl
@@ -157,7 +157,7 @@ end
     end
     @testset "DiscreteNonParametric" begin
         _probs = normalize!(rand(10), 1)
-        @testset "_rng=$_rng, sign=$sign" for _rng in (missing, rng), sign in (1, -1)
+        @testset for _rng in (missing, rng), sign in (1, -1)
             test_location_scale_discretenonparametric(_rng, 1//3, sign * 1//2, 1:10, _probs)
             test_location_scale_discretenonparametric(_rng, -1//4, sign * 1//3, (-10):(-1), _probs)
             test_location_scale_discretenonparametric(_rng, 6//5, sign * 3//2, 15:24, _probs)


### PR DESCRIPTION
We need a slightly larger sample size when testing DiscreteNonParametric to ensure that empirical moments are close enough to theoretical moments.

The semicircle tests were also vulnerable to changes to the drawn variates so I've switched from MersenneTwister to StableRNGs.