### PR TITLE
Reduce allocations of `cov(::MultivariateMixture)`

### DIFF
--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -248,11 +248,7 @@ function cov(d::MultivariateMixture)
             BLAS.syr!('U', pi, md, V)
         end
     end
-    for j in 1:length(d)
-        for i in (j+1):length(d)
-            V[i, j] = V[j, i]
-        end
-    end
+    LinearAlgebra.copytri!(V, 'U')
     return V
 end
 

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -186,7 +186,7 @@ function mean(d::MultivariateMixture)
         pi = p[i]
         if pi > 0.0
             c = component(d, i)
-            m .= muladd.(pi, mean(c), m)
+            mul!(m, pi, mean(c), true, true)
         end
     end
     return m
@@ -236,8 +236,8 @@ function cov(d::MultivariateMixture)
         pi = p[i]
         if pi > 0.0
             c = component(d, i)
-            m .= muladd.(pi, mean(c), m)
-            V .= muladd.(pi, cov(c), V)
+            mul!(m, pi, mean(c), true, true)
+            mul!(V, pi, cov(c), true, true)
         end
     end
     for i = 1:K
@@ -307,7 +307,7 @@ function _mixpdf!(r::AbstractArray, d::AbstractMixtureModel, x)
             else
                 pdf!(t, component(d, i), x)
             end
-            r .= muladd.(pi, t, r)
+            mul!(r, pi, t, true, true)
         end
     end
     return r

--- a/src/mixtures/mixturemodel.jl
+++ b/src/mixtures/mixturemodel.jl
@@ -245,7 +245,7 @@ function cov(d::MultivariateMixture)
         if pi > 0.0
             c = component(d, i)
             md .= mean(c) .- m
-            BLAS.syr!('U', pi, md, V)
+            BLAS.syr!('U', Float64(pi), md, V)
         end
     end
     LinearAlgebra.copytri!(V, 'U')

--- a/test/mixture.jl
+++ b/test/mixture.jl
@@ -1,5 +1,6 @@
 using Distributions, Random
 using Test
+using LinearAlgebra
 using ForwardDiff: Dual
 
 
@@ -252,17 +253,19 @@ end
     end
 
     @testset "Testing MultivariatevariateMixture" begin
-        g_m = MixtureModel(
-            IsoNormal[ MvNormal([0.0, 0.0], I),
-                       MvNormal([0.2, 1.0], I),
-                       MvNormal([-0.5, -3.0], 1.6 * I) ],
-            [0.2, 0.5, 0.3])
-        @test isa(g_m, MixtureModel{Multivariate, Continuous, IsoNormal})
-        @test length(components(g_m)) == 3
-        @test length(g_m) == 2
-        @test insupport(g_m, [0.0, 0.0]) == true
-        test_mixture(g_m, 1000, 10^6, rng)
-        test_params(g_m)
+        for T in (Float32, Float64)
+            g_m = MixtureModel(
+                IsoNormal[ MvNormal([0.0, 0.0], I),
+                           MvNormal([0.2, 1.0], I),
+                           MvNormal([-0.5, -3.0], 1.6 * I) ],
+                T[0.2, 0.5, 0.3])
+            @test isa(g_m, MixtureModel{Multivariate, Continuous, IsoNormal})
+            @test length(components(g_m)) == 3
+            @test length(g_m) == 2
+            @test insupport(g_m, [0.0, 0.0])
+            test_mixture(g_m, 1000, 10^6, rng)
+            test_params(g_m)
+        end
 
         u1 =  Uniform()
         u2 =  Uniform(1.0, 2.0)


### PR DESCRIPTION
The PR reduces allocations of `cov(::MultivatiateMixture)` (addresses a TODO item).