### PR TITLE
Add docstring content to docs website

### DIFF
--- a/docs/src/fit.md
+++ b/docs/src/fit.md
@@ -27,8 +27,7 @@ The function `fit_mle` is for maximum likelihood estimation.
 ### Synopsis
 
 ```@docs
-fit(D, x)
-fit(D, x, w)
+fit(::Type{<:Distribution}, x)
 fit_mle(D, x)
 fit_mle(D, x, w)
 ```

--- a/docs/src/reshape.md
+++ b/docs/src/reshape.md
@@ -4,7 +4,6 @@ Distributions of array variates such as `MultivariateDistribution`s and
 `MatrixDistribution`s can be reshaped.
 
 ```@docs
-Distributions.ReshapedDistribution
 reshape
 vec
 ```

--- a/docs/src/reshape.md
+++ b/docs/src/reshape.md
@@ -4,6 +4,7 @@ Distributions of array variates such as `MultivariateDistribution`s and
 `MatrixDistribution`s can be reshaped.
 
 ```@docs
+Distributions.ReshapedDistribution
 reshape
 vec
 ```

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -70,7 +70,7 @@ We use `Distribution`, a subtype of `Sampleable` as defined below, to capture pr
 abstract type Distribution{F<:VariateForm,S<:ValueSupport} <: Sampleable{F,S} end
 ```
 
-```@doc
+```@docs
 Distributions.Distribution
 ```
 

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -23,13 +23,25 @@ Base.rand(::Distributions.Sampleable)
 Distributions.VariateForm
 ```
 
-The `VariateForm` subtypes defined in `Distributions.jl` are:
+The most commonly used `VariateForm` is the `ArrayLikeVariate`:
+```@docs
+Distributions.ArrayLikeVariate
+```
+
+The `ArrayLikeVariate` types defined in `Distributions.jl` are:
 
 **Type** | **A single sample** | **Multiple samples**
 --- | --- |---
 `Univariate == ArrayLikeVariate{0}` | a scalar number | A numeric array of arbitrary shape, each element being a sample
 `Multivariate == ArrayLikeVariate{1}` | a numeric vector | A matrix, each column being a sample
 `Matrixvariate == ArrayLikeVariate{2}` | a numeric matrix | An array of matrices, each element being a sample matrix
+
+`Distributions.jl` also defines some other `VariateForm` subtypes
+
+```@docs
+Distributions.NamedTupleVariate
+Distributions.CholeskyVariate
+```
 
 ### ValueSupport
 

--- a/src/reshaped.jl
+++ b/src/reshaped.jl
@@ -103,7 +103,7 @@ end
 Return a [`Distribution`](@ref) of `reshape(X, dims)` where `X` is a random variable with
 distribution `d`.
 
-The default implementation returns a [`ReshapedDistribution`](@ref). However, it can return
+The default implementation returns a `ReshapedDistribution`. However, it can return
 more optimized distributions for specific types of distributions and numbers of dimensions.
 Therefore it is recommended to use `reshape` instead of the constructor of
 `ReshapedDistribution`.

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -326,6 +326,16 @@ logpdf(d::UnivariateDistribution, x::Real)
 # extract value from array of zero dimension
 logpdf(d::UnivariateDistribution, x::AbstractArray{<:Real,0}) = logpdf(d, first(x))
 
+"""
+    loglikelihood(d::UnivariateDistribution, x)
+
+The log-likelihood of distribution `d` with respect to `x`.
+
+Here, `x` can be any output of `rand(d, dims...)` and `rand!(d, x)`.
+For univariate distributions, `x` therfore must be a scalar or
+an array with an arbitrary number of dimensions.
+"""
+loglikelihood(d::UnivariateDistribution, x::AbstractArray)
 # loglikelihood for `Real`
 Base.@propagate_inbounds loglikelihood(d::UnivariateDistribution, x::Real) = logpdf(d, x)
 


### PR DESCRIPTION
- Add docstrings to docs website
- Create docstring for `loglikelihood` method
- Fix reference to/of `fit(D, x)` method