### PR TITLE
Relax Fill return type in mvlognormal tests

### DIFF
--- a/test/multivariate/mvlognormal.jl
+++ b/test/multivariate/mvlognormal.jl
@@ -19,7 +19,7 @@ function test_mvlognormal(g::MvLogNormal, n_tsamples::Int=10^6,
     @test partype(g) == Float64
     @test isa(mn, Vector{Float64})
     if g.normal.μ isa Zeros{Float64,1}
-        @test md isa Fill{Float64,1}
+        @test md isa Union{Fill{Float64,1}, Ones{Float64,1}}
     else
         @test md isa Vector{Float64}
     end

--- a/test/multivariate/mvlognormal.jl
+++ b/test/multivariate/mvlognormal.jl
@@ -19,7 +19,7 @@ function test_mvlognormal(g::MvLogNormal, n_tsamples::Int=10^6,
     @test partype(g) == Float64
     @test isa(mn, Vector{Float64})
     if g.normal.μ isa Zeros{Float64,1}
-        @test md isa Union{Fill{Float64,1}, Ones{Float64,1}}
+        @test md isa FillArrays.AbstractFill{Float64,1}
     else
         @test md isa Vector{Float64}
     end


### PR DESCRIPTION
In https://github.com/JuliaArrays/FillArrays.jl/pull/385 I'm working on improving how broadcasting works for FillArrays. One of the changes is that some types may be inferred differently, so e.g.
Currently
```julia
julia> exp.(Zeros(2))
2-element Fill{Float64}, with entries equal to 1.0
```
Proposed:
```julia
julia> exp.(Zeros(2))
2-element Ones{Float64}
```
Currently, in one of the `mvlognormal` tests, this package is explicitly checking for a `Fill`. This PR relaxes this to a `Union{Fill, Ones}` so that the tests pass either way.