### PR TITLE
Fix InverseGaussian cdf overflows

### DIFF
--- a/src/univariate/continuous/inversegaussian.jl
+++ b/src/univariate/continuous/inversegaussian.jl
@@ -102,7 +102,7 @@ function cdf(d::InverseGaussian, x::Real)
     # 2λ/μ and normlogcdf(-u*(v+1)) are similar magnitude, opp. sign
     # truncating to [0, 1] as an additional precaution
     # Ref https://github.com/JuliaStats/Distributions.jl/issues/1873
-    z = clamp(normcdf(u * (v - 1)) + exp(2λ / μ + normlogcdf(-u * (v + 1)), 0, 1))
+    z = clamp(normcdf(u * (v - 1)) + exp(2λ / μ + normlogcdf(-u * (v + 1))), 0, 1)
 
     # otherwise `NaN` is returned for `+Inf`
     return isinf(x) && x > 0 ? one(z) : z
@@ -116,7 +116,7 @@ function ccdf(d::InverseGaussian, x::Real)
     # 2λ/μ and normlogcdf(-u*(v+1)) are similar magnitude, opp. sign
     # truncating to [0, 1] as an additional precaution
     # Ref https://github.com/JuliaStats/Distributions.jl/issues/1873
-    z = clamp(normccdf(u * (v - 1)) - exp(2λ / μ + normlogcdf(-u * (v + 1)), 0, 1))
+    z = clamp(normccdf(u * (v - 1)) - exp(2λ / μ + normlogcdf(-u * (v + 1))), 0, 1)
 
     # otherwise `NaN` is returned for `+Inf`
     return isinf(x) && x > 0 ? zero(z) : z

--- a/src/univariate/continuous/inversegaussian.jl
+++ b/src/univariate/continuous/inversegaussian.jl
@@ -99,7 +99,9 @@ function cdf(d::InverseGaussian, x::Real)
     y = max(x, 0)
     u = sqrt(λ / y)
     v = y / μ
-    z = normcdf(u * (v - 1)) + exp(2λ / μ) * normcdf(-u * (v + 1))
+    # 2λ/μ and normlogcdf(-u*(v+1)) are similar magnitude, opp. sign
+    z = normcdf(u * (v - 1)) + exp(2λ / μ + normlogcdf(-u * (v + 1)))
+    z = clamp(z, 0, 1) # extra safety precaution
 
     # otherwise `NaN` is returned for `+Inf`
     return isinf(x) && x > 0 ? one(z) : z
@@ -110,7 +112,8 @@ function ccdf(d::InverseGaussian, x::Real)
     y = max(x, 0)
     u = sqrt(λ / y)
     v = y / μ
-    z = normccdf(u * (v - 1)) - exp(2λ / μ) * normcdf(-u * (v + 1))
+    z = normccdf(u * (v - 1)) - exp(2λ / μ + normlogcdf(-u * (v + 1)))
+    z = clamp(z, 0, 1)
 
     # otherwise `NaN` is returned for `+Inf`
     return isinf(x) && x > 0 ? zero(z) : z

--- a/src/univariate/continuous/inversegaussian.jl
+++ b/src/univariate/continuous/inversegaussian.jl
@@ -102,7 +102,7 @@ function cdf(d::InverseGaussian, x::Real)
     # 2λ/μ and normlogcdf(-u*(v+1)) are similar magnitude, opp. sign
     # truncating to [0, 1] as an additional precaution
     # Ref https://github.com/JuliaStats/Distributions.jl/issues/1873
-    z = clamp(normcdf(u * (v - 1)) + exp(2λ / μ + normlogcdf(-u * (v + 1)), 0, 1)
+    z = clamp(normcdf(u * (v - 1)) + exp(2λ / μ + normlogcdf(-u * (v + 1)), 0, 1))
 
     # otherwise `NaN` is returned for `+Inf`
     return isinf(x) && x > 0 ? one(z) : z
@@ -116,7 +116,7 @@ function ccdf(d::InverseGaussian, x::Real)
     # 2λ/μ and normlogcdf(-u*(v+1)) are similar magnitude, opp. sign
     # truncating to [0, 1] as an additional precaution
     # Ref https://github.com/JuliaStats/Distributions.jl/issues/1873
-    z = clamp(normccdf(u * (v - 1)) - exp(2λ / μ + normlogcdf(-u * (v + 1)), 0, 1)
+    z = clamp(normccdf(u * (v - 1)) - exp(2λ / μ + normlogcdf(-u * (v + 1)), 0, 1))
 
     # otherwise `NaN` is returned for `+Inf`
     return isinf(x) && x > 0 ? zero(z) : z

--- a/src/univariate/continuous/inversegaussian.jl
+++ b/src/univariate/continuous/inversegaussian.jl
@@ -113,8 +113,10 @@ function ccdf(d::InverseGaussian, x::Real)
     y = max(x, 0)
     u = sqrt(λ / y)
     v = y / μ
-    z = normccdf(u * (v - 1)) - exp(2λ / μ + normlogcdf(-u * (v + 1)))
-    z = clamp(z, 0, 1)
+    # 2λ/μ and normlogcdf(-u*(v+1)) are similar magnitude, opp. sign
+    # truncating to [0, 1] as an additional precaution
+    # Ref https://github.com/JuliaStats/Distributions.jl/issues/1873
+    z = clamp(normccdf(u * (v - 1)) - exp(2λ / μ + normlogcdf(-u * (v + 1)), 0, 1)
 
     # otherwise `NaN` is returned for `+Inf`
     return isinf(x) && x > 0 ? zero(z) : z

--- a/src/univariate/continuous/inversegaussian.jl
+++ b/src/univariate/continuous/inversegaussian.jl
@@ -100,8 +100,9 @@ function cdf(d::InverseGaussian, x::Real)
     u = sqrt(λ / y)
     v = y / μ
     # 2λ/μ and normlogcdf(-u*(v+1)) are similar magnitude, opp. sign
-    z = normcdf(u * (v - 1)) + exp(2λ / μ + normlogcdf(-u * (v + 1)))
-    z = clamp(z, 0, 1) # extra safety precaution
+    # truncating to [0, 1] as an additional precaution
+    # Ref https://github.com/JuliaStats/Distributions.jl/issues/1873
+    z = clamp(normcdf(u * (v - 1)) + exp(2λ / μ + normlogcdf(-u * (v + 1)), 0, 1)
 
     # otherwise `NaN` is returned for `+Inf`
     return isinf(x) && x > 0 ? one(z) : z

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,6 +96,7 @@ const tests = [
     "eachvariate",
     "univariate/continuous/triangular",
     "statsapi",
+    "univariate/continuous/inversegaussian",
 
     ### missing files compared to /src:
     # "common",
@@ -137,7 +138,6 @@ const tests = [
     # "univariate/continuous/generalizedextremevalue",
     # "univariate/continuous/generalizedpareto",
     # "univariate/continuous/inversegamma",
-    # "univariate/continuous/inversegaussian",
     # "univariate/continuous/ksdist",
     # "univariate/continuous/ksonesided",
     # "univariate/continuous/levy",

--- a/test/univariate/continuous.jl
+++ b/test/univariate/continuous.jl
@@ -99,6 +99,19 @@ end
     @test skewness(d) ≈ 3β/(α*sqrt(δ*g))
 end
 
+@testset "InverseGaussian cdf outside of [0, 1] (#1873)" begin
+    for d in [
+        InverseGaussian(1.65, 590),
+        InverseGaussian(0.5, 1000)
+    ]
+        for x in [0.02, 1.0, 20.0, 300.0]
+            p = cdf(d, x)
+            @test 0.0 <= p <= 1.0
+            @test p ≈ exp(logcdf(d, x))
+        end
+    end
+end
+
 @testset "edge cases" begin
     # issue #1371: cdf should not return -0.0
     @test cdf(Rayleigh(1), 0) === 0.0

--- a/test/univariate/continuous.jl
+++ b/test/univariate/continuous.jl
@@ -99,19 +99,6 @@ end
     @test skewness(d) ≈ 3β/(α*sqrt(δ*g))
 end
 
-@testset "InverseGaussian cdf outside of [0, 1] (#1873)" begin
-    for d in [
-        InverseGaussian(1.65, 590),
-        InverseGaussian(0.5, 1000)
-    ]
-        for x in [0.02, 1.0, 20.0, 300.0]
-            p = cdf(d, x)
-            @test 0.0 <= p <= 1.0
-            @test p ≈ exp(logcdf(d, x))
-        end
-    end
-end
-
 @testset "edge cases" begin
     # issue #1371: cdf should not return -0.0
     @test cdf(Rayleigh(1), 0) === 0.0

--- a/test/univariate/continuous/inversegaussian.jl
+++ b/test/univariate/continuous/inversegaussian.jl
@@ -1,0 +1,12 @@
+@testset "InverseGaussian cdf outside of [0, 1] (#1873)" begin
+    for d in [
+        InverseGaussian(1.65, 590),
+        InverseGaussian(0.5, 1000)
+    ]
+        for x in [0.02, 1.0, 20.0, 300.0]
+            p = cdf(d, x)
+            @test 0.0 <= p <= 1.0
+            @test p ≈ exp(logcdf(d, x))
+        end
+    end
+end

--- a/test/univariate/continuous/inversegaussian.jl
+++ b/test/univariate/continuous/inversegaussian.jl
@@ -7,6 +7,12 @@
             p = cdf(d, x)
             @test 0.0 <= p <= 1.0
             @test p ≈ exp(logcdf(d, x))
+
+            q = ccdf(d, x)
+            @test 0.0 <= q <= 1.0
+            @test q ≈ exp(logccdf(d, x))
+
+            @test (p + q) ≈ 1
         end
     end
 end


### PR DESCRIPTION
Closes #1873

Originally I intended to just add `clamp(z, 0, 1)`, but when I found the source of the overflow, I realized there was room for something better.

The original example in the issue, currently:
```julia
julia> d = InverseGaussian(1.65,590)
InverseGaussian{Float64}(μ=1.65, λ=590.0)

julia> cdf(d, 2.)
Inf

julia> exp(logcdf(d, 2.))
0.9998791763271095
```

With this pull request:
```julia
julia> d = InverseGaussian(1.65,590)
InverseGaussian{Float64}(μ=1.65, λ=590.0)

julia> cdf(d, 2.)
0.9998791763271095

julia> exp(logcdf(d, 2.))
0.9998791763271095
```

There is also a backup clamp just in case someone manages to go even further and break the primary fix.