### PR TITLE
Handle degenerate Beta distribution cases

### DIFF
--- a/src/univariate/continuous/beta.jl
+++ b/src/univariate/continuous/beta.jl
@@ -238,20 +238,18 @@ end
 
 # From Knuth
 function rand(rng::AbstractRNG, s::BetaSampler{T, S1, S2})::float(T) where {T, S1, S2}
+    iα = s.iα
+    iβ = s.iβ
     if s.γ
-        g1 = rand(rng, s.s1)
-        g2 = rand(rng, s.s2)
-        return g1 / (g1 + g2)
-    else
-        iα = s.iα
-        iβ = s.iβ
-        
         if iszero(iα)
             return iszero(iβ) ? 0.5 : 1.0
         elseif iszero(iβ)
             return 0
         end
-
+        g1 = rand(rng, s.s1)
+        g2 = rand(rng, s.s2)
+        return g1 / (g1 + g2)
+    else
         while true
             u = rand(rng) # the Uniform sampler just calls rand()
             v = rand(rng)

--- a/test/degenerate.jl
+++ b/test/degenerate.jl
@@ -1,9 +1,9 @@
 using Test, Distributions, StatsBase
 
 @testset "Degenerate Beta" begin
-    d1 = Beta(.5, Inf)
+    d1 = Beta(Inf, .5)
     d2 = Beta(Inf, Inf)
-    d3 = Beta(Inf, 14)
+    d3 = Beta(14, Inf)
 
     @test minimum(d1) == 1
     @test minimum(d2) == .5
@@ -14,7 +14,7 @@ using Test, Distributions, StatsBase
     @test maximum(d3) == 0
 
     @test mean(d1) == 1
-    @test mean(d2) == 5
+    @test mean(d2) == .5
     @test mean(d3) == 0
 
     # Currently hangs due to StatsFuns

--- a/test/degenerate.jl
+++ b/test/degenerate.jl
@@ -1,0 +1,64 @@
+using Test, Distributions, StatsBase
+
+@testset "Degenerate Beta" begin
+    d1 = Beta(.5, Inf)
+    d2 = Beta(Inf, Inf)
+    d3 = Beta(Inf, 14)
+
+    @test minimum(d1) == 1
+    @test minimum(d2) == .5
+    @test minimum(d3) == 0
+
+    @test maximum(d1) == 1
+    @test maximum(d2) == .5
+    @test maximum(d3) == 0
+
+    @test mean(d1) == 1
+    @test mean(d2) == 5
+    @test mean(d3) == 0
+
+    # Currently hangs due to StatsFuns
+    # @test median(d1) == 1
+    # @test median(d2) == .5
+    # @test median(d3) == 0
+
+    @test mode(d1) == 1
+    @test mode(d2) == .5
+    @test mode(d3) == 0
+
+    @test var(d1) == 0
+    @test var(d2) == 0
+    @test var(d3) == 0
+
+    @test std(d3) == 0
+
+    @test isnan(skewness(d1))
+    @test isnan(skewness(d2))
+    @test isnan(skewness(d3))
+
+    @test isnan(kurtosis(d1))
+    @test isnan(kurtosis(d2))
+    @test isnan(kurtosis(d3))
+
+    @test entropy(d1) == 0
+    @test entropy(d2) == 0
+    @test entropy(d3) == 0
+
+    @test meanlogx(d1) == 0
+    @test meanlogx(d2) == log(.5)
+    @test meanlogx(d3) == log(0)
+
+    @test varlogx(d1) == 0
+    @test varlogx(d2) == 0
+    @test varlogx(d3) == 0
+
+    @test stdlogx(d1) == 0
+
+    @test rand(d1) == 1
+    @test rand(d2) == .5
+    @test rand(d3) == 0
+
+    @test rand(sampler(d1)) == 1
+    @test rand(sampler(d2)) == .5
+    @test rand(sampler(d3)) == 0
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,6 +96,7 @@ const tests = [
     "eachvariate",
     "univariate/continuous/triangular",
     "statsapi",
+    "degenerate", # extra file compared to /src
 
     ### missing files compared to /src:
     # "common",


### PR DESCRIPTION
Combined with https://github.com/JuliaStats/StatsFuns.jl/pull/167 , this pull request will significantly improve handling of degenerate beta distributions.

These degenerate beta distributions are the following:
- Beta(Inf, b) is Dirac(1)
- Beta(a, Inf) is Dirac(0)
- Beta(Inf, Inf) is Dirac(0.5)

There are two other degenerate beta distributions that can occur when alpha or beta are 0, but Distributions.jl does not currently allow these to be constructed normally. I have not added checks for these cases. My priority on this pull request is to fix inaccurate behavior for things that are allegedly supported by Distributions.jl, not to add even more allegedly-supported edge cases.

This pull request is not directly dependent on https://github.com/JuliaStats/StatsFuns.jl/pull/167; all tests in this pull request should pass regardless of whether StatsFuns.jl is accepted. However, functions like `cdf`, `pdf`, `quantile` will continue to be inaccurate until then. `median` will continue to hang on `median(Beta(Inf, 1)` because it is dependent on `quantile`, but it will work (via generic fallback) fine once the changes to StatsFuns are made.

Between these two pull requests, degenerate Beta distribution cases will behave more or less identically to corresponding Dirac distributions, EXCEPT with one notable difference; `pdf(Dirac(1), 1) == 1` because it is a pmf (as we treat `Dirac` as discrete) while `pdf(Beta(Inf, 1), 1) == NaN` because it is, by definition, a value which integrates to 1 over a 0-length range.


## Exceptions
I don't work with KL divergence enough to properly comprehend implementing support for degenerate beta distributions. Someone else can figure this one out.

## Performance Regressions

Between this and https://github.com/JuliaStats/StatsFuns.jl/pull/167, I expect almost every single method involving the Beta distribution to experience performance regressions. I believe this is worth it, however, because the status quo often returns inaccurate results or causes hangs (e.g. `median(Beta(Inf, 1)`). 

I have tried to minimize the performance regressions, but we're going from things like `minimum(::Beta) = 0` (which gets compiled out to just a constant if the type is known) to multiple branches (as there are 3 distinct degenerate cases). These are necessary sacrifices for accurate behavior.

## Tests

I have placed new tests in a new file, `degenerate.jl`. There are many other degenerate distributions which are allegedly supported by Distributions.jl currently, but currently have many issues (e.g. `Bernoulli(0)`, `Bernoulli(1)`, `Binomial(n, 0)`, `Binomial(n, 1)`. I fully intend to add more tests to that file in the future.