### PR TITLE
Bump minimal supported julia version to 1.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
+          - '1.6'
           - '1'
           - pre
         os:
@@ -36,7 +36,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           # ARM64 on macos-latest is neither supported by older Julia versions nor setup-julia
-          arch: ${{ matrix.os == 'macos-latest' && matrix.version != '1.3' && 'aarch64' || 'x64' }}
+          arch: ${{ matrix.os == 'macos-latest' && matrix.version >= '1.8' && 'aarch64' || 'x64' }}
           show-versioninfo: true
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1

--- a/Project.toml
+++ b/Project.toml
@@ -57,7 +57,7 @@ StatsAPI = "1.6"
 StatsBase = "0.32, 0.33, 0.34"
 StatsFuns = "0.9.15, 1"
 Test = "<0.0.1, 1"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -15,7 +15,7 @@ import Aqua
     )
     # Tests are not reliable on older Julia versions and
     # show ambiguities in loaded packages
-    if VERSION >= v"1.6"
+    if VERSION >= v"1.7"
         Aqua.test_ambiguities(Distributions)
     end
 end


### PR DESCRIPTION
In https://github.com/JuliaStats/Distributions.jl/pull/1900, dependency on Roots.jl is being added, which only supports julia 1.6+

This seems to result in new failures, so i'm doing this as a separate step.