### PR TITLE
Improve performance of `logpdf` for `DiagNormal` and `IsoNormal`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.120"
+version = "0.25.121"
 
 [deps]
 AliasTables = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -261,6 +261,16 @@ logdetcov(d::MvNormal) = logdet(d.Σ)
 
 sqmahal(d::MvNormal, x::AbstractVector) = invquad(d.Σ, x .- d.μ)
 
+function sqmahal(d::DiagNormal, x::AbstractVector)
+    # Faster than above as this avoids calculating (x .- d.µ)
+    T = promote_type(partype(d), eltype(x))
+    sum = zero(T)
+    for i in eachindex(x)
+        @inbounds sum += abs2(x[i] - d.μ[i]) / d.Σ[i, i]
+    end
+    return sum
+end
+
 sqmahal!(r::AbstractVector, d::MvNormal, x::AbstractMatrix) =
     invquad!(r, d.Σ, x .- d.μ)
 


### PR DESCRIPTION
This PR (sort of) closes #1989. I didn't attempt to make `rand()` faster because the performance drop there was smaller, but the changes here improve the performance of `logpdf` on `DiagNormal` and `IsoNormal` by about 2–3x.

The offending code that made the previous `logpdf` slower was the calculation of `x .- d.µ`:

https://github.com/JuliaStats/Distributions.jl/blob/abb151c42eb67b4994e21da15e24c65f1cc3dd9f/src/multivariate/mvnormal.jl#L262

The new methods avoid this and are thus both faster and avoid allocations.
