### PR TITLE
Fix incorrect formula for mean in geometric.jl #1

### DIFF
--- a/src/univariate/discrete/geometric.jl
+++ b/src/univariate/discrete/geometric.jl
@@ -53,7 +53,7 @@ partype(::Geometric{T}) where {T<:Real} = T
 
 ### Statistics
 
-mean(d::Geometric) = failprob(d) / succprob(d)
+mean(d::Geometric) = 1 / succprob(d)
 
 median(d::Geometric) = -fld(logtwo, log1p(-d.p)) - 1
 


### PR DESCRIPTION
This pull request corrects the formula for the **mean** of the geometric distribution in `geometric.jl`.

The current formula is incorrect. The correct formula for the mean of a geometric distribution is:

$$
\mu = \frac{1}{p}
$$

where $p$ is the probability of success.

**References:**

1. Montgomery, D. C., & Runger, G. C. (2011). *Applied Statistics and Probability for Engineers* (5th ed.). Wiley. (p. 88)

2. Wikipedia contributors. (2025, May 20). *Geometric distribution*. In *Wikipedia, The Free Encyclopedia*. Retrieved June 8, 2025, from [https://en.wikipedia.org/w/index.php?title=Geometric\_distribution\&oldid=1291255291](https://en.wikipedia.org/w/index.php?title=Geometric_distribution&oldid=1291255291)


