### PR TITLE
More efficient sampling with `MvNormalCanon`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.119"
+version = "0.25.120"
 
 [deps]
 AliasTables = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"
@@ -44,7 +44,7 @@ ForwardDiff = "0.10, 1"
 JSON = "0.21"
 LinearAlgebra = "<0.0.1, 1"
 OffsetArrays = "1"
-PDMats = "0.10, 0.11"
+PDMats = "0.11.35"
 Printf = "<0.0.1, 1"
 QuadGK = "2"
 Random = "<0.0.1, 1"

--- a/src/multivariate/mvnormalcanon.jl
+++ b/src/multivariate/mvnormalcanon.jl
@@ -170,20 +170,13 @@ sqmahal!(r::AbstractVector, d::MvNormalCanon, x::AbstractMatrix) = quad!(r, d.J,
 
 # Sampling (for GenericMvNormal)
 
-unwhiten_winv!(J::AbstractPDMat, x::AbstractVecOrMat) = unwhiten!(inv(J), x)
-unwhiten_winv!(J::PDiagMat, x::AbstractVecOrMat) = whiten!(J, x)
-unwhiten_winv!(J::ScalMat, x::AbstractVecOrMat) = whiten!(J, x)
-if isdefined(PDMats, :PDSparseMat)
-    unwhiten_winv!(J::PDSparseMat, x::AbstractVecOrMat) = x[:] = J.chol.PtL' \ x
-end
-
 function _rand!(rng::AbstractRNG, d::MvNormalCanon, x::AbstractVector)
-    unwhiten_winv!(d.J, randn!(rng, x))
+    invunwhiten!(d.J, randn!(rng, x))
     x .+= d.μ
     return x
 end
 function _rand!(rng::AbstractRNG, d::MvNormalCanon, x::AbstractMatrix)
-    unwhiten_winv!(d.J, randn!(rng, x))
+    invunwhiten!(d.J, randn!(rng, x))
     x .+= d.μ
     return x
 end


### PR DESCRIPTION
In PDMats 0.11.35, `invunwhiten!` was added that computes `whiten!` with `inv`erses of `PDMat` matrices. 