### PR TITLE
Fix `BinomialTPESampler` Stirling correction sign error

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.123"
+version = "0.25.124"
 
 [deps]
 AliasTables = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"

--- a/src/samplers/binomial.jl
+++ b/src/samplers/binomial.jl
@@ -209,7 +209,13 @@ function rand(rng::AbstractRNG, s::BinomialTPESampler)
             w = Float64(s.n-y+1)
 
             if A > (s.xM*log(f1/x1) + ((s.n-s.Mi)+0.5)*log(z/w) + (y-s.Mi)*log(w*s.r/(x1*s.q)) +
-                    lstirling_asym(f1) + lstirling_asym(z) + lstirling_asym(x1) + lstirling_asym(w))
+                    # In the 1988 paper, all error terms are added, which is incorrect:
+                    # the third and fourth terms should be subtracted. This can be verified
+                    # by examining the derivation of equation (1): notice that the first two
+                    # terms arise from the approximation of the numerator, while the last two terms
+                    # arise from the denominator. A direct numerical test would require precision
+                    # beyond what is currently practical
+                    lstirling_asym(f1) + lstirling_asym(z) - lstirling_asym(x1) - lstirling_asym(w))
                 # Goto 1
                 continue
             end


### PR DESCRIPTION
I came across this when comparing different implementations of this algorithm and I noticed Distributions.js reproduces an error in the original paper. In step 5.3 of the BTPE algorithm (Kachitvichyanukul & Schmeiser, 1988), the acceptance bound adds all four Stirling terms, but this is incorrect: the corrections for `x1 = y+1` and `w = n-y+1` should be subtracted.

The fix/comment is noted [here](https://github.com/ampl/gsl/blob/fb0cfbc82b5e9e4d22444efce9241924f4aefb83/randist/binomial_tpe.c#L339-L361) in GSL. As the GSL authors mention, the impact is so small it's statistically infeasible to test, but I thought it would be worth putting up anyway. 