### PR TITLE
Test pre-release Julia versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,7 @@ jobs:
         version:
           - '1.3'
           - '1'
+          - pre
         os:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
A possible alternative to https://github.com/JuliaStats/Distributions.jl/pull/1861 which in its current state seems to test only pre-release versions but not the latest stable release anymore.