### PR TITLE
More flexible and less brittle `MvNormal` and `MvNormalCanon` type aliases

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.128"
+version = "0.25.129"
 
 [deps]
 AliasTables = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"

--- a/src/multivariate/mvlogitnormal.jl
+++ b/src/multivariate/mvlogitnormal.jl
@@ -29,6 +29,8 @@ end
 MvLogitNormal(d::AbstractMvNormal) = MvLogitNormal{typeof(d)}(d)
 MvLogitNormal(args...) = MvLogitNormal(MvNormal(args...))
 
+distrname(d::MvLogitNormal) = string("MvLogitNormal{", distrname(d.normal), "}")
+
 function Base.show(io::IO, d::MvLogitNormal; indent::String="  ")
     print(io, distrname(d))
     println(io, "(")

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -54,18 +54,6 @@ of any subtype of `AbstractPDMat`. Particularly, one can use `PDMat` for full co
 in the form of ``\\sigma^2 \\mathbf{I}``. (See the Julia package
 [PDMats](https://github.com/JuliaStats/PDMats.jl/) for details).
 
-We also define a set of aliases for the types using different combinations of mean vectors and covariance:
-
-```julia
-const IsoNormal  = MvNormal{Float64, ScalMat{Float64},                  Vector{Float64}}
-const DiagNormal = MvNormal{Float64, PDiagMat{Float64,Vector{Float64}}, Vector{Float64}}
-const FullNormal = MvNormal{Float64, PDMat{Float64,Matrix{Float64}},    Vector{Float64}}
-
-const ZeroMeanIsoNormal{Axes}  = MvNormal{Float64, ScalMat{Float64},                  Zeros{Float64,1,Axes}}
-const ZeroMeanDiagNormal{Axes} = MvNormal{Float64, PDiagMat{Float64,Vector{Float64}}, Zeros{Float64,1,Axes}}
-const ZeroMeanFullNormal{Axes} = MvNormal{Float64, PDMat{Float64,Matrix{Float64}},    Zeros{Float64,1,Axes}}
-```
-
 Multivariate normal distributions support affine transformations:
 ```julia
 d = MvNormal(μ, Σ)
@@ -169,13 +157,13 @@ end
 
 const MultivariateNormal = MvNormal  # for the purpose of backward compatibility
 
-const IsoNormal  = MvNormal{Float64,ScalMat{Float64},Vector{Float64}}
-const DiagNormal = MvNormal{Float64,PDiagMat{Float64,Vector{Float64}},Vector{Float64}}
-const FullNormal = MvNormal{Float64,PDMat{Float64,Matrix{Float64}},Vector{Float64}}
+const IsoNormal{T}  = MvNormal{T,<:ScalMat{T},<:AbstractVector{T}}
+const DiagNormal{T} = MvNormal{T,<:PDiagMat{T},<:AbstractVector{T}}
+const FullNormal{T} = MvNormal{T,<:PDMat{T},<:AbstractVector{T}}
 
-const ZeroMeanIsoNormal{Axes}  = MvNormal{Float64,ScalMat{Float64},Zeros{Float64,1,Axes}}
-const ZeroMeanDiagNormal{Axes} = MvNormal{Float64,PDiagMat{Float64,Vector{Float64}},Zeros{Float64,1,Axes}}
-const ZeroMeanFullNormal{Axes} = MvNormal{Float64,PDMat{Float64,Matrix{Float64}},Zeros{Float64,1,Axes}}
+const ZeroMeanIsoNormal{T}  = MvNormal{T,<:ScalMat{T},<:Zeros{T,1}}
+const ZeroMeanDiagNormal{T} = MvNormal{T,<:PDiagMat{T},<:Zeros{T,1}}
+const ZeroMeanFullNormal{T} = MvNormal{T,<:PDMat{T},<:Zeros{T,1}}
 
 ### Construction
 function MvNormal(μ::AbstractVector{T}, Σ::AbstractPDMat{T}) where {T<:Real}

--- a/src/multivariate/mvnormalcanon.jl
+++ b/src/multivariate/mvnormalcanon.jl
@@ -26,18 +26,6 @@ struct MvNormalCanon{T<:Real,P<:AbstractPDMat,V<:AbstractVector} <: AbstractMvNo
 end
 ```
 
-We also define aliases for common specializations of this parametric type:
-
-```julia
-const FullNormalCanon = MvNormalCanon{Float64, PDMat{Float64,Matrix{Float64}},    Vector{Float64}}
-const DiagNormalCanon = MvNormalCanon{Float64, PDiagMat{Float64,Vector{Float64}}, Vector{Float64}}
-const IsoNormalCanon  = MvNormalCanon{Float64, ScalMat{Float64},                  Vector{Float64}}
-
-const ZeroMeanFullNormalCanon{Axes} = MvNormalCanon{Float64, PDMat{Float64,Matrix{Float64}},    Zeros{Float64,1,Axes}}
-const ZeroMeanDiagNormalCanon{Axes} = MvNormalCanon{Float64, PDiagMat{Float64,Vector{Float64}}, Zeros{Float64,1,Axes}}
-const ZeroMeanIsoNormalCanon{Axes}  = MvNormalCanon{Float64, ScalMat{Float64},                  Zeros{Float64,1,Axes}}
-```
-
 **Note:** `MvNormalCanon` share the same set of methods as `MvNormal`.
 """
 struct MvNormalCanon{T<:Real,P<:AbstractPDMat,V<:AbstractVector} <: AbstractMvNormal
@@ -46,13 +34,13 @@ struct MvNormalCanon{T<:Real,P<:AbstractPDMat,V<:AbstractVector} <: AbstractMvNo
     J::P    # precision matrix, i.e. inv(Σ)
 end
 
-const FullNormalCanon = MvNormalCanon{Float64,PDMat{Float64,Matrix{Float64}},Vector{Float64}}
-const DiagNormalCanon = MvNormalCanon{Float64,PDiagMat{Float64,Vector{Float64}},Vector{Float64}}
-const IsoNormalCanon  = MvNormalCanon{Float64,ScalMat{Float64},Vector{Float64}}
+const FullNormalCanon{T} = MvNormalCanon{T,<:PDMat{T},<:AbstractVector{T}}
+const DiagNormalCanon{T} = MvNormalCanon{T,<:PDiagMat{T},<:AbstractVector{T}}
+const IsoNormalCanon{T}  = MvNormalCanon{T,<:ScalMat{T},<:AbstractVector{T}}
 
-const ZeroMeanFullNormalCanon{Axes} = MvNormalCanon{Float64,PDMat{Float64,Matrix{Float64}},Zeros{Float64,1,Axes}}
-const ZeroMeanDiagNormalCanon{Axes} = MvNormalCanon{Float64,PDiagMat{Float64,Vector{Float64}},Zeros{Float64,1,Axes}}
-const ZeroMeanIsoNormalCanon{Axes}  = MvNormalCanon{Float64,ScalMat{Float64},Zeros{Float64,1,Axes}}
+const ZeroMeanFullNormalCanon{T} = MvNormalCanon{T,<:PDMat{T},<:Zeros{T,1}}
+const ZeroMeanDiagNormalCanon{T} = MvNormalCanon{T,<:PDiagMat{T},<:Zeros{T,1}}
+const ZeroMeanIsoNormalCanon{T}  = MvNormalCanon{T,<:ScalMat{T},<:Zeros{T,1}}
 
 
 ### Constructors

--- a/test/mixture.jl
+++ b/test/mixture.jl
@@ -255,11 +255,11 @@ end
     @testset "Testing MultivariatevariateMixture" begin
         for T in (Float32, Float64)
             g_m = MixtureModel(
-                IsoNormal[ MvNormal([0.0, 0.0], I),
-                           MvNormal([0.2, 1.0], I),
-                           MvNormal([-0.5, -3.0], 1.6 * I) ],
+                [ MvNormal([0.0, 0.0], I),
+                  MvNormal([0.2, 1.0], I),
+                  MvNormal([-0.5, -3.0], 1.6 * I) ],
                 T[0.2, 0.5, 0.3])
-            @test isa(g_m, MixtureModel{Multivariate, Continuous, IsoNormal})
+            @test isa(g_m, MixtureModel{Multivariate, Continuous, <:IsoNormal})
             @test length(components(g_m)) == 3
             @test length(g_m) == 2
             @test insupport(g_m, [0.0, 0.0])


### PR DESCRIPTION
I always thought it's a bit weird that we mention these type aliases so prominently, even though they're only used for printing and dispatching in `fit_mle`.

Moreover, 1) they don't cover many multivariate normal distributions with dense/diagonal/identity covariance matrix and 2) they are a bit brittle as they rely on the exact type parameter structure in PDMats and FillArrays (which one could argue are not part of the public API).

