### PR TITLE
Update CI: No nightly tests, improve macOS CI setup + use julia-actions/cache

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }}${{ matrix.prerelease && ' (prerelease)' || '' }} - ${{ matrix.os }} - ${{ github.event_name }}
+    name: "Julia ${{ matrix.version }}${{ matrix.prerelease && ' (prerelease)' || '' }} - ${{ matrix.os }} - ${{ github.event_name }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,13 +46,19 @@ jobs:
         id: setup-julia
         with:
           version: ${{ matrix.version }}
+          arch: ${{ runner.arch == "ARM64" && 'aarch64' || runner.arch }}
           include-all-prereleases: ${{ matrix.prerelease }}
           show-versioninfo: true
       - name: Check if prerelease version is available
         continue-on-error: true
         if: ${{ matrix.prerelease }}
         run: |
-          [[ "$VERSION" =~ ^\d+\.\d+\.\d+$ ]] && exit 1
+          if [[ "$VERSION" =~ ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$ ]]
+            echo "no prerelease"
+            exit 1
+          else
+            exit 0
+          fi
         shell: bash
         env:
           VERSION: ${{ steps.setup-julia.outputs.julia-version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test:
-    name: "Julia ${{ matrix.version }}${{ matrix.prerelease && ' (prerelease)' || '' }} - ${{ matrix.os }} - ${{ github.event_name }}"
+    name: Julia ${{ matrix.version }}${{ matrix.prerelease && ' (prerelease)' || '' }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -29,11 +29,17 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        prerelease:
-          - false
+        prerelease: [false]
         include:
-          - version: '1'
-            prerelease: true
+          - prerelease: true
+            version: '1'
+            os: ubuntu-latest
+          - prerelease: true
+            version: '1'
+            os: macos-latest
+          - prerelease: true
+            version: '1'
+            os: windows-latest            
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,8 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: 'x64' # ARM64 on macos-latest is neither supported by older Julia versions nor setup-julia
+          # ARM64 on macos-latest is neither supported by older Julia versions nor setup-julia
+          arch: ${{ maxtrix.os == 'macos-latest' && matrix.version != '1.3' && 'aarch64' || 'x64' }}
           show-versioninfo: true
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           # ARM64 on macos-latest is neither supported by older Julia versions nor setup-julia
-          arch: ${{ maxtrix.os == 'macos-latest' && matrix.version != '1.3' && 'aarch64' || 'x64' }}
+          arch: ${{ matrix.os == 'macos-latest' && matrix.version != '1.3' && 'aarch64' || 'x64' }}
           show-versioninfo: true
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,42 +17,40 @@ concurrency:
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }}${{ matrix.prerelease && ' (prerelease)' || '' }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:
         version:
           - '1.3'
           - '1'
-          - 'nightly'
         os:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        arch:
-          - x64
+        prerelease:
+          - false
         include:
-          - os: macOS-14
-            arch: aarch64
-            version: '1'
+          - version: '1'
+            prerelease: true
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
+        id: setup-julia
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: actions/cache@v4
+          include-all-prereleases: ${{ matrix.prerelease }}
+          show-versioninfo: true
+      - name: Check if prerelease version is available
+        continue-on-error: true
+        if: ${{ matrix.prerelease }}
+        run: |
+          [[ "$VERSION" =~ ^\d+\.\d+\.\d+$ ]] && exit 1
+        shell: bash
         env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+          VERSION: ${{ steps.setup-julia.outputs.julia-version }}
+      - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - run: |
@@ -74,6 +72,7 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
+          show-versioninfo: true
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,7 +46,7 @@ jobs:
         id: setup-julia
         with:
           version: ${{ matrix.version }}
-          arch: ${{ runner.arch == 'ARM64' && 'aarch64' || runner.arch }}
+          arch: 'x64' # ARM64 on macos-latest is neither supported by older Julia versions nor setup-julia
           include-all-prereleases: ${{ matrix.prerelease }}
           show-versioninfo: true
       - name: Check if prerelease version is available
@@ -54,6 +54,7 @@ jobs:
         if: ${{ matrix.prerelease }}
         run: |
           if [[ "$VERSION" =~ ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$ ]]
+          then
             echo "no prerelease"
             exit 1
           else

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,12 +2,12 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - master
   push:
     branches:
       - master
     tags: '*'
+  workflow_dispatch:
+  merge_group:
 
 concurrency:
   # Skip intermediate builds: always.

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }}${{ matrix.prerelease && ' (prerelease)' || '' }} - ${{ matrix.os }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -29,40 +29,13 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        prerelease: [false]
-        include:
-          - prerelease: true
-            version: '1'
-            os: ubuntu-latest
-          - prerelease: true
-            version: '1'
-            os: macos-latest
-          - prerelease: true
-            version: '1'
-            os: windows-latest            
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
-        id: setup-julia
         with:
           version: ${{ matrix.version }}
           arch: 'x64' # ARM64 on macos-latest is neither supported by older Julia versions nor setup-julia
-          include-all-prereleases: ${{ matrix.prerelease }}
           show-versioninfo: true
-      - name: Check if prerelease version is available
-        continue-on-error: true
-        if: ${{ matrix.prerelease }}
-        run: |
-          if [[ "$VERSION" =~ ^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$ ]]
-          then
-            echo "no prerelease"
-            exit 1
-          else
-            exit 0
-          fi
-        shell: bash
-        env:
-          VERSION: ${{ steps.setup-julia.outputs.julia-version }}
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,7 +46,7 @@ jobs:
         id: setup-julia
         with:
           version: ${{ matrix.version }}
-          arch: ${{ runner.arch == "ARM64" && 'aarch64' || runner.arch }}
+          arch: ${{ runner.arch == 'ARM64' && 'aarch64' || runner.arch }}
           include-all-prereleases: ${{ matrix.prerelease }}
           show-versioninfo: true
       - name: Check if prerelease version is available

--- a/test/univariate/continuous/semicircle.jl
+++ b/test/univariate/continuous/semicircle.jl
@@ -1,5 +1,5 @@
 using Distributions
-using Random: MersenneTwister
+using StableRNGs
 using Test
 
 d = Semicircle(2.0)
@@ -39,8 +39,8 @@ d = Semicircle(2.0)
 @test quantile(d,  .5) ==   .0
 @test quantile(d, 1.0) == +2.0
 
-rng = MersenneTwister(0)
-for r in rand(rng, Uniform(0,10), 5)
+rng = StableRNG(123)
+@testset for r in rand(rng, Uniform(0,10), 5)
     N = 10^4
     semi = Semicircle(r)
     sample = rand(rng, semi, N)

--- a/test/univariate/locationscale.jl
+++ b/test/univariate/locationscale.jl
@@ -110,7 +110,7 @@ function test_location_scale(
             @test invlogccdf(dtest, log(0.5)) ≈ invlogccdf(dref, log(0.5))
             @test invlogccdf(dtest, log(0.8)) ≈ invlogccdf(dref, log(0.8))
 
-            r = Array{float(eltype(dtest))}(undef, 100000)
+            r = Array{float(eltype(dtest))}(undef, 200000)
             if ismissing(rng)
                 rand!(dtest, r)
             else
@@ -148,7 +148,7 @@ end
     rng = MersenneTwister(123)
 
     @testset "Normal" begin
-        for _rng in (missing, rng), sign in (1, -1)
+        @testset for _rng in (missing, rng), sign in (1, -1)
             test_location_scale_normal(_rng, 0.3, sign * 0.2, 0.1, 0.2)
             test_location_scale_normal(_rng, -0.3, sign * 0.1, -0.1, 0.3)
             test_location_scale_normal(_rng, 1.3, sign * 0.4, -0.1, 0.5)
@@ -156,11 +156,11 @@ end
         test_location_scale_normal(rng, ForwardDiff.Dual(0.3), 0.2, 0.1, 0.2)
     end
     @testset "DiscreteNonParametric" begin
-        probs = normalize!(rand(10), 1)
-        for _rng in (missing, rng), sign in (1, -1)
-            test_location_scale_discretenonparametric(_rng, 1//3, sign * 1//2, 1:10, probs)
-            test_location_scale_discretenonparametric(_rng, -1//4, sign * 1//3, (-10):(-1), probs)
-            test_location_scale_discretenonparametric(_rng, 6//5, sign * 3//2, 15:24, probs)
+        _probs = normalize!(rand(10), 1)
+        @testset for _rng in (missing, rng), sign in (1, -1)
+            test_location_scale_discretenonparametric(_rng, 1//3, sign * 1//2, 1:10, _probs)
+            test_location_scale_discretenonparametric(_rng, -1//4, sign * 1//3, (-10):(-1), _probs)
+            test_location_scale_discretenonparametric(_rng, 6//5, sign * 3//2, 15:24, _probs)
         end
     end
 


### PR DESCRIPTION
~~In this draft I see if one can achieve something like #1861 without running tests twice if no prerelease is available. Additionally,~~ This PR removes the nightly tests (see #1861), includes a fix for the mac CI setup (see #1856), and switches to julia-actions/cache for caching.

Edit: The PR also includes https://github.com/JuliaStats/Distributions.jl/pull/1862 which fixes tests on Julia 1.11-beta1 (see https://github.com/JuliaStats/Distributions.jl/pull/1862#issuecomment-2133916510).