### PR TITLE
performance: distrname: use `@generated`

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -7,7 +7,7 @@
 #   this function to provide a name that is easier to read,
 #   especially when the type is parametric.
 #
-distrname(d::Distribution) = string(typeof(d))
+@generated distrname(d::Distribution) = string(d)
 
 show(io::IO, d::Distribution) = show(io, d, fieldnames(typeof(d)))
 


### PR DESCRIPTION
Hi! This is my first contribution to Distributions.jl :)

This PR improves the performance of `distrname` (and other display methods that use it). By using `@generated`, the result can be computed at JIT time for each input type and cached, making the function instant and non-allocating.


In my logging application, I found that calls to `Distributions.distrname` were a bottleneck. This PR improves my logging performance 7x.

# Benchmark

Example distributions:

```julia
d1 = Normal(1,2)

d2 = MixtureModel(
    [
        truncated(
            LocationScale(
                2.0,
                0.5,
                MixtureModel(
                    [
                        Normal(0.0, 1.0),
                        GeneralizedExtremeValue(0.0, 1.0, 0.5),
                        LocationScale(-1.0, 2.0, Gamma(2.0, 3.0)),
                    ],
                    Categorical([0.4, 0.35, 0.25]),
                ),
            );
            lower = -20.0,
            upper = 20.0,
        ),

        censored(
            LocationScale(
                -3.0,
                1.5,
                MixtureModel(
                    [
                        Levy(0.0, 1.0),
                        InverseGaussian(1.0, 3.0),
                        truncated(LogNormal(0.0, 0.5); lower = 0.1, upper = 50.0),
                    ],
                    [0.3, 0.3, 0.4],
                ),
            );
            lower = -100.0,
            upper = 100.0,
        ),

        LocationScale(
            10.0,
            0.1,
            LocationScale(
                -5.0,
                2.0,
                LocationScale(0.0, 1.0, Beta(2.0, 5.0)),
            ),
        ),
    ],
    [0.5, 0.3, 0.2],
)
```

Benchmark before the PR:

```
julia> @benchmark Distributions.distrname($d1)
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  40.041 μs …  7.643 ms  ┊ GC (min … max): 0.00% … 96.07%
 Time  (median):     41.458 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   43.412 μs ± 76.519 μs  ┊ GC (mean ± σ):  1.69% ±  0.96%

   █▆▂                                                         
  ▆███▆▅▄▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▁▂▂▂▁▂▂▂▂▂▂▁▁▁▂▂▁▂▂ ▃
  40 μs           Histogram: frequency by time        71.6 μs <

 Memory estimate: 13.30 KiB, allocs estimate: 43.

julia> @benchmark Distributions.distrname($d2)
BenchmarkTools.Trial: 9498 samples with 1 evaluation per sample.
 Range (min … max):  463.083 μs …   3.380 ms  ┊ GC (min … max): 0.00% … 73.34%
 Time  (median):     482.667 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   524.898 μs ± 197.804 μs  ┊ GC (mean ± σ):  2.04% ±  5.54%

  █▆▆▅▄▃▃▃▂▁▁                                                   ▂
  ███████████▇▇▇▇▇▇▅▆▅▅▅▆▆▆▄▅▅▄▅▅▅▃▃▃▄▃▄▄▄▅▅▅▄▅▄▄▄▅▄▁▄▃▄▃▃▃▅▄▃▅ █
  463 μs        Histogram: log(frequency) by time       1.49 ms <

 Memory estimate: 144.47 KiB, allocs estimate: 432.
```


After the PR:


```
julia> @benchmark Distributions.distrname($d1)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations per sample.
 Range (min … max):  2.166 ns … 35.375 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.250 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.365 ns ±  1.091 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▆█ ▇▅▅ ▃▂ ▁▁                                              ▂
  ▇██▁███▁██▁██▇▁▅▅▁▁▃▃▁▃▁▇▁▇▅▄▄▅▁▁▄▄▁▁▁▁▁▁▁▁▁▁▁▄▁▁▁▁▁▁▁▁▁▅▄ █
  2.17 ns      Histogram: log(frequency) by time     3.92 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark Distributions.distrname($d2)
BenchmarkTools.Trial: 10000 samples with 1000 evaluations per sample.
 Range (min … max):  2.250 ns … 996.625 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.375 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.082 ns ±  11.668 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▃ ▁   ▂▄                                                   ▁
  ██▆█▇▄▁██▅▄▁▄▃▄▄▃▁▄▄▄▄▃▄▃▄▄▄▄▁▃▄▃▃▄▄▁▃▁▄▅▃▃▅▄▄▅▄▄▅▄▄▆▄▄▃▄▄▅ █
  2.25 ns      Histogram: log(frequency) by time      14.5 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```



# First call time
The first call time also improve. The benchmarks above, with `@time` instead of `@benchmark` on a cold system:

Before the PR:
```
  0.005251 seconds (873 allocations: 53.484 KiB, 63.19% compilation time)
  0.016345 seconds (1.26 k allocations: 184.703 KiB, 14.42% compilation time)
```

After the PR:
```
  0.003518 seconds (597 allocations: 38.656 KiB, 98.91% compilation time)
  0.013299 seconds (1.66 k allocations: 201.078 KiB, 99.74% compilation time)
```

