### PR TITLE
Require Julia >= 1.10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
+          - 'min'
           - '1'
           - pre
         os:
@@ -35,8 +35,6 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          # ARM64 on macos-latest is neither supported by older Julia versions nor setup-julia
-          arch: ${{ matrix.os == 'macos-latest' && matrix.version != '1.3' && 'aarch64' || 'x64' }}
           show-versioninfo: true
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1

--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ DistributionsTestExt = "Test"
 
 [compat]
 AliasTables = "1"
-Aqua = "0.8"
+Aqua = "0.8.9"
 Calculus = "0.5"
 ChainRulesCore = "1"
 ChainRulesTestUtils = "1"
@@ -57,7 +57,7 @@ StatsAPI = "1.6"
 StatsBase = "0.32, 0.33, 0.34"
 StatsFuns = "0.9.15, 1"
 Test = "<0.0.1, 1"
-julia = "1.3"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/Distributions.jl
+++ b/src/Distributions.jl
@@ -322,13 +322,6 @@ include("statsapi.jl")
 # Testing utilities for other packages which implement distributions.
 include("test_utils.jl")
 
-# Extensions: Implementation of DensityInterface and ChainRulesCore API
-if !isdefined(Base, :get_extension)
-    include("../ext/DistributionsChainRulesCoreExt/DistributionsChainRulesCoreExt.jl")
-    include("../ext/DistributionsDensityInterfaceExt.jl")
-    include("../ext/DistributionsTestExt.jl")
-end
-
 include("deprecates.jl")
 
 """

--- a/src/univariate/continuous/triangular.jl
+++ b/src/univariate/continuous/triangular.jl
@@ -125,17 +125,6 @@ function quantile(d::TriangularDist, p::Real)
               b - sqrt(b_m_a * (b - c) * (1 - p))
 end
 
-_expm1(x::Number) = expm1(x)
-if VERSION < v"1.7.0-DEV.1172"
-    # expm1(::Float16) is not defined in older Julia versions
-    _expm1(x::Float16) = Float16(expm1(Float32(x)))
-    function _expm1(x::Complex{Float16})
-        xr, xi = reim(x)
-        yr, yi = reim(expm1(complex(Float32(xr), Float32(xi))))
-        return complex(Float16(yr), Float16(yi))
-    end
-end
-
 """
     _phi2(x::Real)
 
@@ -146,7 +135,7 @@ Compute
 with the correct limit at ``x = 0``.
 """
 function _phi2(x::Real)
-    res = 2 * (_expm1(x) - x) / x^2
+    res = 2 * (expm1(x) - x) / x^2
     return iszero(x) ? one(res) : res
 end
 function mgf(d::TriangularDist, t::Real)
@@ -181,7 +170,7 @@ with the correct limit at ``x = 0``.
 """
 function _cisphi2(x::Real)
     z = x * im
-    res = -2 * (_expm1(z) - z) / x^2
+    res = -2 * (expm1(z) - z) / x^2
     return iszero(x) ? one(res) : res
 end
 function cf(d::TriangularDist, t::Real)

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -4,18 +4,5 @@ using Test
 import Aqua
 
 @testset "Aqua" begin
-    # Test ambiguities separately without Base and Core
-    # Ref: https://github.com/JuliaTesting/Aqua.jl/issues/77
-    Aqua.test_all(
-        Distributions;
-        ambiguities = false,
-        # On older Julia versions, installed dependencies are quite old
-        # Thus unbound type parameters show up that are fixed in newer versions
-        unbound_args = VERSION >= v"1.6",
-    )
-    # Tests are not reliable on older Julia versions and
-    # show ambiguities in loaded packages
-    if VERSION >= v"1.6"
-        Aqua.test_ambiguities(Distributions)
-    end
+    Aqua.test_all(Distributions)
 end

--- a/test/matrixreshaped.jl
+++ b/test/matrixreshaped.jl
@@ -3,17 +3,6 @@ using Distributions, Test, Random, LinearAlgebra
 
 rng = MersenneTwister(123456)
 
-if VERSION >= v"1.6.0-DEV.254"
-    _redirect_stderr(f, ::Base.DevNull) = redirect_stderr(f, devnull)
-else
-    function _redirect_stderr(f, ::Base.DevNull)
-        nulldev = @static Sys.iswindows() ? "NUL" : "/dev/null"
-        open(nulldev, "w") do io
-            redirect_stderr(f, io)
-        end
-    end
-end
-
 function test_matrixreshaped(rng, d1, sizes)
     @testset "MatrixReshaped $(nameof(typeof(d1))) tests" begin
         x1 = rand(rng, d1)
@@ -117,7 +106,7 @@ end
         μ = rand(rng, 16)
         d1 = MvNormal(μ, σ * σ')
         sizes = [(4, 4), (8, 2), (2, 8), (1, 16), (16, 1), (4,)]
-        _redirect_stderr(devnull) do
+        redirect_stderr(devnull) do
             test_matrixreshaped(rng, d1, sizes)
         end
     end
@@ -127,7 +116,7 @@ end
         α = rand(rng, 36) .+ 1 # mode is only defined if all alpha > 1
         d1 = Dirichlet(α)
         sizes = [(6, 6), (4, 9), (9, 4), (3, 12), (12, 3), (1, 36), (36, 1), (6,)]
-        _redirect_stderr(devnull) do
+        redirect_stderr(devnull) do
             test_matrixreshaped(rng, d1, sizes)
         end
     end

--- a/test/multivariate/mvlogitnormal.jl
+++ b/test/multivariate/mvlogitnormal.jl
@@ -143,7 +143,7 @@ end
         @test kldivergence(d1, d2) ≈ kldivergence(d1.normal, d2.normal)
     end
 
-    VERSION ≥ v"1.8" && @testset "show" begin
+    @testset "show" begin
         d = MvLogitNormal([1.0, 2.0, 3.0], Diagonal([4.0, 5.0, 6.0]))
         @test sprint(show, d) === """
         MvLogitNormal{DiagNormal}(

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -50,10 +50,8 @@ function test_cgf(dist, ts)
     d(f) = Base.Fix1(ForwardDiff.derivative, f)
     κ₁ = d(Base.Fix1(cgf, dist))(0)
     @test κ₁ ≈ mean(dist)
-    if VERSION >= v"1.4"
-        κ₂ = d(d(Base.Fix1(cgf, dist)))(0)
-        @test κ₂ ≈ var(dist)
-    end
+    κ₂ = d(d(Base.Fix1(cgf, dist)))(0)
+    @test κ₂ ≈ var(dist)
     for t in ts
         val = @inferred cgf(dist, t)
         @test isfinite(val)

--- a/test/univariate/continuous/tdist.jl
+++ b/test/univariate/continuous/tdist.jl
@@ -5,12 +5,8 @@ using Test
 
 @testset "TDist" begin
     @testset "Type stability of `rand` (#1614)" begin
-        if VERSION >= v"1.9.0-DEV.348"
-            # randn(::BigFloat) was only added in https://github.com/JuliaLang/julia/pull/44714
-            @inferred(rand(TDist(big"1.0")))
-        end
+        @inferred(rand(TDist(big"1.0")))
         @inferred(rand(TDist(ForwardDiff.Dual(1.0))))
-
     end
 
     for T in (Float32, Float64)


### PR DESCRIPTION
I ran into an issue with a too restrictive function signature in older Julia versions in LinearAlgebra (fixed by https://github.com/JuliaLang/julia/pull/42874 in Julia >= 1.8.0). Of course, I could work around this on older Julia versions but my feeling was that it's about time to bump our Julia compat to 1.10 (latest LTS) instead of adding more version-specific workarounds.

This PR updates the Julia compat to 1.10. Moreover, I tried to remove all version-specific workarounds or checks that are not needed anymore.