### PR TITLE
Bump version from 0.25.122 to 0.25.123

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.122"
+version = "0.25.123"
 
 [deps]
 AliasTables = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"


### PR DESCRIPTION
To release https://github.com/JuliaStats/Distributions.jl/pull/1930.

Fixes #2018.