### PR TITLE
Accept any `AbstractVecOrMat` when sampling from an `MvNormal`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.130"
+version = "0.25.131"
 
 [deps]
 AliasTables = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"

--- a/src/multivariate/mvnormal.jl
+++ b/src/multivariate/mvnormal.jl
@@ -256,18 +256,8 @@ gradlogpdf(d::MvNormal, x::AbstractVector{<:Real}) = -(d.Σ \ (x .- d.μ))
 
 # Sampling (for GenericMvNormal)
 
-function _rand!(rng::AbstractRNG, d::MvNormal, x::VecOrMat)
+function _rand!(rng::AbstractRNG, d::MvNormal, x::AbstractVecOrMat)
     unwhiten!(d.Σ, randn!(rng, x))
-    x .+= d.μ
-    return x
-end
-
-# Workaround: randn! only works for Array, but not generally for AbstractArray
-function _rand!(rng::AbstractRNG, d::MvNormal, x::AbstractVector)
-    for i in eachindex(x)
-        x[i] = randn(rng, eltype(x))
-    end
-    unwhiten!(d.Σ, x)
     x .+= d.μ
     return x
 end

--- a/test/multivariate/mvnormal.jl
+++ b/test/multivariate/mvnormal.jl
@@ -304,30 +304,45 @@ end
     @test logpdf(d, x) ≈ logpdf(Normal(), x[1]) + logpdf(Normal(), x[2])
 end
 
-@testset "MvNormal: Sampling into an AbstractMatrix (#2086)" begin
-    d = MvNormal([1.0, 2.0, 3.0], [4.0 -2.0 -1.0; -2.0 5.0 -1.0; -1.0 -1.0 6.0])
+@testset "MvNormal: Sampling into an AbstractVecOrMat (#2086)" begin
+    μ = [1.0, 2.0, 3.0]
+    C = [4.0 -2.0 -1.0; -2.0 5.0 -1.0; -1.0 -1.0 6.0]
 
-    x = Matrix{Float64}(undef, 3, 10)
-    rand!(StableRNG(1234), d, x)
+    Σs = (PDMat(C), PDiagMat([1.2, 3.4, 2.6]), ScalMat(3, 2.0))
+    @testset "$(nameof(typeof(Σ)))" for Σ in Σs
+        d = MvNormal(μ, Σ)
+        x = rand!(StableRNG(1234), d, Matrix{Float64}(undef, 3, 6))
 
-    # a view of the whole matrix takes the same code path as the matrix itself, so the
-    # samples are identical and not merely approximately equal
-    y = Matrix{Float64}(undef, 3, 10)
-    rand!(StableRNG(1234), d, view(y, :, :))
-    @test y == x
+        # A view of a whole matrix takes the same single `randn!` and `unwhiten!` call as
+        # the matrix, so the samples are exactly equal. Only RNGs without a bulk `randn!`
+        # method give exact equality: the ones in `Random` are defined for
+        # `MersenneTwister`/`Xoshiro` and `Array{Float64}`, which a view is not.
+        y = Matrix{Float64}(undef, 3, 6)
+        rand!(StableRNG(1234), d, view(y, :, :))
+        @test y == x
 
-    # sampling into the columns one at a time draws the same normals, and hence agrees up to
-    # the rounding of the multiplication with the Cholesky factor
-    z = Matrix{Float64}(undef, 3, 10)
-    rng = StableRNG(1234)
-    for i in axes(z, 2)
-        rand!(rng, d, view(z, :, i))
+        # A view of some columns is filled like a matrix of the same size, and no other
+        # column is touched.
+        y = zeros(3, 6)
+        rand!(StableRNG(1234), d, view(y, :, 3:4))
+        @test y[:, 3:4] ≈ rand!(StableRNG(1234), d, Matrix{Float64}(undef, 3, 2))
+        @test all(iszero, y[:, [1, 2, 5, 6]])
+
+        # The same for a view that is not strided, for which `unwhiten!` cannot use BLAS.
+        y = zeros(3, 6)
+        rand!(StableRNG(1234), d, view(y, :, [1, 3, 5]))
+        @test y[:, [1, 3, 5]] ≈ rand!(StableRNG(1234), d, Matrix{Float64}(undef, 3, 3))
+        @test all(iszero, y[:, [2, 4, 6]])
+
+        # Vectors do not need a separate method: `randn!` is generic.
+        y = zeros(3, 2)
+        rand!(StableRNG(1234), d, view(y, :, 1))
+        @test y[:, 1] ≈ rand!(StableRNG(1234), d, Vector{Float64}(undef, 3))
+        @test all(iszero, y[:, 2])
+
+        # A view without columns draws nothing.
+        y = zeros(3, 6)
+        rand!(StableRNG(1234), d, view(y, :, 1:0))
+        @test all(iszero, y)
     end
-    @test z ≈ x
-
-    # only the columns of the view are modified
-    w = zeros(3, 10)
-    rand!(StableRNG(1234), d, view(w, :, 1:4))
-    @test w[:, 1:4] ≈ x[:, 1:4]
-    @test all(iszero, w[:, 5:10])
 end

--- a/test/multivariate/mvnormal.jl
+++ b/test/multivariate/mvnormal.jl
@@ -9,6 +9,7 @@ using Distributions
 using LinearAlgebra, Random, Test
 using SparseArrays
 using FillArrays
+using StableRNGs
 
 ###### General Testing
 
@@ -301,4 +302,32 @@ end
     # (bug fixed by https://github.com/JuliaStats/Distributions.jl/pull/1429)
     x = rand(d)
     @test logpdf(d, x) ≈ logpdf(Normal(), x[1]) + logpdf(Normal(), x[2])
+end
+
+@testset "MvNormal: Sampling into an AbstractMatrix (#2086)" begin
+    d = MvNormal([1.0, 2.0, 3.0], [4.0 -2.0 -1.0; -2.0 5.0 -1.0; -1.0 -1.0 6.0])
+
+    x = Matrix{Float64}(undef, 3, 10)
+    rand!(StableRNG(1234), d, x)
+
+    # a view of the whole matrix takes the same code path as the matrix itself, so the
+    # samples are identical and not merely approximately equal
+    y = Matrix{Float64}(undef, 3, 10)
+    rand!(StableRNG(1234), d, view(y, :, :))
+    @test y == x
+
+    # sampling into the columns one at a time draws the same normals, and hence agrees up to
+    # the rounding of the multiplication with the Cholesky factor
+    z = Matrix{Float64}(undef, 3, 10)
+    rng = StableRNG(1234)
+    for i in axes(z, 2)
+        rand!(rng, d, view(z, :, i))
+    end
+    @test z ≈ x
+
+    # only the columns of the view are modified
+    w = zeros(3, 10)
+    rand!(StableRNG(1234), d, view(w, :, 1:4))
+    @test w[:, 1:4] ≈ x[:, 1:4]
+    @test all(iszero, w[:, 5:10])
 end


### PR DESCRIPTION
Fixes #2086.

`_rand!` for `MvNormal` was defined for `VecOrMat === Union{Vector,Matrix}`, so any other `AbstractMatrix` — a `view`, most commonly — missed it and fell back to the generic `eachvariate` method in `genericrand.jl`, which draws column by column. That replaced one `randn!` and one BLAS-3 `unwhiten!` with `size(x, 2)` scalar `randn` loops and `size(x, 2)` BLAS-2 `unwhiten!` calls.

This widens the signature to `AbstractVecOrMat` and drops the separate scalar-loop method for `AbstractVector`, whose comment — *"randn! only works for Array, but not generally for AbstractArray"* — no longer holds: `randn!` has a generic `AbstractArray` method on every Julia version this package supports (`julia = "1.10"`), and `MvNormalCanon` and `GenericMvTDist` already accept an `AbstractMatrix` and rely on it.

For a 10×1000 draw with a dense covariance matrix:

| | before | after |
| --- | --- | --- |
| `MvNormal`, `Matrix` | 21.416 μs | 21.416 μs |
| `MvNormal`, `view` | 115.583 μs | 43.375 μs |
| `MvLogNormal`, `view` | 149.625 μs | 76.417 μs |

`MvLogNormal` follows because it takes an `AbstractVecOrMat` and forwards into `MvNormal`. The view path now sits level with `MvNormalCanon`'s (45.875 μs), which already had the wider signature.

Behaviour:

- `Vector` and `Matrix` arguments keep the body they already dispatched to; a seeded `Matrix` draw hashes identically before and after.
- For other `AbstractVecOrMat` the drawn normals are unchanged, since the generic `randn!` walks `eachindex` in the same column-major order the per-column loop did. Only `unwhiten!` moves from `size(x, 2)` BLAS-2 calls to one BLAS-3 call, which is bit-identical for a `PDiagMat` and differs at the rounding level for a `PDMat` (`maxdiff = 8.9e-16` on a 6×40 draw).
- `Test.detect_ambiguities(Distributions; recursive = true)` stays at 0. `(MvNormal, AbstractVecOrMat)` is strictly more specific than `(Sampleable{<:ArrayLikeVariate}, AbstractArray)` in both arguments.
- `PDMats`' `unwhiten!` is already declared for `AbstractVecOrMat` throughout, so no companion change is needed.
- `MvLogitNormal` is affected beyond the view case. Its `_rand!` passes `@views _drop1(x)` into `rand!(rng, d.normal, …)`, i.e. always a `SubArray`, so even a plain `Matrix` draw moves from the column loop to the bulk path and its output changes at the rounding level in the common case.

Since the change is behaviour-preserving up to rounding, the testset can only do so much. The one assertion that fails on `master` is that sampling into a view of a whole matrix gives *exactly* the same samples as sampling into the matrix, and it fails there through the rounding difference between one BLAS-3 `unwhiten!` and one BLAS-2 call per column (`maxdiff = 4.4e-16` for the covariance matrix used). The remaining assertions guard against breakage rather than proving that the bulk path is taken: a view of some columns is filled like a matrix of the same size and nothing outside it is written, for a `PDMat`, a `PDiagMat` and a `ScalMat`, for a view that is not strided and hence cannot use BLAS in `unwhiten!`, for a single column in place of the removed `AbstractVector` method, and for a view without columns.

That exact equality holds only because `StableRNG` has no bulk `randn!`. The ones in `Random` are defined for `MersenneTwister`/`Xoshiro` *and* `Array{Float64}`, and a view satisfies neither, so with those RNGs a `Matrix` and a view draw different streams by design, both before and after this PR. This is also the residual performance gap between the two, and it is a Julia-level matter that is not addressed here.

---

This pull request was written with the assistance of generative AI (Claude Code).

