### PR TITLE
mark the MatrixReshaped type as deprecated

### DIFF
--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -54,7 +54,7 @@ end
 
 # Deprecate `MatrixReshaped`
 const MatrixReshaped{S<:ValueSupport,D<:MultivariateDistribution{S}} = ReshapedDistribution{2,S,D}
-Base.deprecate(Distributions, :MatrixReshaped)
+Base.deprecate(@__MODULE__, :MatrixReshaped)
 @deprecate MatrixReshaped(
     d::MultivariateDistribution, n::Integer, p::Integer=n
 ) reshape(d, (n, p))

--- a/src/deprecates.jl
+++ b/src/deprecates.jl
@@ -54,6 +54,7 @@ end
 
 # Deprecate `MatrixReshaped`
 const MatrixReshaped{S<:ValueSupport,D<:MultivariateDistribution{S}} = ReshapedDistribution{2,S,D}
+Base.deprecate(Distributions, :MatrixReshaped)
 @deprecate MatrixReshaped(
     d::MultivariateDistribution, n::Integer, p::Integer=n
 ) reshape(d, (n, p))


### PR DESCRIPTION
This PR marks the `MatrixReshaped` type itself as deprecated, not just its constructor.  That should prevent it from being displayed as the type name in Julia.  (See [this discourse post](https://discourse.julialang.org/t/axes-not-working-on-reshaped-array/118820/2?u=stevengj).)

For example:
```jl
julia> struct Bar{T}; x::T; end

julia> const Foo = Bar{Int}
Foo (alias for Bar{Int64})

julia> Foo(3) # displays alias Foo instead of Bar{Int}
Foo(3)

julia> Base.deprecate(Main, :Foo)

julia> Foo(3) # no longer displays the deprecated Foo type alias
Bar{Int64}(3)
```