### PR TITLE
Define fallback implementations for mean, var, and entropy

### DIFF
--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -163,14 +163,14 @@ rand(rng::AbstractRNG, d::UnivariateDistribution) = quantile(d, rand(rng))
 
 Compute the expectation.
 """
-mean(d::UnivariateDistribution)
+mean(d::UnivariateDistribution) = expectation(identity, d)
 
 """
     var(d::UnivariateDistribution)
 
 Compute the variance. (A generic std is provided as `std(d) = sqrt(var(d))`)
 """
-var(d::UnivariateDistribution)
+var(d::UnivariateDistribution) = (μ = mean(d); expectation(x -> (x - μ)^2, d))
 
 """
     std(d::UnivariateDistribution)
@@ -214,7 +214,7 @@ skewness(d::UnivariateDistribution)
 
 Compute the entropy value of distribution `d`.
 """
-entropy(d::UnivariateDistribution)
+entropy(d::UnivariateDistribution) = expectation(x -> -log(pdf(d, x)), d)
 
 """
     entropy(d::UnivariateDistribution, b::Real)


### PR DESCRIPTION
We have the internal `expectation` function that uses `quadgk` to compute integrals, as well as a fallback implementation for `kldivergence` that uses `expectation`, so it seems reasonable to similarly define fallbacks for other quantities trivially computable using `expectation`: `mean`, `var`, and `entropy`. We could probably do `skewness` and `kurtosis` as well.

To do:
- [ ] Determine the set of functions that should support `expectation`-based fallbacks
- [ ] Add tests
- [ ] Document that the fallbacks exist

(n.b. I skipped CI on the initial commit purposefully as I haven't given this a ton of thought yet and wanted to see whether anybody was strongly for or against it before doing meaningful work here)