### PR TITLE
Change PoissonADSampler threshold to 10

### DIFF
--- a/src/univariate/discrete/poisson.jl
+++ b/src/univariate/discrete/poisson.jl
@@ -135,7 +135,7 @@ fit_mle(::Type{<:Poisson}, ss::PoissonStats) = Poisson(ss.sx / ss.tw)
 
 ## samplers
 
-const poissonsampler_threshold = 6
+const poissonsampler_threshold = 10
 
 function sampler(d::Poisson)
     if rate(d) < poissonsampler_threshold

--- a/src/univariate/discrete/poisson.jl
+++ b/src/univariate/discrete/poisson.jl
@@ -135,6 +135,7 @@ fit_mle(::Type{<:Poisson}, ss::PoissonStats) = Poisson(ss.sx / ss.tw)
 
 ## samplers
 
+# PoissonADSampler is biased for μ < 10
 const poissonsampler_threshold = 10
 
 function sampler(d::Poisson)

--- a/test/univariate/discrete/poisson.jl
+++ b/test/univariate/discrete/poisson.jl
@@ -4,6 +4,13 @@ test_cgf(Poisson(1   ), (1f0,2f0,10.0,50.0))
 test_cgf(Poisson(10  ), (1f0,2f0,10.0,50.0))
 test_cgf(Poisson(1e-3), (1f0,2f0,10.0,50.0))
 
+# Regression: PoissonADSampler is biased for low values of μ
+# because the Ahrens-Dieter algorithm is only designed for μ ≥ 10;
+# Threshold now requires μ ≥ 10 for AD; μ < 10 uses PoissonCountSampler.
+let n = 100_000_000, μ = 6.0, tol = 5 * sqrt(μ / n)
+    @test abs(sum(rand(Poisson(μ)) for _ in 1:n) / n - μ) < tol
+end
+
 @testset "Poisson suffstats and OffsetArrays" begin
     a = rand(Poisson(), 11)
     wa = 1.0:11.0

--- a/test/univariate/discrete/poisson.jl
+++ b/test/univariate/discrete/poisson.jl
@@ -7,8 +7,11 @@ test_cgf(Poisson(1e-3), (1f0,2f0,10.0,50.0))
 # Regression: PoissonADSampler is biased for low values of μ
 # because the Ahrens-Dieter algorithm is only designed for μ ≥ 10;
 # Threshold now requires μ ≥ 10 for AD; μ < 10 uses PoissonCountSampler.
-let n = 100_000_000, μ = 6.0, tol = 5 * sqrt(μ / n)
-    @test abs(sum(rand(Poisson(μ)) for _ in 1:n) / n - μ) < tol
+@testset "Poisson sampler bias for μ < 10" begin
+    n = 100_000_000
+    μ = 6.0
+    tol = 5 * sqrt(μ / n)
+    @test sum(rand(Poisson(μ)) for _ in 1:n) / n ≈ μ atol = tol
 end
 
 @testset "Poisson suffstats and OffsetArrays" begin


### PR DESCRIPTION
Another one that came up when I was going through some of the older papers for sampling algorithms:

In the Poisson sampler, the threshold at which `PoissonADSampler` kicks in is  currently `μ >= 6`, but the [Ahrens-Dieter PD algorithm](https://dl.acm.org/doi/10.1145/355993.355997) says it is designed for `μ >= 10`. I am not sure why 6 was chosen (it looks like it was originally from PoissonRandom.jl, see https://github.com/JuliaStats/Distributions.jl/pull/1021 but I don't see anything beyond that). To verify that this is actually a problem: if you plot the hat function (equation 24) against the residual between the discretized normal and the poisson PMF, you will see that at 6 it definitely goes outside the bounds. With the following:

```r
pmf_diff <- function(x, mu) {
  s <- sqrt(mu)
  dpois(floor(x), lambda = mu) - 
    pnorm(floor(x+1), mean = mu, sd = s) +
    pnorm(floor(x), mean = mu, sd = s)
}

hat <- function(t, mu) (0.1069 / mu) * exp(-abs(t - 1.8))
```

<img width="898" height="556" alt="plot of the hat function vs the pmf" src="https://github.com/user-attachments/assets/ad86a2ee-4783-40a1-8ba6-16b4e22185dd" />

In terms of demonstrating the bias, right now the sampler tests only check down to `10.0`, not `6.0`:

https://github.com/JuliaStats/Distributions.jl/blob/a7ed7b6116aac2b27abadfaa3c6d1819887a69f0/test/samplers.jl#L63

You can detect it at 6, but I found that you need to use `n=10^8` (I included a regression test in the PR which fails on master). At μ=7 it requires `n=10^9`, I didn't go further than that.

Note: I think you would expect performance regressions for this change for values of μ from 6 to 9, since `PoissonADSampler` should be faster down to 6.

