### PR TITLE
Fix NoncentralBeta sampling

### DIFF
--- a/src/univariate/continuous/noncentralbeta.jl
+++ b/src/univariate/continuous/noncentralbeta.jl
@@ -43,15 +43,13 @@ partype(::NoncentralBeta{T}) where {T} = T
 @rand_rdist(NoncentralBeta)
 
 function rand(d::NoncentralBeta)
-    β = d.β
-    a = rand(NoncentralChisq(2d.α, β))
-    b = rand(Chisq(2β))
+    a = rand(NoncentralChisq(2d.α, d.λ))
+    b = rand(Chisq(2d.β))
     a / (a + b)
 end
 
 function rand(rng::AbstractRNG, d::NoncentralBeta)
-    β = d.β
-    a = rand(rng, NoncentralChisq(2d.α, β))
-    b = rand(rng, Chisq(2β))
+    a = rand(rng, NoncentralChisq(2d.α, d.λ))
+    b = rand(rng, Chisq(2d.β))
     a / (a + b)
 end

--- a/test/univariates.jl
+++ b/test/univariates.jl
@@ -144,8 +144,7 @@ function verify_and_test(D::Union{Type,Function}, d::UnivariateDistribution, dct
     # generic testing
     if isa(d, Cosine)
         n_tsamples = floor(Int, n_tsamples / 10)
-    elseif isa(d, NoncentralBeta) ||
-           isa(d, NoncentralChisq) ||
+    elseif isa(d, NoncentralChisq) ||
            isa(d, NoncentralF) ||
            isa(d, NoncentralT)
         n_tsamples = min(n_tsamples, 100)


### PR DESCRIPTION
Split from https://github.com/JuliaStats/Distributions.jl/pull/2027 as a simple bugfix.

This was previously uncaught because we were only testing NoncentralBeta with 100 samples instead of 10^6 like everything else (so we were testing with very loose bounds on the distribution).