### PR TITLE
Special case Geometric(OneHalf())

### DIFF
--- a/src/univariate/discrete/geometric.jl
+++ b/src/univariate/discrete/geometric.jl
@@ -136,9 +136,9 @@ cf(d::Geometric, t::Real) = laplace_transform(d, -t*im)
 
 ### Sampling
 
-# Inlining is required to hoist the d.p == 0.5 check when generating in bulk
+# Inlining is required to hoist the d.p == 1//2 check when generating in bulk
 @inline function rand(rng::AbstractRNG, d::Geometric)
-    if d.p == 0.5
+    if d.p == 1//2
         leading_zeros(rand(rng, UInt)) # This branch is a performance optimization
     else
         floor(Int,-randexp(rng) / log1p(-d.p))

--- a/src/univariate/discrete/geometric.jl
+++ b/src/univariate/discrete/geometric.jl
@@ -34,7 +34,9 @@ function Geometric(p::Real; check_args::Bool=true)
     return Geometric{typeof(p)}(p)
 end
 
-Geometric() = Geometric{Float64}(0.5)
+struct OneHalf <: Real end
+Geometric() = Geometric{OneHalf}(OneHalf())
+Base.getproperty(d::Geometric{OneHalf}, s::Symbol) = s == :p ? 0.5 : getfield(d, s)
 
 @distr_support Geometric 0 Inf
 
@@ -137,6 +139,7 @@ cf(d::Geometric, t::Real) = laplace_transform(d, -t*im)
 ### Sampling
 
 rand(rng::AbstractRNG, d::Geometric) = floor(Int,-randexp(rng) / log1p(-d.p))
+rand(rng::AbstractRNG, ::Geometric{OneHalf}) = leading_zeros(rand(rng, UInt))
 
 ### Model Fitting
 


### PR DESCRIPTION
Before
```julia-repl
julia> @b Geometric() mean
2.097 ns

julia> @b Geometric() rand
10.762 ns

julia> @b Geometric() var
2.102 ns

julia> @b Geometric() entropy
8.543 ns

julia> @b Geometric() rand(_, 1000)
9.264 μs (3 allocs: 7.875 KiB)
```
1331649
```julia-repl
julia> @b Geometric() mean
1.199 ns

julia> @b Geometric() rand
2.409 ns

julia> @b Geometric() var
1.195 ns

julia> @b Geometric() entropy
1.197 ns

julia> @b Geometric() rand(_, 1000)
1.118 μs (3 allocs: 7.875 KiB)
```
After
```julia-repl
julia> @b Geometric() mean
1.990 ns

julia> @b Geometric() rand
3.516 ns

julia> @b Geometric() var
2.047 ns

julia> @b Geometric() entropy
8.339 ns

julia> @b Geometric() rand(_, 1000)
1.193 μs (3 allocs: 7.875 KiB)
```
In the PR, `rand` uses a substantially different (and simpler) algorithm proposed in #1933 for the p=0.5 case. ~`mean`, `var`, and `entropy` constant propagate. This latter impact is more of a convenient result than an intended design as those methods should never be bottlenecks for `Geometric()`~