### PR TITLE
axes(::ReshapedDistribution) should throw, added missing ndims

### DIFF
--- a/src/reshaped.jl
+++ b/src/reshaped.jl
@@ -25,7 +25,7 @@ end
 
 Base.size(d::ReshapedDistribution) = d.dims
 Base.eltype(::Type{ReshapedDistribution{<:Any,<:ValueSupport,D}}) where {D} = eltype(D)
-Base.axes(d::ReshapedDistribution, k::Integer) = Base.oneto(d.dims[k])
+Base.axes(d::ReshapedDistribution, k::Integer) = Base.OneTo(d.dims[k])
 Base.ndims(d::ReshapedDistribution{N}) where {N} = N
 
 partype(d::ReshapedDistribution) = partype(d.dist)

--- a/src/reshaped.jl
+++ b/src/reshaped.jl
@@ -25,7 +25,6 @@ end
 
 Base.size(d::ReshapedDistribution) = d.dims
 Base.eltype(::Type{ReshapedDistribution{<:Any,<:ValueSupport,D}}) where {D} = eltype(D)
-Base.axes(d::ReshapedDistribution) = throw(MethodError(axes, (d,))) # avoid generic fallback: not indexable
 Base.ndims(d::ReshapedDistribution{N}) where {N} = N
 
 partype(d::ReshapedDistribution) = partype(d.dist)

--- a/src/reshaped.jl
+++ b/src/reshaped.jl
@@ -25,7 +25,7 @@ end
 
 Base.size(d::ReshapedDistribution) = d.dims
 Base.eltype(::Type{ReshapedDistribution{<:Any,<:ValueSupport,D}}) where {D} = eltype(D)
-Base.axes(d::ReshapedDistribution, k::Integer) = Base.OneTo(d.dims[k])
+Base.axes(d::ReshapedDistribution) = throw(MethodError(axes, (d,))) # avoid generic fallback: not indexable
 Base.ndims(d::ReshapedDistribution{N}) where {N} = N
 
 partype(d::ReshapedDistribution) = partype(d.dist)

--- a/src/reshaped.jl
+++ b/src/reshaped.jl
@@ -26,6 +26,7 @@ end
 Base.size(d::ReshapedDistribution) = d.dims
 Base.eltype(::Type{ReshapedDistribution{<:Any,<:ValueSupport,D}}) where {D} = eltype(D)
 Base.axes(d::ReshapedDistribution, k::Integer) = Base.oneto(d.dims[k])
+Base.ndims(d::ReshapedDistribution{N}) where {N} = N
 
 partype(d::ReshapedDistribution) = partype(d.dist)
 params(d::ReshapedDistribution) = (d.dist, d.dims)

--- a/src/reshaped.jl
+++ b/src/reshaped.jl
@@ -25,6 +25,7 @@ end
 
 Base.size(d::ReshapedDistribution) = d.dims
 Base.eltype(::Type{ReshapedDistribution{<:Any,<:ValueSupport,D}}) where {D} = eltype(D)
+Base.axes(d::ReshapedDistribution, k::Integer) = Base.oneto(d.dims[k])
 
 partype(d::ReshapedDistribution) = partype(d.dist)
 params(d::ReshapedDistribution) = (d.dist, d.dims)

--- a/test/matrixreshaped.jl
+++ b/test/matrixreshaped.jl
@@ -30,6 +30,11 @@ function test_matrixreshaped(rng, d1, sizes)
             @test length(d) == length(d1)
         end
     end
+    @testset "MatrixReshaped axes" begin
+        for (d,s) in zip(d1s,sizes), k in 1:ndims(d)
+            @test axes(d)[k] == axes(d,k) == Base.oneto(s[k])
+        end
+    end
     @testset "MatrixReshaped rank" begin
         for (d, s) in zip(d1s, sizes)
             @test rank(d) == minimum(s)

--- a/test/matrixreshaped.jl
+++ b/test/matrixreshaped.jl
@@ -24,6 +24,7 @@ function test_matrixreshaped(rng, d1, sizes)
         for (d, s) in zip(d1s[1:end-1], sizes[1:end-1])
             @test size(d) == s
         end
+        @test size(d1s[end]) == (sizes[end], sizes[end])
     end
     @testset "MatrixReshaped length" begin
         for d in d1s

--- a/test/matrixreshaped.jl
+++ b/test/matrixreshaped.jl
@@ -30,9 +30,16 @@ function test_matrixreshaped(rng, d1, sizes)
             @test length(d) == length(d1)
         end
     end
+    @testset "MatrixReshaped ndims" begin
+        for d in d1s
+            @test ndims(d) == 2
+        end
+    end
     @testset "MatrixReshaped axes" begin
-        for (d,s) in zip(d1s,sizes), k in 1:ndims(d)
-            @test axes(d)[k] == axes(d,k) == 1:s[min(k, length(s))]
+        for d in d1s
+            # should be unimplemented:
+            @test_throws MethodError axes(d)
+            @test_throws MethodError axes(d, 1)
         end
     end
     @testset "MatrixReshaped rank" begin

--- a/test/matrixreshaped.jl
+++ b/test/matrixreshaped.jl
@@ -24,7 +24,7 @@ function test_matrixreshaped(rng, d1, sizes)
         for (d, s) in zip(d1s[1:end-1], sizes[1:end-1])
             @test size(d) == s
         end
-        @test size(d1s[end]) == (sizes[end], sizes[end])
+        @test size(d1s[end]) == (sizes[end][1], sizes[end][1])
     end
     @testset "MatrixReshaped length" begin
         for d in d1s
@@ -34,13 +34,6 @@ function test_matrixreshaped(rng, d1, sizes)
     @testset "MatrixReshaped ndims" begin
         for d in d1s
             @test ndims(d) == 2
-        end
-    end
-    @testset "MatrixReshaped axes" begin
-        for d in d1s
-            # should be unimplemented:
-            @test_throws MethodError axes(d)
-            @test_throws MethodError axes(d, 1)
         end
     end
     @testset "MatrixReshaped rank" begin

--- a/test/matrixreshaped.jl
+++ b/test/matrixreshaped.jl
@@ -32,7 +32,7 @@ function test_matrixreshaped(rng, d1, sizes)
     end
     @testset "MatrixReshaped axes" begin
         for (d,s) in zip(d1s,sizes), k in 1:ndims(d)
-            @test axes(d)[k] == axes(d,k) == 1:s[k]
+            @test axes(d)[k] == axes(d,k) == 1:s[min(k, length(s))]
         end
     end
     @testset "MatrixReshaped rank" begin

--- a/test/matrixreshaped.jl
+++ b/test/matrixreshaped.jl
@@ -32,7 +32,7 @@ function test_matrixreshaped(rng, d1, sizes)
     end
     @testset "MatrixReshaped axes" begin
         for (d,s) in zip(d1s,sizes), k in 1:ndims(d)
-            @test axes(d)[k] == axes(d,k) == Base.oneto(s[k])
+            @test axes(d)[k] == axes(d,k) == Base.OneTo(s[k])
         end
     end
     @testset "MatrixReshaped rank" begin

--- a/test/matrixreshaped.jl
+++ b/test/matrixreshaped.jl
@@ -32,7 +32,7 @@ function test_matrixreshaped(rng, d1, sizes)
     end
     @testset "MatrixReshaped axes" begin
         for (d,s) in zip(d1s,sizes), k in 1:ndims(d)
-            @test axes(d)[k] == axes(d,k) == Base.OneTo(s[k])
+            @test axes(d)[k] == axes(d,k) == 1:s[k]
         end
     end
     @testset "MatrixReshaped rank" begin


### PR DESCRIPTION
As noted [on discourse](https://discourse.julialang.org/t/axes-not-working-on-reshaped-array/118820/2?u=stevengj), this method was missing.  Also added `ndims`.

*Update:* from the discussion below, since `d::ReshapedDistribution` is not indexable, it seems that the actual problem is that `axes(d)` is defined at all thanks to the generic fallback in `Base`.  So, this PR is updated to throw a `MethodError`.

*Update:* @devmotion preferred not to have `axes(d)` throw an error, so I removed it.