### PR TITLE
Initialize Dirichlet fitting without sample variable

### DIFF
--- a/src/multivariate/dirichlet.jl
+++ b/src/multivariate/dirichlet.jl
@@ -224,33 +224,38 @@ end
 
 ## Initialization
 
-function _dirichlet_mle_init2(μ::Vector{Float64}, γ::Vector{Float64})
+# initialization based on mean and log-mean
+# Ref https://tminka.github.io/papers/dirichlet/minka-dirichlet.pdf
+function _dirichlet_mle_init2(μ::Vector{Float64}, logμ::Vector{Float64})
     K = length(μ)
 
-    α0 = 0.
-    for k = 1:K
-        μk = μ[k]
-        γk = γ[k]
-        ak = (μk - γk) / (γk - μk * μk)
-        α0 += ak
-    end
-    α0 /= K
+    # Minka eq 42
+    α₀ = (K - 1) / 2 / sum(μₖ * (log(μₖ) - logμₖ) for (μₖ, logμₖ) in zip(μ, logμ))
 
-    lmul!(α0, μ)
+    # Run five iterations of a fixed point equation for good starting values
+    # Note! Minka doesn't suggest the number of iterations
+    for i = 1:5
+        for k = 1:K
+            # Minka eq 9
+            μ[k] = invdigamma(digamma(α₀) + logμ[k])
+        end
+        α₀ = sum(μ)
+    end
+
+    return μ
 end
 
 function dirichlet_mle_init(P::AbstractMatrix{Float64})
     K = size(P, 1)
     n = size(P, 2)
 
-    μ = vec(sum(P, dims=2))       # E[p]
-    γ = vec(sum(abs2, P, dims=2)) # E[p^2]
+    μ = vec(sum(P, dims=2))         # E[p]
+    logμ = vec(sum(log, P, dims=2)) # E[log(p)]
 
-    c = 1.0 / n
-    μ .*= c
-    γ .*= c
+    μ ./= n
+    logμ ./= n
 
-    _dirichlet_mle_init2(μ, γ)
+    return _dirichlet_mle_init2(μ, logμ)
 end
 
 function dirichlet_mle_init(P::AbstractMatrix{Float64}, w::AbstractArray{Float64})

--- a/src/multivariate/dirichlet.jl
+++ b/src/multivariate/dirichlet.jl
@@ -257,18 +257,6 @@ function _dirichlet_mle_init(μ::Vector{Float64}, logμ::Vector{Float64})
     return α
 end
 
-function dirichlet_mle_init(P::AbstractMatrix{Float64})
-    μ = vec(mean(P, dims=2))                     # E[p]
-    logμ = mean_logp(suffstats(Dirichlet, P))    # E[log(p)]
-    return _dirichlet_mle_init(μ, logμ)
-end
-
-function dirichlet_mle_init(P::AbstractMatrix{Float64}, w::AbstractArray{Float64})
-    μ = P * vec(w) ./ sum(w)                     # E[p]
-    logμ = mean_logp(suffstats(Dirichlet, P, w)) # E[log(p)]
-    return _dirichlet_mle_init(μ, logμ)
-end
-
 ## Newton-Ralphson algorithm
 
 function fit_dirichlet!(elogp::Vector{Float64}, α::Vector{Float64};

--- a/src/multivariate/dirichlet.jl
+++ b/src/multivariate/dirichlet.jl
@@ -225,31 +225,34 @@ end
 ## Initialization
 
 # Compute a starting value for the Newton iterations in `fit_dirichlet!` based on
-# the sample mean `μ = E[p]` and the sample log-mean `logμ = E[log(p)]`.
+# the sample mean `μ = E[p]` and the mean of the log-samples `elogp = E[log(p)]`.
+# The starting value is written into `μ`.
 # Ref https://tminka.github.io/papers/dirichlet/minka-dirichlet.pdf
-function _dirichlet_mle_init(μ::Vector{Float64}, logμ::Vector{Float64})
+function _dirichlet_mle_init!(μ::Vector{Float64}, elogp::Vector{Float64})
     K = length(μ)
 
     # Initialize the precision α₀ with the moment estimate in Minka eq 42. In contrast
     # to the estimates in Minka eq 21 and 23, it remains finite when some components
-    # of the sample have zero variance (see issue #602). By Jensen's inequality, the
-    # denominator is non-negative, and it is zero only if all samples are identical,
-    # in which case the MLE doesn't exist.
-    s = sum(μₖ * (log(μₖ) - logμₖ) for (μₖ, logμₖ) in zip(μ, logμ))
-    s > 0 || throw(ArgumentError(
-        "the samples are all identical so the MLE of the Dirichlet distribution doesn't exist"))
-    α₀ = (K - 1) / 2 / s
+    # of the sample have zero variance (see issue #602). In exact arithmetic, the
+    # denominator is non-negative by Jensen's inequality and zero only if all samples
+    # are identical, in which case the MLE doesn't exist. However, due to roundoff,
+    # the computed denominator can have either sign for (nearly) identical samples,
+    # so the check below cannot detect all such degenerate samples.
+    s = sum(μₖ * (log(μₖ) - elogpₖ) for (μₖ, elogpₖ) in zip(μ, elogp))
+    isfinite(s) && s > 0 || throw(ArgumentError(
+        "the samples are (nearly) identical or contain zeros so a starting value couldn't be computed"))
+    α₀ = (K - 1) / (2 * s)
 
     # Refine with a few iterations of the fixed point iteration in Minka eq 9. The
     # result is no longer a moment estimate but a starting value for the Newton
     # iterations in `fit_dirichlet!`. Minka doesn't suggest a specific number of
     # iterations but five appear to be sufficient to reach the region where the
-    # Newton iterations converge quadratically. The vector μ isn't needed anymore
-    # so we reuse it for the refined values.
-    α = μ
+    # Newton iterations converge quadratically.
+    α = μ  # the mean isn't needed anymore so we overwrite it with the refined values
     for _ in 1:5
+        dgα₀ = digamma(α₀)
         for k in 1:K
-            α[k] = invdigamma(digamma(α₀) + logμ[k])
+            α[k] = invdigamma(dgα₀ + elogp[k])
         end
         α₀ = sum(α)
     end
@@ -296,33 +299,38 @@ function fit_dirichlet!(elogp::Vector{Float64}, α::Vector{Float64};
             b += gk * iq[k]
             iqs += iq[k]
 
-            agk = abs(gk)
-            if agk > gnorm
-                gnorm = agk
-            end
+            # In contrast to the branch `abs(gk) > gnorm ? abs(gk) : gnorm`, `max`
+            # propagates NaNs so a NaN gradient fails the convergence check below
+            # instead of being silently ignored
+            gnorm = max(gnorm, abs(gk))
         end
-        b /= (iz + iqs)
-
-        # update α
-
-        for k = 1:K
-            α[k] -= (g[k] - b) * iq[k]
-            if α[k] < 1.0e-12
-                α[k] = 1.0e-12
-            end
-        end
-        α0 = sum(α)
-
-        if debug
-            prev_objv = objv
-            objv = dot(α .- 1.0, elogp) + loggamma(α0) - sum(loggamma, α)
-            @printf("Iter %4d: objv = %.4e  ch = %.3e  gnorm = %.3e\n",
-                t, objv, objv - prev_objv, gnorm)
-        end
-
-        # determine convergence
-
+        # Determine convergence before updating α so that the returned iterate is the
+        # one that satisfied the convergence criterion. An additional Newton update
+        # from an already converged iterate with very large elements could produce
+        # non-finite values because the denominator of b, which approaches (K - 1)/2
+        # as the elements of α grow, is then dominated by cancellation errors
         converged = gnorm < tol
+
+        if !converged
+            b /= (iz + iqs)
+
+            # update α
+
+            for k = 1:K
+                α[k] -= (g[k] - b) * iq[k]
+                if α[k] < 1.0e-12
+                    α[k] = 1.0e-12
+                end
+            end
+            α0 = sum(α)
+
+            if debug
+                prev_objv = objv
+                objv = dot(α .- 1.0, elogp) + loggamma(α0) - sum(loggamma, α)
+                @printf("Iter %4d: objv = %.4e  ch = %.3e  gnorm = %.3e\n",
+                    t, objv, objv - prev_objv, gnorm)
+            end
+        end
     end
 
     if !converged
@@ -338,7 +346,7 @@ function fit_mle(::Type{T}, P::AbstractMatrix{Float64};
     debug::Bool=false) where {T<:Dirichlet}
 
     elogp = mean_logp(suffstats(T, P))
-    α = isempty(init) ? _dirichlet_mle_init(vec(mean(P, dims=2)), elogp) : init
+    α = isempty(init) ? _dirichlet_mle_init!(vec(mean(P, dims=2)), elogp) : init
     fit_dirichlet!(elogp, α; maxiter=maxiter, tol=tol, debug=debug)
 end
 
@@ -350,7 +358,8 @@ function fit_mle(::Type{<:Dirichlet}, P::AbstractMatrix{Float64},
     n = size(P, 2)
     length(w) == n || throw(DimensionMismatch("Inconsistent argument dimensions."))
 
-    elogp = mean_logp(suffstats(Dirichlet, P, w))
-    α = isempty(init) ? _dirichlet_mle_init(P * vec(w) ./ sum(w), elogp) : init
+    ss = suffstats(Dirichlet, P, w)
+    elogp = mean_logp(ss)
+    α = isempty(init) ? _dirichlet_mle_init!(P * vec(w) ./ ss.tw, elogp) : init
     fit_dirichlet!(elogp, α; maxiter=maxiter, tol=tol, debug=debug)
 end

--- a/src/multivariate/dirichlet.jl
+++ b/src/multivariate/dirichlet.jl
@@ -224,63 +224,49 @@ end
 
 ## Initialization
 
-# initialization based on mean and log-mean
+# Compute a starting value for the Newton iterations in `fit_dirichlet!` based on
+# the sample mean `μ = E[p]` and the sample log-mean `logμ = E[log(p)]`.
 # Ref https://tminka.github.io/papers/dirichlet/minka-dirichlet.pdf
-function _dirichlet_mle_init2(μ::Vector{Float64}, logμ::Vector{Float64})
+function _dirichlet_mle_init(μ::Vector{Float64}, logμ::Vector{Float64})
     K = length(μ)
 
-    # Minka eq 42
-    α₀ = (K - 1) / 2 / sum(μₖ * (log(μₖ) - logμₖ) for (μₖ, logμₖ) in zip(μ, logμ))
+    # Initialize the precision α₀ with the moment estimate in Minka eq 42. In contrast
+    # to the estimates in Minka eq 21 and 23, it remains finite when some components
+    # of the sample have zero variance (see issue #602). By Jensen's inequality, the
+    # denominator is non-negative, and it is zero only if all samples are identical,
+    # in which case the MLE doesn't exist.
+    s = sum(μₖ * (log(μₖ) - logμₖ) for (μₖ, logμₖ) in zip(μ, logμ))
+    s > 0 || throw(ArgumentError(
+        "the samples are all identical so the MLE of the Dirichlet distribution doesn't exist"))
+    α₀ = (K - 1) / 2 / s
 
-    # Run five iterations of a fixed point equation for good starting values
-    # Note! Minka doesn't suggest the number of iterations
-    for i = 1:5
-        for k = 1:K
-            # Minka eq 9
-            μ[k] = invdigamma(digamma(α₀) + logμ[k])
+    # Refine with a few iterations of the fixed point iteration in Minka eq 9. The
+    # result is no longer a moment estimate but a starting value for the Newton
+    # iterations in `fit_dirichlet!`. Minka doesn't suggest a specific number of
+    # iterations but five appear to be sufficient to reach the region where the
+    # Newton iterations converge quadratically. The vector μ isn't needed anymore
+    # so we reuse it for the refined values.
+    α = μ
+    for _ in 1:5
+        for k in 1:K
+            α[k] = invdigamma(digamma(α₀) + logμ[k])
         end
-        α₀ = sum(μ)
+        α₀ = sum(α)
     end
 
-    return μ
+    return α
 end
 
 function dirichlet_mle_init(P::AbstractMatrix{Float64})
-    K = size(P, 1)
-    n = size(P, 2)
-
-    μ = vec(sum(P, dims=2))         # E[p]
-    logμ = vec(sum(log, P, dims=2)) # E[log(p)]
-
-    μ ./= n
-    logμ ./= n
-
-    return _dirichlet_mle_init2(μ, logμ)
+    μ = vec(mean(P, dims=2))                     # E[p]
+    logμ = mean_logp(suffstats(Dirichlet, P))    # E[log(p)]
+    return _dirichlet_mle_init(μ, logμ)
 end
 
 function dirichlet_mle_init(P::AbstractMatrix{Float64}, w::AbstractArray{Float64})
-    K = size(P, 1)
-    n = size(P, 2)
-
-    μ = zeros(K)  # E[p]
-    γ = zeros(K)  # E[p^2]
-    tw = 0.0
-
-    for i in 1:n
-        wi = w[i]
-        tw += wi
-        for k in 1:K
-            pk = P[k, i]
-            μ[k] += pk * wi
-            γ[k] += pk * pk * wi
-        end
-    end
-
-    c = 1.0 / tw
-    μ .*= c
-    γ .*= c
-
-    _dirichlet_mle_init2(μ, γ)
+    μ = P * vec(w) ./ sum(w)                     # E[p]
+    logμ = mean_logp(suffstats(Dirichlet, P, w)) # E[log(p)]
+    return _dirichlet_mle_init(μ, logμ)
 end
 
 ## Newton-Ralphson algorithm
@@ -363,8 +349,8 @@ function fit_mle(::Type{T}, P::AbstractMatrix{Float64};
     init::Vector{Float64}=Float64[], maxiter::Int=25, tol::Float64=1.0e-12,
     debug::Bool=false) where {T<:Dirichlet}
 
-    α = isempty(init) ? dirichlet_mle_init(P) : init
     elogp = mean_logp(suffstats(T, P))
+    α = isempty(init) ? _dirichlet_mle_init(vec(mean(P, dims=2)), elogp) : init
     fit_dirichlet!(elogp, α; maxiter=maxiter, tol=tol, debug=debug)
 end
 
@@ -376,7 +362,7 @@ function fit_mle(::Type{<:Dirichlet}, P::AbstractMatrix{Float64},
     n = size(P, 2)
     length(w) == n || throw(DimensionMismatch("Inconsistent argument dimensions."))
 
-    α = isempty(init) ? dirichlet_mle_init(P, w) : init
     elogp = mean_logp(suffstats(Dirichlet, P, w))
+    α = isempty(init) ? _dirichlet_mle_init(P * vec(w) ./ sum(w), elogp) : init
     fit_dirichlet!(elogp, α; maxiter=maxiter, tol=tol, debug=debug)
 end

--- a/test/multivariate/dirichlet.jl
+++ b/test/multivariate/dirichlet.jl
@@ -160,3 +160,14 @@ end
         end
     end
 end
+
+@testset "zero sample variance. Issue 602" begin
+    X = [
+        0.1 0.1
+        0.5 0.3
+        0.4 0.6
+    ]
+    @test all(isfinite, Distributions.dirichlet_mle_init(X))
+    ft = fit_mle(Dirichlet, X)
+    @test ft.alpha ≈ [4.818417154882677, 17.25974156242572, 21.70076086163771]
+end

--- a/test/multivariate/dirichlet.jl
+++ b/test/multivariate/dirichlet.jl
@@ -167,7 +167,9 @@ end
         0.5 0.3
         0.4 0.6
     ]
-    @test all(isfinite, Distributions.dirichlet_mle_init(X))
+    μ = vec(mean(X, dims=2))
+    logμ = vec(mean(log, X, dims=2))
+    @test all(isfinite, Distributions._dirichlet_mle_init(μ, logμ))
     ft = fit_mle(Dirichlet, X)
     @test ft.alpha ≈ [4.818417154882677, 17.25974156242572, 21.70076086163771]
 

--- a/test/multivariate/dirichlet.jl
+++ b/test/multivariate/dirichlet.jl
@@ -168,8 +168,8 @@ end
         0.4 0.6
     ]
     μ = vec(mean(X, dims=2))
-    logμ = vec(mean(log, X, dims=2))
-    @test all(isfinite, Distributions._dirichlet_mle_init(μ, logμ))
+    elogp = vec(mean(log, X, dims=2))
+    @test all(isfinite, Distributions._dirichlet_mle_init!(μ, elogp))
     ft = fit_mle(Dirichlet, X)
     @test ft.alpha ≈ [4.818417154882677, 17.25974156242572, 21.70076086163771]
 
@@ -177,7 +177,23 @@ end
     ftw = fit_mle(Dirichlet, X, fill(2.0, size(X, 2)))
     @test ftw.alpha ≈ ft.alpha
 
-    # The MLE doesn't exist when all samples are identical
-    @test_throws ArgumentError fit_mle(Dirichlet, X[:, [1, 1]])
-    @test_throws ArgumentError fit_mle(Dirichlet, X[:, 1:1])
+    # The MLE doesn't exist when all samples are identical but due to roundoff the
+    # degenerate samples can't be detected reliably, so the fit is only guaranteed
+    # to either throw or return a finite estimate
+    for n in 1:12
+        Xdegenerate = repeat([0.1, 0.5, 0.4], 1, n)
+        result = try
+            fit_mle(Dirichlet, Xdegenerate)
+        catch e
+            e
+        end
+        if result isa Dirichlet
+            @test all(αₖ -> isfinite(αₖ) && αₖ > 0, result.alpha)
+        else
+            @test result isa Union{ArgumentError, ErrorException}
+        end
+    end
+
+    # Zero entries are invalid and should throw instead of returning NaN estimates
+    @test_throws ArgumentError fit_mle(Dirichlet, [0.0 0.2 0.3; 0.5 0.3 0.3; 0.5 0.5 0.4])
 end

--- a/test/multivariate/dirichlet.jl
+++ b/test/multivariate/dirichlet.jl
@@ -118,8 +118,8 @@ rng = MersenneTwister(123)
         r = fit(Dirichlet{Float32}, x)
         @test r.alpha ≈ d.alpha atol=0.25
 
-        # r = fit_mle(Dirichlet, x, fill(2.0, n))
-        # @test r.alpha ≈ d.alpha atol=0.25
+        r = fit_mle(Dirichlet, x, fill(2.0, n))
+        @test r.alpha ≈ d.alpha atol=0.25
     end
 end
 
@@ -170,4 +170,12 @@ end
     @test all(isfinite, Distributions.dirichlet_mle_init(X))
     ft = fit_mle(Dirichlet, X)
     @test ft.alpha ≈ [4.818417154882677, 17.25974156242572, 21.70076086163771]
+
+    # Uniform weights should give the same estimate as the unweighted fit
+    ftw = fit_mle(Dirichlet, X, fill(2.0, size(X, 2)))
+    @test ftw.alpha ≈ ft.alpha
+
+    # The MLE doesn't exist when all samples are identical
+    @test_throws ArgumentError fit_mle(Dirichlet, X[:, [1, 1]])
+    @test_throws ArgumentError fit_mle(Dirichlet, X[:, 1:1])
 end


### PR DESCRIPTION
This avoids dividing by zero. The new initialization is based on the paper by Thomas Minka linked in the comment. This is an alternative to https://github.com/JuliaStats/Distributions.jl/pull/610 based on some of the ideas in the paper. It also avoids the extra allocation. Of course, at the cost of some special function evaluations.

Fixes #602