### PR TITLE
Use BTRS instead of BTPE for binomial sampling

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-      - run: 'using Pkg; Pkg.instantiate()'
+      - run: 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
         shell: julia --color=yes --project=perf {0}
       - run: julia --color=yes --project=perf perf/samplers.jl
       - uses: julia-actions/julia-processcoverage@v1

--- a/perf/samplers.jl
+++ b/perf/samplers.jl
@@ -35,13 +35,12 @@ end
 if haskey(ENV, "binomial") && ENV["binomial"] != "skip"
     @info "Binomial"
     
-    import Distributions: BinomialAliasSampler, BinomialGeomSampler, BinomialTPESampler, BinomialTRSSampler, BinomialTRSBatchSampler
+    import Distributions: BinomialAliasSampler, BinomialGeomSampler, BinomialTPESampler, BinomialTRSSampler
     
     for ST in [BinomialAliasSampler,
                    BinomialGeomSampler, 
                    BinomialTPESampler, 
-                   BinomialTRSSampler,
-                   BinomialTRSBatchSampler]
+                   BinomialTRSSampler]
         mt = Random.MersenneTwister(33)
         @info string(ST)
         nvals = haskey(ENV, "CI") ? [2] : 2 .^ (1:12)

--- a/perf/samplers.jl
+++ b/perf/samplers.jl
@@ -35,12 +35,13 @@ end
 if haskey(ENV, "binomial") && ENV["binomial"] != "skip"
     @info "Binomial"
     
-    import Distributions: BinomialAliasSampler, BinomialGeomSampler, BinomialTPESampler, BinomialTRSSampler
+    import Distributions: BinomialAliasSampler, BinomialGeomSampler, BinomialTPESampler, BinomialTRSSampler, BinomialTRSBatchSampler
     
     for ST in [BinomialAliasSampler,
                    BinomialGeomSampler, 
                    BinomialTPESampler, 
-                   BinomialTRSSampler]
+                   BinomialTRSSampler,
+                   BinomialTRSBatchSampler]
         mt = Random.MersenneTwister(33)
         @info string(ST)
         nvals = haskey(ENV, "CI") ? [2] : 2 .^ (1:12)

--- a/perf/samplers.jl
+++ b/perf/samplers.jl
@@ -35,12 +35,12 @@ end
 if haskey(ENV, "binomial") && ENV["binomial"] != "skip"
     @info "Binomial"
     
-    import Distributions: BinomialAliasSampler, BinomialGeomSampler, BinomialTPESampler, BinomialPolySampler
+    import Distributions: BinomialAliasSampler, BinomialGeomSampler, BinomialTPESampler, BinomialTRSSampler
     
     for ST in [BinomialAliasSampler,
                    BinomialGeomSampler, 
                    BinomialTPESampler, 
-                   BinomialPolySampler]
+                   BinomialTRSSampler]
         mt = Random.MersenneTwister(33)
         @info string(ST)
         nvals = haskey(ENV, "CI") ? [2] : 2 .^ (1:12)

--- a/src/samplers/binomial.jl
+++ b/src/samplers/binomial.jl
@@ -265,21 +265,41 @@ function BinomialTRSSampler(n::Int, prob::Float64)
     BinomialTRSSampler(comp, n, a, b, c, v_r, p/q, α, m)
 end
 
-function rand(rng::AbstractRNG, s::BinomialTRSSampler)
-    (; comp, n, a, b, r, m) = s
+struct BinomialTRSBatchSampler <: Sampleable{Univariate,Discrete}
+    s::BinomialTRSSampler
+    ub_m::Float64
+end
+
+function trs_ub_m(s::BinomialTRSSampler)
+    (; n, r, m) = s
+    return (m + 0.5) * log((m + 1) / (r * (n - m + 1))) +
+           (n + 1) * log(n - m + 1.0) +
+           lstirling_asym(m + 1) + lstirling_asym(n - m + 1)
+end
+trs_ub_m(s::BinomialTRSBatchSampler) = s.ub_m
+
+trs_sampler(s::BinomialTRSSampler) = s
+trs_sampler(s::BinomialTRSBatchSampler) = s.s
+
+function BinomialTRSBatchSampler(n::Int, prob::Float64)
+    s = BinomialTRSSampler(n, prob)
+    return BinomialTRSBatchSampler(s, trs_ub_m(s))
+end
+
+function rand(rng::AbstractRNG, s::Union{BinomialTRSSampler,BinomialTRSBatchSampler})
+    t = trs_sampler(s)
+    (; comp, n, a, b, r) = t
     while true
         u = rand(rng) - 0.5
         v = rand(rng)
         us = 0.5 - abs(u)
-        kf = (2 * a / us + b) * u + s.c
+        kf = (2 * a / us + b) * u + t.c
         (kf < 0.0 || kf >= n + 1) && continue
         k = floor(Int, kf)
-        (us >= 0.07 && v <= s.v_r) && return comp ? n - k : k
-        v = log(v * s.α / (a / (us * us) + b))
-        ub = (m + 0.5) * log((m + 1) / (r * (n - m + 1))) +
-             (n + 1) * log((n - m + 1) / (n - k + 1)) +
-             (k + 0.5) * log(r * (n - k + 1) / (k + 1)) +
-             lstirling_asym(m + 1) + lstirling_asym(n - m + 1) -
+        (us >= 0.07 && v <= t.v_r) && return comp ? n - k : k
+        v = log(v * t.α / (a / (us * us) + b))
+        ub = trs_ub_m(s) - (n + 1) * log(n - k + 1) +
+             (k + 0.5) * log(r * (n - k + 1) / (k + 1)) -
              lstirling_asym(k + 1) - lstirling_asym(n - k + 1)
         v <= ub && return comp ? n - k : k
     end

--- a/src/samplers/binomial.jl
+++ b/src/samplers/binomial.jl
@@ -228,6 +228,74 @@ function rand(rng::AbstractRNG, s::BinomialTPESampler)
     (s.comp ? s.n - y : y)::Int
 end
 
+#=
+BTRS algorithm from:
+
+W. Hörmann
+"The generation of binomial random variates"
+Journal of Statistical Computation and Simulation, 46(1-2):101-110
+doi:10.1080/00949659308811496
+=#
+# Valid only for n * min(p, 1-p) >= 10
+struct BinomialTRSSampler{T <: AbstractFloat} <: Sampleable{Univariate,Discrete}
+    n::Int
+    a::T
+    b::T
+    c::T
+    v_r::T
+    r::T
+    α::T
+    m::Int
+end
+
+function BinomialTRSSampler{T}(n::Int, prob::Real) where {T<:AbstractFloat}
+    p = T(prob)
+    q = one(T) - p
+    n * min(p, q) >= 10 || throw(ArgumentError("BinomialTRSSampler requires n * min(p, 1-p) >= 10"))
+    spq = sqrt(T(n) * p * q)
+    b = T(1.15) + T(2.53) * spq
+    a = T(-0.0873) + T(0.0248) * b + T(0.01) * p
+    c = T(n) * p + T(0.5)
+    v_r = T(0.92) - T(4.2) / b
+    α = (T(2.83) + T(5.1) / b) * spq
+    m = floor(Int, (T(n) + one(T)) * p)
+    BinomialTRSSampler{T}(n, a, b, c, v_r, p/q, α, m)
+end
+
+
+BinomialTRSSampler(n::Int, prob::Float64) = BinomialTRSSampler{Float64}(n, prob)
+
+@inline function binom_stirling_tail(::Type{T}, k::Int) where {T<:AbstractFloat}
+    if k < 10
+        tbl = (0.0810614667953272, 0.0413406959554093, 0.0276779256849983,
+               0.0207906721037650, 0.0166446911898211, 0.0138761288230707,
+               0.0118967099458917, 0.0104112652619720, 0.00925546218271273,
+               0.00833056343336287)
+        return T(@inbounds tbl[k + 1])
+    end
+    kp1sq = (T(k) + one(T))^2
+    return (T(1//12) - (T(1//360) - T(1//1260) / kp1sq) / kp1sq) / (T(k) + one(T))
+end
+
+function rand(rng::AbstractRNG, s::BinomialTRSSampler{T}) where {T}
+    (; n, a, b, r, m) = s
+    while true
+        u = rand(rng, T) - T(1/2)
+        v = rand(rng, T)
+        us = T(1/2) - abs(u)
+        kf = (T(2) * a / us + b) * u + s.c
+        (kf < zero(T) || kf > T(n)) && continue
+        k = floor(Int, kf)
+        (us >= T(0.07) && v <= s.v_r) && return k
+        v = log(v * s.α / (a / (us * us) + b))
+        ub = (T(m) + T(1/2)) * log((T(m) + one(T)) / (r * T(n-m+1))) +
+             (T(n) + one(T)) * log(T(n-m+1) / T(n-k+1)) +
+             (T(k) + T(1/2)) * log(r*T(n-k+1) / (T(k) + one(T))) +
+             binom_stirling_tail(T, m) + binom_stirling_tail(T, n-m) -
+             binom_stirling_tail(T, k) - binom_stirling_tail(T, n-k)
+        v <= ub && return k
+    end
+end
 
 # Constructing an alias table by directly computing the probability vector
 #

--- a/src/samplers/binomial.jl
+++ b/src/samplers/binomial.jl
@@ -235,65 +235,53 @@ W. Hörmann
 "The generation of binomial random variates"
 Journal of Statistical Computation and Simulation, 46(1-2):101-110
 doi:10.1080/00949659308811496
+
+Valid only for n * min(p, 1-p) >= 10
 =#
-# Valid only for n * min(p, 1-p) >= 10
-struct BinomialTRSSampler{T <: AbstractFloat} <: Sampleable{Univariate,Discrete}
+struct BinomialTRSSampler <: Sampleable{Univariate,Discrete}
+    comp::Bool
     n::Int
-    a::T
-    b::T
-    c::T
-    v_r::T
-    r::T
-    α::T
-    m::Int
+    a::Float64
+    b::Float64
+    c::Float64   # n*p + 0.5
+    v_r::Float64
+    r::Float64   # p / q
+    α::Float64
+    m::Int       # floor((n+1)*p)
 end
 
-function BinomialTRSSampler{T}(n::Int, prob::Real) where {T<:AbstractFloat}
-    p = T(prob)
-    q = one(T) - p
-    n * min(p, q) >= 10 || throw(ArgumentError("BinomialTRSSampler requires n * min(p, 1-p) >= 10"))
-    spq = sqrt(T(n) * p * q)
-    b = T(1.15) + T(2.53) * spq
-    a = T(-0.0873) + T(0.0248) * b + T(0.01) * p
-    c = T(n) * p + T(0.5)
-    v_r = T(0.92) - T(4.2) / b
-    α = (T(2.83) + T(5.1) / b) * spq
-    m = floor(Int, (T(n) + one(T)) * p)
-    BinomialTRSSampler{T}(n, a, b, c, v_r, p/q, α, m)
+function BinomialTRSSampler(n::Int, prob::Float64)
+    comp = prob > 0.5
+    p = comp ? 1.0 - prob : prob
+    q = 1.0 - p
+    n * p >= 10 || throw(ArgumentError("BinomialTRSSampler requires n * min(prob, 1-prob) >= 10"))
+    spq = sqrt(n * p * q)
+    b = 1.15 + 2.53 * spq
+    a = -0.0873 + 0.0248 * b + 0.01 * p
+    c = n * p + 0.5
+    v_r = 0.92 - 4.2 / b
+    α = (2.83 + 5.1 / b) * spq
+    m = floor(Int, (n + 1) * p)
+    BinomialTRSSampler(comp, n, a, b, c, v_r, p/q, α, m)
 end
 
-
-BinomialTRSSampler(n::Int, prob::Float64) = BinomialTRSSampler{Float64}(n, prob)
-
-@inline function binom_stirling_tail(::Type{T}, k::Int) where {T<:AbstractFloat}
-    if k < 10
-        tbl = (0.0810614667953272, 0.0413406959554093, 0.0276779256849983,
-               0.0207906721037650, 0.0166446911898211, 0.0138761288230707,
-               0.0118967099458917, 0.0104112652619720, 0.00925546218271273,
-               0.00833056343336287)
-        return T(@inbounds tbl[k + 1])
-    end
-    kp1sq = (T(k) + one(T))^2
-    return (T(1//12) - (T(1//360) - T(1//1260) / kp1sq) / kp1sq) / (T(k) + one(T))
-end
-
-function rand(rng::AbstractRNG, s::BinomialTRSSampler{T}) where {T}
-    (; n, a, b, r, m) = s
+function rand(rng::AbstractRNG, s::BinomialTRSSampler)
+    (; comp, n, a, b, r, m) = s
     while true
-        u = rand(rng, T) - T(1/2)
-        v = rand(rng, T)
-        us = T(1/2) - abs(u)
-        kf = (T(2) * a / us + b) * u + s.c
-        (kf < zero(T) || kf > T(n)) && continue
+        u = rand(rng) - 0.5
+        v = rand(rng)
+        us = 0.5 - abs(u)
+        kf = (2 * a / us + b) * u + s.c
+        (kf < 0.0 || kf >= n + 1) && continue
         k = floor(Int, kf)
-        (us >= T(0.07) && v <= s.v_r) && return k
+        (us >= 0.07 && v <= s.v_r) && return comp ? n - k : k
         v = log(v * s.α / (a / (us * us) + b))
-        ub = (T(m) + T(1/2)) * log((T(m) + one(T)) / (r * T(n-m+1))) +
-             (T(n) + one(T)) * log(T(n-m+1) / T(n-k+1)) +
-             (T(k) + T(1/2)) * log(r*T(n-k+1) / (T(k) + one(T))) +
-             binom_stirling_tail(T, m) + binom_stirling_tail(T, n-m) -
-             binom_stirling_tail(T, k) - binom_stirling_tail(T, n-k)
-        v <= ub && return k
+        ub = (m + 0.5) * log((m + 1) / (r * (n - m + 1))) +
+             (n + 1) * log((n - m + 1) / (n - k + 1)) +
+             (k + 0.5) * log(r * (n - k + 1) / (k + 1)) +
+             lstirling_asym(m + 1) + lstirling_asym(n - m + 1) -
+             lstirling_asym(k + 1) - lstirling_asym(n - k + 1)
+        v <= ub && return comp ? n - k : k
     end
 end
 
@@ -306,33 +294,3 @@ end
 BinomialAliasSampler(n::Int, p::Float64) = BinomialAliasSampler(AliasTable(binompvec(n, p)))
 
 rand(rng::AbstractRNG, s::BinomialAliasSampler) = rand(rng, s.table) - 1
-
-
-# Integrated Polyalgorithm sampler that automatically chooses the proper one
-#
-# It is important for type-stability
-#
-mutable struct BinomialPolySampler <: Sampleable{Univariate,Discrete}
-    use_btpe::Bool
-    geom_sampler::BinomialGeomSampler
-    btpe_sampler::BinomialTPESampler
-end
-
-function BinomialPolySampler(n::Int, p::Float64)
-    q = 1.0 - p
-    if n * min(p, q) > 20
-        use_btpe = true
-        geom_sampler = BinomialGeomSampler()
-        btpe_sampler = BinomialTPESampler(n, p)
-    else
-        use_btpe = false
-        geom_sampler = BinomialGeomSampler(n, p)
-        btpe_sampler = BinomialTPESampler()
-    end
-    BinomialPolySampler(use_btpe, geom_sampler, btpe_sampler)
-end
-
-BinomialPolySampler(n::Real, p::Real) = BinomialPolySampler(round(Int, n), Float64(p))
-
-rand(rng::AbstractRNG, s::BinomialPolySampler) =
-    s.use_btpe ? rand(rng, s.btpe_sampler) : rand(rng, s.geom_sampler)

--- a/src/samplers/binomial.jl
+++ b/src/samplers/binomial.jl
@@ -243,18 +243,20 @@ struct BinomialTRSSampler <: Sampleable{Univariate,Discrete}
     n::Int
     a::Float64
     b::Float64
-    c::Float64   # n*p + 0.5
+    c::Float64    # n*p + 0.5
     v_r::Float64
-    r::Float64   # p / q
+    r::Float64    # p / q
     α::Float64
-    m::Int       # floor((n+1)*p)
+    m::Int        # floor((n+1)*p)
+    ub_m::Float64 # k-independent part of ub
 end
 
-function BinomialTRSSampler(n::Int, prob::Float64)
+function trs_params(n::Int, prob::Float64)
     comp = prob > 0.5
     p = comp ? 1.0 - prob : prob
     q = 1.0 - p
-    n * p >= 10 || throw(ArgumentError("BinomialTRSSampler requires n * min(prob, 1-prob) >= 10"))
+    n * p >= 10 ||
+        throw(ArgumentError("BinomialTRSSampler requires n * min(prob, 1-prob) >= 10"))
     spq = sqrt(n * p * q)
     b = 1.15 + 2.53 * spq
     a = -0.0873 + 0.0248 * b + 0.01 * p
@@ -262,48 +264,43 @@ function BinomialTRSSampler(n::Int, prob::Float64)
     v_r = 0.92 - 4.2 / b
     α = (2.83 + 5.1 / b) * spq
     m = floor(Int, (n + 1) * p)
-    BinomialTRSSampler(comp, n, a, b, c, v_r, p/q, α, m)
+    return (; comp, n, a, b, c, v_r, r = p / q, α, m)
 end
 
-struct BinomialTRSBatchSampler <: Sampleable{Univariate,Discrete}
-    s::BinomialTRSSampler
-    ub_m::Float64
-end
-
-function trs_ub_m(s::BinomialTRSSampler)
-    (; n, r, m) = s
+trs_ub_m(ub_m::Float64, _) = ub_m
+function trs_ub_m(::Nothing, params)
+    (; n, r, m) = params
     return (m + 0.5) * log((m + 1) / (r * (n - m + 1))) +
-           (n + 1) * log(n - m + 1.0) +
            lstirling_asym(m + 1) + lstirling_asym(n - m + 1)
 end
-trs_ub_m(s::BinomialTRSBatchSampler) = s.ub_m
 
-trs_sampler(s::BinomialTRSSampler) = s
-trs_sampler(s::BinomialTRSBatchSampler) = s.s
-
-function BinomialTRSBatchSampler(n::Int, prob::Float64)
-    s = BinomialTRSSampler(n, prob)
-    return BinomialTRSBatchSampler(s, trs_ub_m(s))
+function BinomialTRSSampler(n::Int, prob::Float64)
+    params = trs_params(n, prob)
+    return BinomialTRSSampler(params..., trs_ub_m(nothing, params))
 end
 
-function rand(rng::AbstractRNG, s::Union{BinomialTRSSampler,BinomialTRSBatchSampler})
-    t = trs_sampler(s)
-    (; comp, n, a, b, r) = t
+function trs_rand(rng::AbstractRNG, params, ub_m)
+    (; comp, n, a, b, c, v_r, r, α, m) = params
     while true
         u = rand(rng) - 0.5
         v = rand(rng)
         us = 0.5 - abs(u)
-        kf = (2 * a / us + b) * u + t.c
+        kf = (2 * a / us + b) * u + c
         (kf < 0.0 || kf >= n + 1) && continue
         k = floor(Int, kf)
-        (us >= 0.07 && v <= t.v_r) && return comp ? n - k : k
-        v = log(v * t.α / (a / (us * us) + b))
-        ub = trs_ub_m(s) - (n + 1) * log(n - k + 1) +
+        (us >= 0.07 && v <= v_r) && return comp ? n - k : k
+        v = log(v * α / (a / (us * us) + b))
+        ub = trs_ub_m(ub_m, params) + (n + 1) * log((n - m + 1) / (n - k + 1)) +
              (k + 0.5) * log(r * (n - k + 1) / (k + 1)) -
              lstirling_asym(k + 1) - lstirling_asym(n - k + 1)
         v <= ub && return comp ? n - k : k
     end
 end
+
+trs_rand(rng::AbstractRNG, n::Int, prob::Float64) =
+    trs_rand(rng, trs_params(n, prob), nothing)
+
+rand(rng::AbstractRNG, s::BinomialTRSSampler) = trs_rand(rng, s, s.ub_m)
 
 # Constructing an alias table by directly computing the probability vector
 #

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -167,7 +167,7 @@ function rand(rng::AbstractRNG, d::Binomial)
     if r*n <= 10.0
         y = rand(rng, BinomialGeomSampler(n,r))
     else
-        y = rand(rng, BinomialTPESampler(n,r))
+        y = rand(rng, BinomialTRSSampler(n,r))
     end
     p <= 0.5 ? y : n-y
 end

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -162,11 +162,18 @@ function sampler(d::Binomial)
     if n * min(p, 1 - p) <= 10
         return BinomialGeomSampler(n, p)
     else
-        return BinomialTRSSampler(n, p)
+        return BinomialTRSBatchSampler(n, p)
     end
 end
 
-rand(rng::AbstractRNG, d::Binomial) = rand(rng, sampler(d))
+function rand(rng::AbstractRNG, d::Binomial)
+    n, p = d.n, d.p
+    if n * min(p, 1 - p) <= 10
+        return rand(rng, BinomialGeomSampler(n, p))
+    else
+        return rand(rng, BinomialTRSSampler(n, p))
+    end
+end
 
 function mgf(d::Binomial, t::Real)
     n, p = params(d)

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -157,20 +157,16 @@ end
 
 @_delegate_statsfuns Binomial binom n p
 
-function rand(rng::AbstractRNG, d::Binomial)
-    p, n = d.p, d.n
-    if p <= 0.5
-        r = p
+function sampler(d::Binomial)
+    n, p = d.n, d.p
+    if n * min(p, 1 - p) <= 10
+        return BinomialGeomSampler(n, p)
     else
-        r = 1.0-p
+        return BinomialTRSSampler(n, p)
     end
-    if r*n <= 10.0
-        y = rand(rng, BinomialGeomSampler(n,r))
-    else
-        y = rand(rng, BinomialTRSSampler(n,r))
-    end
-    p <= 0.5 ? y : n-y
 end
+
+rand(rng::AbstractRNG, d::Binomial) = rand(rng, sampler(d))
 
 function mgf(d::Binomial, t::Real)
     n, p = params(d)

--- a/src/univariate/discrete/binomial.jl
+++ b/src/univariate/discrete/binomial.jl
@@ -162,7 +162,7 @@ function sampler(d::Binomial)
     if n * min(p, 1 - p) <= 10
         return BinomialGeomSampler(n, p)
     else
-        return BinomialTRSBatchSampler(n, p)
+        return BinomialTRSSampler(n, p)
     end
 end
 
@@ -171,7 +171,7 @@ function rand(rng::AbstractRNG, d::Binomial)
     if n * min(p, 1 - p) <= 10
         return rand(rng, BinomialGeomSampler(n, p))
     else
-        return rand(rng, BinomialTRSSampler(n, p))
+        return trs_rand(rng, n, p)
     end
 end
 

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -7,6 +7,7 @@ import Distributions:
     AliasTable,
     BinomialGeomSampler,
     BinomialTPESampler,
+    BinomialTRSSampler,
     BinomialPolySampler,
     BinomialAliasSampler,
     PoissonADSampler,
@@ -46,6 +47,7 @@ import Distributions:
     @testset "Binomial: $S" for (S, paramlst) in [
             (BinomialGeomSampler, [(0, 0.4), (0, 0.6), (5, 0.0), (5, 1.0), (1, 0.2), (1, 0.8), (3, 0.4), (4, 0.6)]),
             (BinomialTPESampler, [(40, 0.5), (100, 0.4), (300, 0.6)]),
+            (BinomialTRSSampler, [(40, 0.5), (100, 0.4), (300, 0.6), (25, 0.45), (2000, 0.02)]),
             (BinomialPolySampler, binomparams),
             (BinomialAliasSampler, binomparams) ]
         @testset "pa=$pa" for pa in paramlst

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -8,6 +8,7 @@ import Distributions:
     BinomialGeomSampler,
     BinomialTPESampler,
     BinomialTRSSampler,
+    BinomialTRSBatchSampler,
     BinomialAliasSampler,
     PoissonADSampler,
     PoissonCountSampler,
@@ -47,6 +48,7 @@ import Distributions:
             (BinomialGeomSampler, [(0, 0.4), (0, 0.6), (5, 0.0), (5, 1.0), (1, 0.2), (1, 0.8), (3, 0.4), (4, 0.6)]),
             (BinomialTPESampler, [(40, 0.5), (100, 0.4), (300, 0.6)]),
             (BinomialTRSSampler, [(20, 0.5), (40, 0.5), (100, 0.4), (300, 0.6), (25, 0.45), (2000, 0.02)]),
+            (BinomialTRSBatchSampler, [(20, 0.5), (40, 0.5), (100, 0.4), (300, 0.6), (25, 0.45), (2000, 0.02)]),
             (BinomialAliasSampler, binomparams) ]
         @testset "pa=$pa" for pa in paramlst
             n, p = pa

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -8,7 +8,6 @@ import Distributions:
     BinomialGeomSampler,
     BinomialTPESampler,
     BinomialTRSSampler,
-    BinomialTRSBatchSampler,
     BinomialAliasSampler,
     PoissonADSampler,
     PoissonCountSampler,
@@ -48,7 +47,6 @@ import Distributions:
             (BinomialGeomSampler, [(0, 0.4), (0, 0.6), (5, 0.0), (5, 1.0), (1, 0.2), (1, 0.8), (3, 0.4), (4, 0.6)]),
             (BinomialTPESampler, [(40, 0.5), (100, 0.4), (300, 0.6)]),
             (BinomialTRSSampler, [(20, 0.5), (40, 0.5), (100, 0.4), (300, 0.6), (25, 0.45), (2000, 0.02)]),
-            (BinomialTRSBatchSampler, [(20, 0.5), (40, 0.5), (100, 0.4), (300, 0.6), (25, 0.45), (2000, 0.02)]),
             (BinomialAliasSampler, binomparams) ]
         @testset "pa=$pa" for pa in paramlst
             n, p = pa

--- a/test/samplers.jl
+++ b/test/samplers.jl
@@ -8,7 +8,6 @@ import Distributions:
     BinomialGeomSampler,
     BinomialTPESampler,
     BinomialTRSSampler,
-    BinomialPolySampler,
     BinomialAliasSampler,
     PoissonADSampler,
     PoissonCountSampler,
@@ -47,14 +46,14 @@ import Distributions:
     @testset "Binomial: $S" for (S, paramlst) in [
             (BinomialGeomSampler, [(0, 0.4), (0, 0.6), (5, 0.0), (5, 1.0), (1, 0.2), (1, 0.8), (3, 0.4), (4, 0.6)]),
             (BinomialTPESampler, [(40, 0.5), (100, 0.4), (300, 0.6)]),
-            (BinomialTRSSampler, [(40, 0.5), (100, 0.4), (300, 0.6), (25, 0.45), (2000, 0.02)]),
-            (BinomialPolySampler, binomparams),
+            (BinomialTRSSampler, [(20, 0.5), (40, 0.5), (100, 0.4), (300, 0.6), (25, 0.45), (2000, 0.02)]),
             (BinomialAliasSampler, binomparams) ]
         @testset "pa=$pa" for pa in paramlst
             n, p = pa
             test_samples(S(n, p), Binomial(n, p), n_tsamples)
             test_samples(S(n, p), Binomial(n, p), n_tsamples, rng=rng)
         end
+        @test_throws ArgumentError BinomialTRSSampler(19, 0.5)
     end
 
     ## Poisson samplers


### PR DESCRIPTION
Replaces the BinomialTPE sampler (Kachitvichyanukul & Schmeiser 1988) with BTRS (Hörmann 1993) when `n*min(p,1-p) > 10`. 

| n | p | BTPE | BTRS | speedup |
|---|---|---|---|---|
| 25 | 0.45 | 76.8 ns | 48.4 ns | 1.59x |
| 40 | 0.50 | 73.3 ns | 46.2 ns | 1.58x |
| 100 | 0.40 | 62.5 ns | 38.3 ns | 1.63x |
| 300 | 0.60 | 44.2 ns | 30.4 ns | 1.45x |
| 1000 | 0.30 | 37.2 ns | 25.0 ns | 1.49x |
| 2000 | 0.02 | 63.7 ns | 32.8 ns | 1.94x |
| 10000 | 0.37 | 29.6 ns | 20.9 ns | 1.42x |
| 100000 | 0.10 | 29.1 ns | 20.6 ns | 1.41x |
| 1000000 | 0.10 | 28.2 ns | 20.2 ns | 1.40x |

BTRS is also what JAX (`jax/_src/random/core.py`), TensorFlow (`random_binomial_op.cc`) and PyTorch (`ATen/native/Distributions.h`) use. 

When `n*min(p,1-p) > 10` is not satisfied, the sampler is biased, so we throw an error. This should never happen via `rand(::Binomial)` which explicitly branches on that condition.
