### PR TITLE
Skip parameter checks when constructing `Normal` distributions for `LogNormal` calculations

### DIFF
--- a/src/univariate/continuous/lognormal.jl
+++ b/src/univariate/continuous/lognormal.jl
@@ -133,7 +133,7 @@ cquantile(d::LogNormal, q::Real) =  exp(StatsFuns.norminvccdf(d.μ, d.σ, q))
 invlogcdf(d::LogNormal, lq::Real) = exp(StatsFuns.norminvlogcdf(d.μ, d.σ, lq))
 invlogccdf(d::LogNormal, lq::Real) = exp(StatsFuns.norminvlogccdf(d.μ, d.σ, lq))
 
-function gradlogpdf(d::LogNormal{T}, x::Real) where {T<:Real}
+function gradlogpdf(d::LogNormal, x::Real)
     outofsupport = x ≤ zero(x)
     y = outofsupport ? one(x) : x
     z = ((d.μ - log(y)) / d.σ^2 - 1) / y

--- a/src/univariate/continuous/lognormal.jl
+++ b/src/univariate/continuous/lognormal.jl
@@ -123,15 +123,15 @@ function logpdf(d::LogNormal, x::Real)
     return StatsFuns.normlogpdf(d.μ, d.σ, logx) - b
 end
 
-for f in (:cdf, :ccdf, :logcdf, :logccdf)
-    g = Symbol(:norm, f)
-    @eval $f(d::LogNormal, x::Real) = StatsFuns.$g(d.μ, d.σ, x ≤ zero(x) ? log(zero(x)) : log(x))
-end
+cdf(d::LogNormal, x::Real) = StatsFuns.normcdf(d.μ, d.σ, log(max(x, zero(x))))
+ccdf(d::LogNormal, x::Real) = StatsFuns.normccdf(d.μ, d.σ, log(max(x, zero(x))))
+logcdf(d::LogNormal, x::Real) = StatsFuns.normlogcdf(d.μ, d.σ, log(max(x, zero(x))))
+logccdf(d::LogNormal, x::Real) = StatsFuns.normlogccdf(d.μ, d.σ, log(max(x, zero(x))))
 
-quantile(d::LogNormal, q::Real) =  exp(StatsFuns.invcdf(d.μ, d.σ, q))
-cquantile(d::LogNormal, q::Real) =  exp(StatsFuns.invccdf(d.μ, d.σ, q))
-invlogcdf(d::LogNormal, lq::Real) = exp(StatsFuns.invlogcdf(d.μ, d.σ, lq))
-invlogccdf(d::LogNormal, lq::Real) = exp(StatsFuns.invlogccdf(d.μ, d.σ, lq))
+quantile(d::LogNormal, q::Real) =  exp(StatsFuns.norminvcdf(d.μ, d.σ, q))
+cquantile(d::LogNormal, q::Real) =  exp(StatsFuns.norminvccdf(d.μ, d.σ, q))
+invlogcdf(d::LogNormal, lq::Real) = exp(StatsFuns.norminvlogcdf(d.μ, d.σ, lq))
+invlogccdf(d::LogNormal, lq::Real) = exp(StatsFuns.norminvlogccdf(d.μ, d.σ, lq))
 
 function gradlogpdf(d::LogNormal{T}, x::Real) where {T<:Real}
     outofsupport = x ≤ zero(x)


### PR DESCRIPTION
Quite a few methods for `LogNormal` call and post-process methods for `Normal` distributions. However, currently the outer constructor for `Normal` distributions is used and hence parameter values (mean and standard deviation) are re-checked (to ensure that the standard deviation is non-negative) in every call.

This PR switches to the ~~inner constructor~~ StatsFuns API (see discussion below) to skip these parameter checks. The difference can be seen e.g. in the output of `@code_llvm` and also be observed when benchmarking e.g. `logpdf`:

### On the master branch

```julia
julia> using Distributions, Chairmarks

julia> @be rand(1000) map(x -> logpdf(LogNormal(3.1, 2.5), x), _)
Benchmark: 6251 samples with 1 evaluation
 min    11.750 μs (3 allocs: 8.062 KiB)
 median 12.416 μs (3 allocs: 8.062 KiB)
 mean   13.721 μs (3 allocs: 8.062 KiB, 0.15% gc time)
 max    2.115 ms (3 allocs: 8.062 KiB, 98.68% gc time)
```

## With this PR

```julia
julia> using Distributions, Chairmarks

julia> @be rand(1000) map(x -> logpdf(LogNormal(3.1, 2.5), x), _)
Benchmark: 4180 samples with 3 evaluations
 min    6.000 μs (3 allocs: 8.062 KiB)
 median 6.333 μs (3 allocs: 8.062 KiB)
 mean   7.213 μs (3 allocs: 8.062 KiB, 0.31% gc time)
 max    1.005 ms (3 allocs: 8.062 KiB, 98.62% gc time)
```