### PR TITLE
Fix `mode` of `LKJCholesky`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.116"
+version = "0.25.117"
 
 [deps]
 AliasTables = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"

--- a/src/cholesky/lkjcholesky.jl
+++ b/src/cholesky/lkjcholesky.jl
@@ -109,9 +109,18 @@ function insupport(d::LKJCholesky, R::LinearAlgebra.Cholesky)
     return true
 end
 
-function StatsBase.mode(d::LKJCholesky)
+function StatsBase.mean(d::LKJCholesky)
     factors = Matrix{eltype(d)}(LinearAlgebra.I, size(d))
     return LinearAlgebra.Cholesky(factors, d.uplo, 0)
+end
+
+function mode(d::LKJCholesky; check_args::Bool=true)
+    @check_args(
+        LKJCholesky,
+        @setup(η = d.η),
+        (η, η > 1, "mode is defined only when η > 1."),
+    )
+    return mean(d)
 end
 
 StatsBase.params(d::LKJCholesky) = (d.d, d.η, d.uplo)

--- a/src/cholesky/lkjcholesky.jl
+++ b/src/cholesky/lkjcholesky.jl
@@ -109,18 +109,14 @@ function insupport(d::LKJCholesky, R::LinearAlgebra.Cholesky)
     return true
 end
 
-function StatsBase.mean(d::LKJCholesky)
-    factors = Matrix{eltype(d)}(LinearAlgebra.I, size(d))
-    return LinearAlgebra.Cholesky(factors, d.uplo, 0)
-end
-
 function mode(d::LKJCholesky; check_args::Bool=true)
     @check_args(
         LKJCholesky,
         @setup(η = d.η),
         (η, η > 1, "mode is defined only when η > 1."),
     )
-    return mean(d)
+    factors = Matrix{eltype(d)}(LinearAlgebra.I, size(d))
+    return LinearAlgebra.Cholesky(factors, d.uplo, 0)
 end
 
 StatsBase.params(d::LKJCholesky) = (d.d, d.η, d.uplo)

--- a/test/cholesky/lkjcholesky.jl
+++ b/test/cholesky/lkjcholesky.jl
@@ -124,7 +124,7 @@ using FiniteDifferences
     end
 
     @testset "properties" begin
-        @testset for p in (4, 5), η in (0.5, 2, 3.5), uplo in ('L', 'U')
+        @testset for p in (4, 5), η in (0.5, 1, 2, 3.5), uplo in ('L', 'U')
             d = LKJCholesky(p, η, uplo)
             @test d.d == p
             @test size(d) == (p, p)

--- a/test/cholesky/lkjcholesky.jl
+++ b/test/cholesky/lkjcholesky.jl
@@ -141,10 +141,6 @@ using FiniteDifferences
             m = mode(d; check_args = false)
             @test m isa Cholesky{eltype(d)}
             @test Matrix(m) ≈ I
-
-            m = mean(d)
-            @test m isa Cholesky{eltype(d)}
-            @test Matrix(m) ≈ I
         end
         for (d, η) in ((2, 4), (2, 1), (3, 1)), T in (Float32, Float64)
             @test @inferred(partype(LKJCholesky(d, T(η)))) === T

--- a/test/cholesky/lkjcholesky.jl
+++ b/test/cholesky/lkjcholesky.jl
@@ -124,14 +124,25 @@ using FiniteDifferences
     end
 
     @testset "properties" begin
-        @testset for p in (4, 5), η in (2, 3.5), uplo in ('L', 'U')
+        @testset for p in (4, 5), η in (0.5, 2, 3.5), uplo in ('L', 'U')
             d = LKJCholesky(p, η, uplo)
             @test d.d == p
             @test size(d) == (p, p)
             @test Distributions.params(d) == (d.d, d.η, d.uplo)
             @test partype(d) <: Float64
 
-            m = mode(d)
+            if η > 1
+                m = mode(d)
+                @test m isa Cholesky{eltype(d)}
+                @test Matrix(m) ≈ I
+            else
+                @test_throws DomainError(η, "LKJCholesky: mode is defined only when η > 1.") mode(d)
+            end
+            m = mode(d; check_args = false)
+            @test m isa Cholesky{eltype(d)}
+            @test Matrix(m) ≈ I
+
+            m = mean(d)
             @test m isa Cholesky{eltype(d)}
             @test Matrix(m) ≈ I
         end


### PR DESCRIPTION
For LKJ the mode is only defined (and then identical to the identity matrix) if η > 1: If 0 < η < 1, the identity matrix is a trough of the density, and if η = 1 then it's a uniform distribution of correlation matrices (see e.g. https://mc-stan.org/docs/functions-reference/correlation_matrix_distributions.html#probability-density-function). Therefore for `LKJ` `mode` is defined only if `η > 1`:

```julia
julia> mode(LKJ(1, 0.5))
ERROR: DomainError with 0.5:
LKJ: mode is defined only when η > 1.
Stacktrace:
 [1] #545
   @ ~/.julia/packages/Distributions/cWeit/src/matrix/lkj.jl:79 [inlined]
 [2] check_args
   @ ~/.julia/packages/Distributions/cWeit/src/utils.jl:89 [inlined]
 [3] #mode#544
   @ ~/.julia/packages/Distributions/cWeit/src/matrix/lkj.jl:79 [inlined]
 [4] mode(d::LKJ{Float64, Int64})
   @ Distributions ~/.julia/packages/Distributions/cWeit/src/matrix/lkj.jl:78
 [5] top-level scope
   @ REPL[48]:1

julia> mode(LKJ(1, 1.5))
1×1 Matrix{Float64}:
 1.0
```

For `LKJCholesky`, however, on the master branch `mode` always returns the identity matrix, irrespective of the parameters:

```julia
julia> mode(LKJCholesky(1, 0.5))
LinearAlgebra.Cholesky{Float64, Matrix{Float64}}
L factor:
1×1 LinearAlgebra.LowerTriangular{Float64, Matrix{Float64}}:
 1.0

julia> mode(LKJCholesky(1, 1.5))
LinearAlgebra.Cholesky{Float64, Matrix{Float64}}
L factor:
1×1 LinearAlgebra.LowerTriangular{Float64, Matrix{Float64}}:
 1.0
```

This PR fixes the problem, ~~and defines `mean` for `LKJCholesky` which is currently missing and should always return the identity matrix:~~

```julia
julia> mean(LKJ(1, 0.5))
1×1 Matrix{Float64}:
 1.0

julia> mean(LKJ(1, 1.5))
1×1 Matrix{Float64}:
 1.0

julia> mean(LKJCholesky(1, 0.5))
ERROR: MethodError: no method matching iterate(::LKJCholesky{Float64})
[...]

julia> mean(LKJCholesky(1, 1.5))
ERROR: MethodError: no method matching iterate(::LKJCholesky{Float64})
[...]
```