### PR TITLE
Avoid intermediate `string` creation in fallback when printing distribution names

### DIFF
--- a/src/multivariate/mvlogitnormal.jl
+++ b/src/multivariate/mvlogitnormal.jl
@@ -30,7 +30,7 @@ MvLogitNormal(d::AbstractMvNormal) = MvLogitNormal{typeof(d)}(d)
 MvLogitNormal(args...) = MvLogitNormal(MvNormal(args...))
 
 function Base.show(io::IO, d::MvLogitNormal; indent::String="  ")
-    print(io, distrname(d))
+    print_distrname(io, d)
     println(io, "(")
     normstr = strip(sprint(show, d.normal; context=IOContext(io)))
     normstr = replace(normstr, "\n" => "\n$indent")

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -233,13 +233,13 @@ end
 
 ### Show
 
-distrname(d::IsoNormal)  = "IsoNormal"    # Note: IsoNormal, etc are just alias names.
-distrname(d::DiagNormal) = "DiagNormal"
-distrname(d::FullNormal) = "FullNormal"
+print_distrname(io::IO, ::IsoNormal) = print(io, "IsoNormal") # Note: IsoNormal, etc are just alias names.
+print_distrname(io::IO, ::DiagNormal) = print(io, "DiagNormal")
+print_distrname(io::IO, ::FullNormal) = print(io, "FullNormal")
 
-distrname(d::ZeroMeanIsoNormal) = "ZeroMeanIsoNormal"
-distrname(d::ZeroMeanDiagNormal) = "ZeroMeanDiagNormal"
-distrname(d::ZeroMeanFullNormal) = "ZeroMeanFullNormal"
+print_distrname(io::IO, ::ZeroMeanIsoNormal) = print(io, "ZeroMeanIsoNormal")
+print_distrname(io::IO, ::ZeroMeanDiagNormal) = print(io, "ZeroMeanDiagNormal")
+print_distrname(io::IO, ::ZeroMeanFullNormal) = print(io, "ZeroMeanFullNormal")
 
 Base.show(io::IO, d::MvNormal) =
     show_multline(io, d, [(:dim, length(d)), (:μ, mean(d)), (:Σ, cov(d))])

--- a/src/multivariate/mvnormalcanon.jl
+++ b/src/multivariate/mvnormalcanon.jl
@@ -118,13 +118,13 @@ Base.@deprecate MvNormalCanon(d::Int, prec::Real) MvNormalCanon(LinearAlgebra.Di
 
 ### Show
 
-distrname(d::IsoNormalCanon) = "IsoNormalCanon"
-distrname(d::DiagNormalCanon) = "DiagNormalCanon"
-distrname(d::FullNormalCanon) = "FullNormalCanon"
+print_distrname(io::IO, ::IsoNormalCanon) = print(io, "IsoNormalCanon")
+print_distrname(io::IO, ::DiagNormalCanon) = print(io, "DiagNormalCanon")
+print_distrname(io::IO, ::FullNormalCanon) = print(io, "FullNormalCanon")
 
-distrname(d::ZeroMeanIsoNormalCanon) = "ZeroMeanIsoNormalCanon"
-distrname(d::ZeroMeanDiagNormalCanon) = "ZeroMeanDiagormalCanon"
-distrname(d::ZeroMeanFullNormalCanon) = "ZeroMeanFullNormalCanon"
+print_distrname(io::IO, ::ZeroMeanIsoNormalCanon) = print(io, "ZeroMeanIsoNormalCanon")
+print_distrname(io::IO, ::ZeroMeanDiagNormalCanon) = print(io, "ZeroMeanDiagormalCanon")
+print_distrname(io::IO, ::ZeroMeanFullNormalCanon) = print(io, "ZeroMeanFullNormalCanon")
 
 ### Conversion
 function convert(::Type{MvNormalCanon{T}}, d::MvNormalCanon) where {T<:Real}

--- a/src/namedtuple/productnamedtuple.jl
+++ b/src/namedtuple/productnamedtuple.jl
@@ -67,8 +67,8 @@ function Base.show(io::IO, d::ProductNamedTupleDistribution)
     return show_multline(io, d, collect(pairs(d.dists)))
 end
 
-function distrname(::ProductNamedTupleDistribution{K}) where {K}
-    return "ProductNamedTupleDistribution{$K}"
+function print_distrname(io::IO, ::ProductNamedTupleDistribution{K}) where {K}
+    return print(io, "ProductNamedTupleDistribution{", K, "}")
 end
 
 """

--- a/src/show.jl
+++ b/src/show.jl
@@ -7,7 +7,7 @@
 #   this function to provide a name that is easier to read,
 #   especially when the type is parametric.
 #
-distrname(d::Distribution) = string(typeof(d))
+print_distrname(io::IO, d::Distribution) = print(io, typeof(d))
 
 show(io::IO, d::Distribution) = show(io, d, fieldnames(typeof(d)))
 
@@ -52,7 +52,7 @@ function _use_multline_show(d::Distribution)
 end
 
 function show_oneline(io::IO, d::Distribution, namevals)
-    print(io, distrname(d))
+    print_distrname(io, d)
     np = length(namevals)
     print(io, '(')
     for (i, nv) in enumerate(namevals)
@@ -68,7 +68,7 @@ function show_oneline(io::IO, d::Distribution, namevals)
 end
 
 function show_multline(io::IO, d::Distribution, namevals; newline=true)
-    print(io, distrname(d))
+    print_distrname(io, d)
     println(io, "(")
     for (p, pv) in namevals
         print(io, p)


### PR DESCRIPTION
See https://github.com/JuliaStats/Distributions.jl/pull/2050#issuecomment-4172319875