### PR TITLE
Remove docstring for `cdf(::Skellam, ::Real)`

### DIFF
--- a/src/univariate/discrete/skellam.jl
+++ b/src/univariate/discrete/skellam.jl
@@ -91,17 +91,13 @@ function cf(d::Skellam, t::Real)
     exp(μ1 * (cis(t) - 1) + μ2 * (cis(-t) - 1))
 end
 
-"""
-    cdf(d::Skellam, t::Real)
-
+#=
 Implementation based on SciPy: https://github.com/scipy/scipy/blob/v0.15.1/scipy/stats/_discrete_distns.py
 
 Refer to Eqn (5) in On an Extension of the Connexion Between Poisson and χ2 Distributions, N.L Johnson(1959)
 Vol 46, No 3/4, doi:10.2307/2333532
 It relates the Skellam and Non-central chisquare PDFs, which is very similar to their CDFs computation as well.
-
-Computing cdf of the Skellam distribution.
-"""
+=#
 function cdf(d::Skellam, t::Integer)
     μ1, μ2 = params(d)
     return if t < 0


### PR DESCRIPTION
IMO this should be an internal comment and not a public docstring. For users, there's nothing special about `cdf(::Skellam, ::Real)`, so there's no need for a separate docstring. See https://github.com/JuliaStats/Distributions.jl/pull/1985#discussion_r2154641063 for an example of the situation on the master branch.