### PR TITLE
Quantile bisect widen interval

### DIFF
--- a/src/quantilealgs.jl
+++ b/src/quantilealgs.jl
@@ -1,8 +1,17 @@
 # Various algorithms for computing quantile
 
+"""
+quantile_bisect(d::ContinuousUnivariateDistribution, p::Real, lx::T, rx::T) where {T<:Real}
+
+Compute the quantile of `d` at probability `p` using the bisection method, starting from
+the bracketing interval `[lx, rx]`.
+
+In theory, the interval `[lx, rx]` should satisfy `cdf(d, lx) <= p <= cdf(d, rx)`.
+However, due to numerical issues, this condition may not hold. In such cases, the algorithm
+attempts to recover a valid bracketing interval by expanding the initial interval.
+"""
 function quantile_bisect(d::ContinuousUnivariateDistribution, p::Real, lx::T, rx::T) where {T<:Real}
     rx < lx && throw(ArgumentError("empty bracketing interval [$lx, $rx]"))
-
     # In some special cases, e.g. #1501, rx == lx`
     # If the distribution is degenerate the check below can fail, hence we skip it
     if rx == lx
@@ -15,23 +24,58 @@ function quantile_bisect(d::ContinuousUnivariateDistribution, p::Real, lx::T, rx
     # ≈ 3.7e-11 for Float64
     # ≈ 2.4e-5 for Float32
     tol = cbrt(eps(float(T)))^2
+
+    # find a valid bracketing interval, if necessary
+    lx, rx = find_interval_quantile_bisect(d, p, lx, rx)
+
     # find quantile using bisect algorithm
-    cl = cdf(d, lx)
-    cr = cdf(d, rx)
-    cl <= p <= cr ||
-        throw(ArgumentError("[$lx, $rx] is not a valid bracketing interval for `quantile(d, $p)`"))
     while rx - lx > tol
         m = (lx + rx)/2
         c = cdf(d, m)
         if p > c
-            cl = c
             lx = m
         else
-            cr = c
             rx = m
         end
     end
     return (lx + rx)/2
+end
+
+@inline function find_interval_quantile_bisect(d::ContinuousUnivariateDistribution, p::Real, x_left::T, x_right::T) where {T<:Real}
+    c_left = cdf(d, x_left)
+    c_right = cdf(d, x_right)
+    @show c_left c_right
+    c_left <= p <= c_right && return x_left, x_right
+    # expand the interval by eps() * 2^i at each iteration until it contains the quantile.
+    max_expand = 64 # max `i` in `eps() * 2^i`. Completely arbitrary to avoid infinite loop.
+    if p > c_right
+        step = max(abs(x_right), one(x_right)) * eps(float(T))
+        for i in 1:max_expand
+            x_right += step
+            c_right = cdf(d, x_right)
+            if p <= c_right
+                break
+            end
+            step *= 2
+        end
+    end
+    if p < c_left
+        step = max(abs(x_left), one(x_left)) * eps(float(T))
+        for i in 1:max_expand
+            x_left -= step
+            c_left = cdf(d, x_left)
+            if p >= c_left
+                break
+            end
+            step *= 2
+        end
+    end
+
+    # infinite loop in bisect if isinf(x_right). Still fine is isinf(x_left) though
+    if (!isinf(x_right)) && (c_left <= p <= c_right)
+        return x_left, x_right
+    end
+    throw(ArgumentError("[$x_left, $x_right] is not a valid bracketing interval for `quantile(d, $p)`"))
 end
 
 function quantile_bisect(d::ContinuousUnivariateDistribution, p::Real, lx::Real, rx::Real)

--- a/src/quantilealgs.jl
+++ b/src/quantilealgs.jl
@@ -44,13 +44,14 @@ end
 @inline function find_interval_quantile_bisect(d::ContinuousUnivariateDistribution, p::Real, x_left::T, x_right::T) where {T<:Real}
     c_left = cdf(d, x_left)
     c_right = cdf(d, x_right)
-    @show c_left c_right
     c_left <= p <= c_right && return x_left, x_right
+
     # expand the interval by eps() * 2^i at each iteration until it contains the quantile.
     max_expand = 64 # max `i` in `eps() * 2^i`. Completely arbitrary to avoid infinite loop.
     if p > c_right
         step = max(abs(x_right), one(x_right)) * eps(float(T))
         for i in 1:max_expand
+            x_left = x_right # we can since we know c_right < p
             x_right += step
             c_right = cdf(d, x_right)
             if p <= c_right
@@ -59,9 +60,12 @@ end
             step *= 2
         end
     end
+
+    c_left = cdf(d, x_left)
     if p < c_left
         step = max(abs(x_left), one(x_left)) * eps(float(T))
         for i in 1:max_expand
+            x_right = x_left # we can since we know c_left > p
             x_left -= step
             c_left = cdf(d, x_left)
             if p >= c_left

--- a/test/mixture.jl
+++ b/test/mixture.jl
@@ -233,6 +233,23 @@ end
             @test extrema(g_u) == (-Inf, Inf)
         end
 
+        # edge case with numerical issues, see #1869
+        g_u = MixtureModel(
+            [Exponential(2.1656391815606704e-5), Exponential(79.77140291062331)],
+            [8.83763312432469e-25, 1.0]
+        )
+        q = 0.1066425045830068
+        @test isapprox(
+            cdf(g_u, @inferred(quantile(g_u, q))), q;
+            atol = cbrt(eps(Float64))^2
+        )
+        q = 0.001
+        g_u = MixtureModel([Normal(0, 1), Normal(eps(), 1)], [0.5, 0.5])
+        @test isapprox(
+            cdf(g_u, @inferred(quantile(g_u, q))), q;
+            atol = cbrt(eps(Float64))^2
+        )
+
         # https://github.com/JuliaStats/Distributions.jl/issues/1121
         @test @inferred(logpdf(UnivariateGMM(μ, σ, Categorical(p)), 42)) isa Float64
 


### PR DESCRIPTION
Fixes #1869 

## The issue

Specifically for mixture models, in this code
https://github.com/JuliaStats/Distributions.jl/blob/da420cde4fc0df074fa8c54b36bad70c46903a0c/src/mixtures/mixturemodel.jl#L446-L450

Let's call $F(x) = \text{cdf}(d, x)$ and $F_i(x) = \text{cdf}(\text{component}(d, i), x)$, same $F^{-1}$ and $F_i^{-1}$ for quantile. `quantile_bisect` requires that

$$
F(q_\text{min}) \leq p \leq F(q_\text{max})
$$

otherwise an error is thrown. Mathematically, in the code above, the condition is guaranteed. But if we take the definition of $q_\text{min}$ and $q_\text{max}$, the condition becomes

$$
F(\min_i F_i^{-1}(p)) \leq p \leq F(\max_i F_i^{-1}(p)) .
$$

And numerically, for some specific edge cases dealing with very small numbers, this condition is not satisfied. For example,

```julia-repl
julia> d = MixtureModel([Normal(0, 1), Normal(eps(), 1)], [0.5, 0.5])
MixtureModel{Normal{Float64}}(K = 2)
components[1] (prior = 0.5000): Normal{Float64}(μ=0.0, σ=1.0)
components[2] (prior = 0.5000): Normal{Float64}(μ=2.220446049250313e-16, σ=1.0)


julia> d1, d2 = components(d)
2-element Vector{Normal{Float64}}:
 Normal{Float64}(μ=0.0, σ=1.0)
 Normal{Float64}(μ=2.220446049250313e-16, σ=1.0)

julia> p = 0.001
0.001

julia> cdf(d, quantile(d1, p)), cdf(d, quantile(d2, p))
(0.000999999999999983, 0.0009999999999999853)

julia> quantile(d, p)
ERROR: ArgumentError: [-3.090232306167818, -3.0902323061678176] is not a valid bracketing interval for `quantile(d, 0.001)`
```

I found another example different than "almost identical" components, but still with the same issue:

```julia-repl
julia> d = MixtureModel(
           [Exponential(2.1656391815606704e-5), Exponential(79.77140291062331)],
           [8.83763312432469e-25, 1.0],
       )
MixtureModel{Exponential{Float64}}(K = 2)
components[1] (prior = 0.0000): Exponential{Float64}(θ=2.1656391815606704e-5)
components[2] (prior = 1.0000): Exponential{Float64}(θ=79.77140291062331)


julia> d1, d2 = components(d)
2-element Vector{Exponential{Float64}}:
 Exponential{Float64}(θ=2.1656391815606704e-5)
 Exponential{Float64}(θ=79.77140291062331)

julia> p = 0.1066425045830068
0.1066425045830068

julia> cdf(d1, quantile(d1, p)) <= p, cdf(d2, quantile(d2, p)) <= p
(true, true)

julia> quantile(d, p)
ERROR: ArgumentError: [2.442157681386963e-6, 8.995697253353159] is not a valid bracketing interval for `quantile(d, 0.1066425045830068)`
```

I did not found any issues such that $p < F(q_\text{min})$ though. It's always $p > F(q_\text{max})$. Maybe it is impossible with mixtures? 


## The fix

Because it seems specific to mixture models, we could simply make the interval wider in `quantile(d::UnivariateMixture{Continuous}, p::Real)` by adding some small number to `max_q` and subtracting some small number from `min_q`. But I think it would be better to make the `quantile_bisect` function more robust, by allowing it to widen the interval if the condition is not satisfied. It does not impact the old case at all, and it would fix the issue for mixture models, and potentially for other / future distributions with similar issues.