### PR TITLE
Remove unneeded methods for `EachVariate`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.129"
+version = "0.25.130"
 
 [deps]
 AliasTables = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"

--- a/src/eachvariate.jl
+++ b/src/eachvariate.jl
@@ -11,12 +11,9 @@ function EachVariate{V}(x::AbstractArray{<:Real,M}) where {V,M}
     return EachVariate{V,typeof(x),typeof(ax),T,M-V}(x, ax)
 end
 
-Base.IteratorSize(::Type{EachVariate{V,P,A,T,N}}) where {V,P,A,T,N} = Base.HasShape{N}()
-
 Base.axes(x::EachVariate) = x.axes
 
 Base.size(x::EachVariate) = map(length, x.axes)
-Base.size(x::EachVariate, d::Int) = 1 <= ndims(x) ? length(axes(x)[d]) : 1
 
 # We don't need `setindex!` (currently), therefore only `getindex` is implemented
 Base.@propagate_inbounds function Base.getindex(


### PR DESCRIPTION
These already have generic definitions in Base. The `size()` method also had a bug where it checked `1 <= ndims(x)` instead of `d < ndims(x)`.

Should fix these invalidations seen when loading CurveFit.jl on 1.13:
```julia
 inserting size(x::Distributions.EachVariate, d::Int64) @ Distributions ~/.julia/packages/Distributions/XAng5/src/eachvariate.jl:19 invalidated:                                                                                               
   mt_backedges: 1: signature Tuple{typeof(size), Union{ForwardDiff.Dual{T, V, P}, AbstractArray{<:ForwardDiff.Dual{T, V, P}}} where {T, V, P}, Int64} triggered MethodInstance for issquare(::Union{ForwardDiff.Dual{T, V, P}, AbstractArray{<:ForwardDiff.Dual{T, V, P}}} where {T, V, P}) (0 children)
   backedges: 1: superseding size(t::AbstractArray, dim) @ Base abstractarray.jl:42 with MethodInstance for size(::Union{AbstractArray{<:ForwardDiff.Dual{T, V, P}} where P, AbstractArray{T1} where {P, T1<:ForwardDiff.Dual{T, V, P}}} where {T, V}, ::Int64) (3 children)
              2: superseding size(t::AbstractArray, dim) @ Base abstractarray.jl:42 with MethodInstance for size(::AbstractVecOrMat, ::Int64) (9 children)
              3: superseding size(t::AbstractArray, dim) @ Base abstractarray.jl:42 with MethodInstance for size(::AbstractVector, ::Int64) (13 children)
              4: superseding size(t::AbstractArray, dim) @ Base abstractarray.jl:42 with MethodInstance for size(::AbstractArray, ::Int64) (30 children)
              5: superseding size(t::AbstractArray, dim) @ Base abstractarray.jl:42 with MethodInstance for size(::AbstractMatrix, ::Int64) (46 children)
```