### PR TITLE
Derive discrete `quantile` from `cdf`/`ccdf`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Distributions"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
 authors = ["JuliaStats"]
-version = "0.25.131"
+version = "0.25.132"
 
 [deps]
 AliasTables = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"

--- a/src/univariate/discrete/betabinomial.jl
+++ b/src/univariate/discrete/betabinomial.jl
@@ -82,10 +82,12 @@ function kurtosis(d::BetaBinomial)
     return (left * right) - 3
 end
 
-function logpdf(d::BetaBinomial, k::Real)
+logpdf(d::BetaBinomial, k::Real) = logpdf_int(d, k)
+
+function logpdf(d::BetaBinomial, k::Integer)
     n, α, β = d.n, d.α, d.β
     _insupport = insupport(d, k)
-    _k = _insupport ? round(Int, k) : 0
+    _k = _insupport ? k : 0
     logbinom = - log1p(n) - logbeta(_k + 1, n - _k + 1)
     lognum   = logbeta(_k + α, n - _k + β)
     logdenom = logbeta(α, β)
@@ -103,15 +105,49 @@ for f in (:ccdf, :logcdf, :logccdf)
     end
 end
 
-# Shifted categorical distribution corresponding to `BetaBinomial`
-_categorical(d::BetaBinomial) = Categorical(map(Base.Fix1(pdf, d), support(d)))
+function entropy(d::BetaBinomial)
+    broadcasted = Broadcast.broadcasted(support(d)) do k
+        xlogx(pdf(d, k))
+    end
+    return -sum(Broadcast.instantiate(broadcasted))
+end
 
-entropy(d::BetaBinomial) = entropy(_categorical(d))
-median(d::BetaBinomial) = median(_categorical(d)) - 1
-mode(d::BetaBinomial) = mode(_categorical(d)) - 1
-modes(d::BetaBinomial) = modes(_categorical(d)) .- 1
+# `pdf(d, k + 1) / pdf(d, k) = (n - k) * (k + α) / ((k + 1) * (n - k - 1 + β))`, i.e.
+# `pdf(d, k + 1) >= pdf(d, k)` iff `k * (2 - α - β) + n * (α - 1) - (β - 1) >= 0`
+function mode(d::BetaBinomial)
+    n, α, β = params(d)
+    c = α + β - 2
+    if c < 0
+        # `pdf` is U-shaped, hence maximized at a boundary of the support
+        return logbeta(n + α, β) > logbeta(α, n + β) ? n : 0
+    elseif iszero(c)
+        return α > 1 ? n : 0
+    else
+        # `pdf` increases up to `ceil(kstar)` and decreases afterwards
+        kstar = (n * (α - 1) - (β - 1)) / c
+        return kstar < 0 ? 0 : (kstar >= n ? n : ceil(Int, kstar))
+    end
+end
 
-quantile(d::BetaBinomial, p::Float64) = quantile(_categorical(d), p) - 1
+function modes(d::BetaBinomial)
+    n, α, β = params(d)
+    c = α + β - 2
+    if c < 0
+        if !iszero(n) && logbeta(n + α, β) == logbeta(α, n + β)
+            return [0, n]
+        end
+    elseif iszero(c)
+        # `α == β == 1` corresponds to a uniform distribution on the support
+        isone(α) && return collect(support(d))
+    else
+        kstar = (n * (α - 1) - (β - 1)) / c
+        0 <= kstar < n && isinteger(kstar) && return [Int(kstar), Int(kstar) + 1]
+    end
+    return [mode(d)]
+end
+
+quantile(d::BetaBinomial, p::Real) = integerunitrange_quantile(d, p)
+cquantile(d::BetaBinomial, p::Real) = integerunitrange_cquantile(d, p)
 
 #### Sampling
 

--- a/src/univariate/discrete/categorical.jl
+++ b/src/univariate/discrete/categorical.jl
@@ -61,20 +61,6 @@ function Base.isapprox(c1::Categorical, c2::Categorical; kwargs...)
         isapprox(probs(c1), probs(c2); kwargs...)
 end
 
-### Statistics
-
-function median(d::Categorical{T}) where {T<:Real}
-    k = ncategories(d)
-    p = probs(d)
-    cp = zero(T)
-    i = 0
-    while cp < 1/2 && i <= k
-        i += 1
-        cp += p[i]
-    end
-    i
-end
-
 ### Evaluation
 
 # the fallbacks are overridden by `DiscreteNonParameteric`

--- a/src/univariate/discrete/discretenonparametric.jl
+++ b/src/univariate/discrete/discretenonparametric.jl
@@ -162,18 +162,33 @@ function ccdf(d::DiscreteNonParametric, x::Real)
     return s
 end
 
+# as in `cdf` and `ccdf`, the lower tail is summed if `q <= 1/2` and the upper tail otherwise
 function quantile(d::DiscreteNonParametric, q::Real)
-    0 <= q <= 1 || throw(DomainError())
+    0 <= q <= 1 || throw(DomainError(q, "`q` must satisfy `0 <= q <= 1`"))
     x = support(d)
     p = probs(d)
-    k = length(x)
-    i = 1
-    cp = p[1]
-    while cp < q && i < k #Note: is i < k necessary?
-        i += 1
-        cp += p[i]
+    n = length(p)
+
+    if q <= 1//2
+        # smallest `x[i]` with `cdf(d, x[i]) = sum(p[1:i]) >= q`
+        i = 1
+        c = p[1]
+        while c < q && i < n
+            i += 1
+            c += p[i]
+        end
+        return x[i]
+    else
+        # `c == ccdf(d, x[i - 1])`, hence `x[i]` is a solution as soon as `c > 1 - q`
+        r = 1 - q
+        i = n
+        c = p[n]
+        while c <= r && i > 1
+            i -= 1
+            c += p[i]
+        end
+        return x[i]
     end
-    x[i]
 end
 
 minimum(d::DiscreteNonParametric) = first(support(d))

--- a/src/univariate/discrete/noncentralhypergeometric.jl
+++ b/src/univariate/discrete/noncentralhypergeometric.jl
@@ -9,24 +9,8 @@ abstract type NoncentralHypergeometric{T<:Real} <: DiscreteUnivariateDistributio
 
 # Functions
 
-function quantile(d::NoncentralHypergeometric{T}, q::Real) where T<:Real
-    if !(zero(q) <= q <= one(q))
-        T(NaN)
-    else
-        range = support(d)
-        if q > 1/2
-            q = 1 - q
-            range = reverse(range)
-        end
-
-        qsum, i = zero(T), 0
-        while qsum < q
-            i += 1
-            qsum += pdf(d, range[i])
-        end
-        range[i]
-    end
-end
+quantile(d::NoncentralHypergeometric, p::Real) = integerunitrange_quantile(d, p)
+cquantile(d::NoncentralHypergeometric, p::Real) = integerunitrange_cquantile(d, p)
 
 params(d::NoncentralHypergeometric) = (d.ns, d.nf, d.n, d.ω)
 @inline partype(d::NoncentralHypergeometric{T}) where {T<:Real} = T
@@ -83,7 +67,7 @@ testfd(d::FisherNoncentralHypergeometric) = d.ω^3
 #
 # but the rule for terminating the summation has been slightly modified.
 function pdf(d::FisherNoncentralHypergeometric, k::Integer)
-    ω, _ = promote(d.ω, float(k))
+    ω, _ = map(float, promote(d.ω, k))
     l = max(0, d.n - d.nf)
     u = min(d.ns, d.n)
     if !insupport(d, k)
@@ -128,52 +112,65 @@ function pdf(d::FisherNoncentralHypergeometric, k::Integer)
     return fₖ/s
 end
 
+pdf(d::FisherNoncentralHypergeometric, k::Real) = pdf_int(d, k)
 logpdf(d::FisherNoncentralHypergeometric, k::Real) = log(pdf(d, k))
 
-function cdf(d::FisherNoncentralHypergeometric, k::Integer)
-    ω, _ = promote(d.ω, float(k))
-    l = max(0, d.n - d.nf)
-    u = min(d.ns, d.n)
-    if k < l
-        return zero(ω)
-    elseif k >= u
-        return one(ω)
-    end
+# unnormalized weights of `minimum(d):k` and of `(k + 1):maximum(d)`, hence the normalizing
+# constant is `Fₖ + Gₖ`
+#
+# a term that no longer contributes to the tail it belongs to does not contribute to
+# `Fₖ + Gₖ` either, so the two tails determine when the summations can be terminated
+function _fisher_tails(d::FisherNoncentralHypergeometric, k::Integer)
+    ω, _ = map(float, promote(d.ω, k))
+    l, u = extrema(d)
     η = mode(d)
-    s = one(ω)
-    fᵢ = one(ω)
     Fₖ = k >= η ? one(ω) : zero(ω)
+    Gₖ = one(ω) - Fₖ
+
+    fᵢ = one(ω)
     for i in (η + 1):u
         rᵢ = (d.ns - i + 1)*ω/(i*(d.nf - d.n  + i))*(d.n - i + 1)
         fᵢ *= rᵢ
-
-        # break if terms no longer contribute to s
-        sfᵢ = s + fᵢ
-        if sfᵢ == s && i > k
-            break
-        end
-        s = sfᵢ
         if i <= k
             Fₖ += fᵢ
+        else
+            Gₖ + fᵢ == Gₖ && break
+            Gₖ += fᵢ
         end
     end
+
     fᵢ = one(ω)
     for i in (η - 1):-1:l
         rᵢ₊ = (d.ns - i)*ω/((i + 1)*(d.nf - d.n + i + 1))*(d.n - i)
         fᵢ /= rᵢ₊
-
-        # break if terms no longer contribute to s
-        sfᵢ = s + fᵢ
-        if sfᵢ == s && i < k
-            break
-        end
-        s = sfᵢ
-        if i <= k
+        if i > k
+            Gₖ += fᵢ
+        else
+            i < k && Fₖ + fᵢ == Fₖ && break
             Fₖ += fᵢ
         end
     end
 
-    return Fₖ/s
+    return Fₖ, Gₖ
+end
+
+function cdf(d::FisherNoncentralHypergeometric, k::Integer)
+    ω, _ = map(float, promote(d.ω, k))
+    k < minimum(d) && return zero(ω)
+    k >= maximum(d) && return one(ω)
+    Fₖ, Gₖ = _fisher_tails(d, k)
+    return Fₖ/(Fₖ + Gₖ)
+end
+
+# `1 - cdf(d, k)` cancels to 0 in the upper tail
+ccdf(d::FisherNoncentralHypergeometric, k::Real) = ccdf_int(d, k)
+
+function ccdf(d::FisherNoncentralHypergeometric, k::Integer)
+    ω, _ = map(float, promote(d.ω, k))
+    k < minimum(d) && return one(ω)
+    k >= maximum(d) && return zero(ω)
+    Fₖ, Gₖ = _fisher_tails(d, k)
+    return Gₖ/(Fₖ + Gₖ)
 end
 
 function _expectation(f, d::FisherNoncentralHypergeometric)
@@ -267,7 +264,9 @@ entropy(d::WalleniusNoncentralHypergeometric) = 1
 
 testfd(d::WalleniusNoncentralHypergeometric) = d.ω^3
 
-function logpdf(d::WalleniusNoncentralHypergeometric, k::Real)
+logpdf(d::WalleniusNoncentralHypergeometric, k::Real) = logpdf_int(d, k)
+
+function logpdf(d::WalleniusNoncentralHypergeometric, k::Integer)
     if insupport(d, k)
         D = d.ω * (d.ns - k) + (d.nf - d.n + k)
         f(t) = (1 - t^(d.ω / D))^k * (1 - t^(1 / D))^(d.n - k)

--- a/src/univariate/discrete/poissonbinomial.jl
+++ b/src/univariate/discrete/poissonbinomial.jl
@@ -108,13 +108,13 @@ function kurtosis(d::PoissonBinomial{T}) where {T}
 end
 
 entropy(d::PoissonBinomial) = entropy(d.pmf)
-median(d::PoissonBinomial) = median(Categorical(d.pmf)) - 1
 mode(d::PoissonBinomial) = argmax(d.pmf) - 1
 modes(d::PoissonBinomial) = modes(DiscreteNonParametric(support(d), d.pmf))
 
 #### Evaluation
 
-quantile(d::PoissonBinomial, x::Float64) = quantile(Categorical(d.pmf), x) - 1
+quantile(d::PoissonBinomial, p::Real) = integerunitrange_quantile(d, p)
+cquantile(d::PoissonBinomial, p::Real) = integerunitrange_cquantile(d, p)
 
 function mgf(d::PoissonBinomial, t::Real)
     expm1_t = expm1(t)
@@ -130,7 +130,8 @@ function cf(d::PoissonBinomial, t::Real)
     end
 end
 
-pdf(d::PoissonBinomial, k::Real) = insupport(d, k) ? d.pmf[Int(k+1)] : zero(eltype(d.pmf))
+pdf(d::PoissonBinomial, k::Integer) = insupport(d, k) ? d.pmf[k + 1] : zero(eltype(d.pmf))
+pdf(d::PoissonBinomial, k::Real) = pdf_int(d, k)
 logpdf(d::PoissonBinomial, k::Real) = log(pdf(d, k))
 
 cdf(d::PoissonBinomial, k::Int) = integerunitrange_cdf(d, k)

--- a/src/univariates.jl
+++ b/src/univariates.jl
@@ -499,6 +499,32 @@ end
 
 ### special definitions for distributions with integer-valued support
 
+function pdf_int(d::DiscreteUnivariateDistribution, x::Real)
+    # `0` is only evaluated to obtain a value of the correct type
+    _isinteger = isinteger(x)
+    p = float(pdf(d, _isinteger ? round(Int, x) : 0))
+    return if _isinteger
+        p
+    elseif isnan(x)
+        oftype(p, NaN)
+    else
+        zero(p)
+    end
+end
+
+function logpdf_int(d::DiscreteUnivariateDistribution, x::Real)
+    # `0` is only evaluated to obtain a value of the correct type
+    _isinteger = isinteger(x)
+    p = float(logpdf(d, _isinteger ? round(Int, x) : 0))
+    return if _isinteger
+        p
+    elseif isnan(x)
+        oftype(p, NaN)
+    else
+        oftype(p, -Inf)
+    end
+end
+
 function cdf_int(d::DiscreteUnivariateDistribution, x::Real)
     # handle `NaN` and `±Inf` which can't be truncated to `Int`
     isfinite_x = isfinite(x)
@@ -571,10 +597,10 @@ function integerunitrange_cdf(d::DiscreteUnivariateDistribution, x::Integer)
 
     result = if isfinite(minimum_d) && !(isfinite(maximum_d) && x >= div(minimum_d + maximum_d, 2))
         c = sum(Base.Fix1(pdf, d), minimum_d:(max(x, minimum_d)))
-        x < minimum_d ? zero(c) : c
+        x < minimum_d ? zero(c) : min(c, one(c))
     else
         c = 1 - sum(Base.Fix1(pdf, d), (min(x + 1, maximum_d)):maximum_d)
-        x >= maximum_d ? one(c) : c
+        x >= maximum_d ? one(c) : max(c, zero(c))
     end
 
     return result
@@ -586,10 +612,10 @@ function integerunitrange_ccdf(d::DiscreteUnivariateDistribution, x::Integer)
 
     result = if isfinite(minimum_d) && !(isfinite(maximum_d) && x >= div(minimum_d + maximum_d, 2))
         c = 1 - sum(Base.Fix1(pdf, d), minimum_d:(max(x, minimum_d)))
-        x < minimum_d ? one(c) : c
+        x < minimum_d ? one(c) : max(c, zero(c))
     else
         c = sum(Base.Fix1(pdf, d), (min(x + 1, maximum_d)):maximum_d)
-        x >= maximum_d ? zero(c) : c
+        x >= maximum_d ? zero(c) : min(c, one(c))
     end
 
     return result
@@ -601,10 +627,10 @@ function integerunitrange_logcdf(d::DiscreteUnivariateDistribution, x::Integer)
 
     result = if isfinite(minimum_d) && !(isfinite(maximum_d) && x >= div(minimum_d + maximum_d, 2))
         c = logsumexp(logpdf(d, y) for y in minimum_d:(max(x, minimum_d)))
-        x < minimum_d ? oftype(c, -Inf) : c
+        x < minimum_d ? oftype(c, -Inf) : min(c, zero(c))
     else
-        c = log1mexp(logsumexp(logpdf(d, y) for y in (min(x + 1, maximum_d)):maximum_d))
-        x >= maximum_d ? zero(c) : c
+        s = logsumexp(logpdf(d, y) for y in (min(x + 1, maximum_d)):maximum_d)
+        x >= maximum_d ? zero(s) : log1mexp(min(s, zero(s)))
     end
 
     return result
@@ -615,14 +641,67 @@ function integerunitrange_logccdf(d::DiscreteUnivariateDistribution, x::Integer)
     isfinite(minimum_d) || isfinite(maximum_d) || error("support is unbounded")
 
     result = if isfinite(minimum_d) && !(isfinite(maximum_d) && x >= div(minimum_d + maximum_d, 2))
-        c = log1mexp(logsumexp(logpdf(d, y) for y in minimum_d:(max(x, minimum_d))))
-        x < minimum_d ? zero(c) : c
+        s = logsumexp(logpdf(d, y) for y in minimum_d:(max(x, minimum_d)))
+        x < minimum_d ? zero(s) : log1mexp(min(s, zero(s)))
     else
         c = logsumexp(logpdf(d, y) for y in (min(x + 1, maximum_d)):maximum_d)
-        x >= maximum_d ? oftype(c, -Inf) : c
+        x >= maximum_d ? oftype(c, -Inf) : min(c, zero(c))
     end
 
     return result
+end
+
+# implementation of the quantile for distributions whose support is a unitrange of integers
+#
+# the lower tail is summed if `p <= 1/2` and the upper tail otherwise, as in
+# `integerunitrange_cdf`: `cdf` rounds to 1 for many `x` in the upper tail, e.g.
+# `cdf(BetaBinomial(1000, 0.1, 20), 814) == 1`
+function integerunitrange_quantile(d::DiscreteUnivariateDistribution, p::Real)
+    0 <= p <= 1 || throw(DomainError(p, "`p` must satisfy `0 <= p <= 1`"))
+    return p <= 1//2 ? integerunitrange_invcdf(d, p) : integerunitrange_invccdf(d, 1 - p)
+end
+
+function integerunitrange_cquantile(d::DiscreteUnivariateDistribution, p::Real)
+    0 <= p <= 1 || throw(DomainError(p, "`p` must satisfy `0 <= p <= 1`"))
+    return p <= 1//2 ? integerunitrange_invccdf(d, p) : integerunitrange_invcdf(d, 1 - p)
+end
+
+# unlike the cdf, the quantile requires a finite support: its far end terminates the search
+# if `p` is never reached, e.g. for `p = 1` below
+function integerunitrange_support(d::DiscreteUnivariateDistribution)
+    hasfinitesupport(d) || error("support is unbounded")
+    xs = support(d)
+    xs isa UnitRange{Int} || error("support is not a unitrange of integers")
+    return xs
+end
+
+# smallest `x` in the support with `cdf(d, x) = sum(pdf(d, y) for y in minimum(d):x) >= p`
+function integerunitrange_invcdf(d::DiscreteUnivariateDistribution, p::Real)
+    xs = integerunitrange_support(d)
+
+    x = first(xs)
+    c = pdf(d, x)
+    while c < p && x < last(xs)
+        x += 1
+        c += pdf(d, x)
+    end
+
+    return x
+end
+
+# smallest `x` in the support with `ccdf(d, x) = sum(pdf(d, y) for y in (x + 1):maximum(d)) <= p`
+function integerunitrange_invccdf(d::DiscreteUnivariateDistribution, p::Real)
+    xs = integerunitrange_support(d)
+
+    # `c == ccdf(d, x - 1)`, hence `x` is a solution as soon as `c > p`
+    x = last(xs)
+    c = pdf(d, x)
+    while c <= p && x > first(xs)
+        x -= 1
+        c += pdf(d, x)
+    end
+
+    return x
 end
 
 ### macros to use StatsFuns for method implementation

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,7 @@ const tests = [
     "univariate/discrete/binomial",
     "univariate/discrete/betabinomial",
     "univariate/discrete/poissonbinomial",
+    "univariate/discrete/noncentralhypergeometric",
     "multivariate/dirichlet",
     "multivariate/dirichletmultinomial",
     "univariate/continuous/logitnormal",
@@ -157,7 +158,6 @@ const tests = [
     # "univariate/continuous/noncentralf",
     # "univariate/discrete/geometric",
     # "univariate/discrete/hypergeometric",
-    # "univariate/discrete/noncentralhypergeometric",
     # "univariate/discrete/poisson",
     # "univariate/discrete/skellam",
 

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -36,6 +36,7 @@ function test_distr(distr::DiscreteUnivariateDistribution, n::Int;
     test_support(distr, vs)
     test_evaluation(distr, vs, testquan)
     test_range_evaluation(distr)
+    test_extreme_quantiles(distr)
     test_nonfinite(distr)
 
     test_stats(distr, vs)
@@ -411,6 +412,43 @@ end
 
 
 #### Testing evaluation methods
+
+# the guards exclude extreme values with zero probability, e.g. `maximum(Bernoulli(0))`
+function test_extreme_quantiles(d::DiscreteUnivariateDistribution)
+    if islowerbounded(d) && pdf(d, minimum(d)) > 0
+        @test quantile(d, 0) == minimum(d)
+        @test cquantile(d, 1) == minimum(d)
+    end
+    if isupperbounded(d) && pdf(d, maximum(d)) > 0
+        @test quantile(d, 1) == maximum(d)
+        @test cquantile(d, 0) == maximum(d)
+    end
+end
+
+# `quantile(d, p)` is the smallest `x` in the support with `cdf(d, x) >= p` and
+# `cquantile(d, p)` the smallest `x` with `ccdf(d, x) <= p`, checked with
+# `cdf(d, x - 1) = cdf(d, x) - pdf(d, x)` and `ccdf(d, x - 1) = ccdf(d, x) + pdf(d, x)`
+function test_quantile_invariants(d::DiscreteUnivariateDistribution, ps=0.01:0.01:0.99)
+    test_extreme_quantiles(d)
+    @test issorted(quantile(d, p) for p in ps)
+    @test issorted((cquantile(d, p) for p in ps); rev=true)
+
+    for p in ps
+        k = @inferred quantile(d, p)
+        @test insupport(d, k)
+        @test cdf(d, k) >= p
+        if k != minimum(d)
+            @test cdf(d, k) < p + pdf(d, k)
+        end
+
+        k = @inferred cquantile(d, p)
+        @test insupport(d, k)
+        @test ccdf(d, k) <= p
+        if k != minimum(d)
+            @test ccdf(d, k) + pdf(d, k) > p
+        end
+    end
+end
 
 function test_range_evaluation(d::DiscreteUnivariateDistribution)
     # check the consistency between range-based and ordinary pdf

--- a/test/univariate/discrete/betabinomial.jl
+++ b/test/univariate/discrete/betabinomial.jl
@@ -37,4 +37,41 @@ using Test
             end
         end
     end
+
+    @testset "quantile" begin
+        # https://github.com/JuliaStats/Distributions.jl/issues/2090
+        @test @inferred(quantile(BetaBinomial(1000, 0.1, 20), 1)) == 1000
+        @test @inferred(quantile(BetaBinomial(100, 0.1, 10), 1)) == 100
+
+        d = BetaBinomial(10, 2, 2.5)
+        @test @inferred(quantile(d, 1//2)) == quantile(d, 0.5) == median(d)
+        @test @inferred(quantile(d, 0.5f0)) isa Int
+        for p in (-0.1, 1.1, NaN)
+            err = DomainError(p, "`p` must satisfy `0 <= p <= 1`")
+            @test_throws err quantile(d, p)
+            @test_throws err cquantile(d, p)
+        end
+
+        @testset "$d" for d in (BetaBinomial(0, 1, 1), BetaBinomial(1, 0.5, 0.5),
+                                BetaBinomial(10, 2, 2.5), BetaBinomial(50, 0.2, 0.6),
+                                BetaBinomial(100, 0.1, 10), BetaBinomial(1000, 0.1, 20))
+            test_quantile_invariants(d)
+        end
+    end
+
+    @testset "mode" begin
+        @testset "$d" for d in (BetaBinomial(0, 1, 1), BetaBinomial(1, 0.5, 0.5),
+                                BetaBinomial(10, 2, 2.5), BetaBinomial(10, 60, 40),
+                                BetaBinomial(10, 0.5, 0.5), BetaBinomial(11, 3, 3),
+                                BetaBinomial(20, 3, 1), BetaBinomial(50, 0.2, 0.6),
+                                BetaBinomial(1000, 0.1, 20))
+            ps = map(Base.Fix1(pdf, d), support(d))
+            @test @inferred(modes(d)) == support(d)[ps .== maximum(ps)]
+            @test @inferred(mode(d)) == first(modes(d))
+        end
+
+        # `BetaBinomial(n, 1, 1)` is uniform, but `pdf` breaks the ties by rounding errors
+        @test @inferred(modes(BetaBinomial(20, 1, 1))) == 0:20
+        @test @inferred(mode(BetaBinomial(20, 1, 1))) == 0
+    end
 end

--- a/test/univariate/discrete/categorical.jl
+++ b/test/univariate/discrete/categorical.jl
@@ -137,4 +137,13 @@ end
     @test count(==(1e8), priorities[iat]) >= 13
 end
 
+@testset "quantile with a thin upper tail" begin
+    # https://github.com/JuliaStats/Distributions.jl/issues/2090
+    d = Categorical(map(Base.Fix1(pdf, BetaBinomial(1000, 0.1, 20)), 0:1000))
+    @test quantile(d, 1) == 1001 == ncategories(d)
+    @test quantile(d, 0) == 1
+    @test median(d) == quantile(d, 1//2)
+    test_quantile_invariants(d)
+end
+
 end

--- a/test/univariate/discrete/discretenonparametric.jl
+++ b/test/univariate/discrete/discretenonparametric.jl
@@ -214,3 +214,19 @@ end
     @test DiscreteNonParametric(1:2, [0.5, 0.5]) == DiscreteNonParametric([1, 2], [0.5f0, 0.5f0])
     @test DiscreteNonParametric(1:2, [0.5, 0.5]) ≈ DiscreteNonParametric([1, 2], [0.5f0, 0.5f0])
 end
+
+@testset "quantile with a thin upper tail" begin
+    # https://github.com/JuliaStats/Distributions.jl/issues/2090
+    d0 = BetaBinomial(1000, 0.1, 20)
+    d = DiscreteNonParametric(0:1000, map(Base.Fix1(pdf, d0), 0:1000))
+    @test quantile(d, 1) == 1000 == maximum(d)
+    @test quantile(d, 0) == 0 == minimum(d)
+    @test quantile(d, 1//2) == quantile(d0, 1//2)
+
+    # the last support point has zero probability
+    @test quantile(DiscreteNonParametric(1:3, [0.5, 0.5, 0.0]), 1) == 2
+
+    for q in (-eps(), nextfloat(1.0), NaN)
+        @test_throws DomainError(q, "`q` must satisfy `0 <= q <= 1`") quantile(d, q)
+    end
+end

--- a/test/univariate/discrete/noncentralhypergeometric.jl
+++ b/test/univariate/discrete/noncentralhypergeometric.jl
@@ -1,0 +1,152 @@
+using Distributions
+using Test
+
+# `pdf(d, k) ∝ binomial(ns, k) * binomial(nf, n - k) * ω^k`, evaluated exactly
+function fisher_refprobs(d::FisherNoncentralHypergeometric)
+    ns, nf, n, ω = params(d)
+    ws = [binomial(big(ns), big(k)) * binomial(big(nf), big(n - k)) * big(ω)^k
+          for k in support(d)]
+    return ws ./ sum(ws)
+end
+
+@testset "noncentralhypergeometric" begin
+    @testset "$(nameof(D))" for D in (FisherNoncentralHypergeometric,
+                                      WalleniusNoncentralHypergeometric)
+        d = D(8, 6, 10, 2)
+        xs = support(d)
+
+        @testset "constructor" begin
+            @test D(8, 6, 10, 1) isa D{Float64}
+            @test D(8, 6, 10, 0.5f0) isa D{Float32}
+            @test params(d) == (8, 6, 10, 2.0)
+            @test partype(d) === Float64
+            for args in ((-1, 6, 10, 1), (8, -1, 10, 1), (8, 6, 0, 1), (8, 6, 14, 1),
+                         (8, 6, 10, 0))
+                @test_throws DomainError D(args...)
+                @test D(args...; check_args=false) isa D{Float64}
+            end
+        end
+
+        @testset "support" begin
+            @test extrema(d) == (4, 8)
+            @test xs == 4:8
+            @test insupport(d, 4)
+            @test !insupport(d, 3)
+            @test !insupport(d, 4.5)
+            # the support starts at zero unless more than `nf` samples are drawn
+            @test support(D(50, 500, 30, 0.3)) == 0:30
+        end
+
+        @testset "pdf" begin
+            @test sum(Base.Fix1(pdf, d), xs) ≈ 1
+            @test all(pdf(d, k) == pdf(d, float(k)) == pdf(d, k // 1) for k in xs)
+            @test all(logpdf(d, k) ≈ log(pdf(d, k)) for k in xs)
+
+            # `pdf(::FisherNoncentralHypergeometric, ::AbstractFloat)` used to recurse
+            for x in (4.5, 3, 9, 3.0, 9.0, -Inf, Inf)
+                @test iszero(pdf(d, x))
+                @test logpdf(d, x) == -Inf
+            end
+            @test isnan(pdf(d, NaN))
+            @test isnan(logpdf(d, NaN))
+        end
+
+        @testset "parameter type" begin
+            d32 = D(8, 6, 10, 2.0f0)
+            # the Wallenius pmf loses the parameter type in the numerical integration
+            broken = D === WalleniusNoncentralHypergeometric
+            for f in (pdf, logpdf, cdf, ccdf, logcdf, logccdf)
+                @test @inferred(f(d32, 5)) isa Float32 broken=broken
+                @test @inferred(f(d32, 5.0)) isa Float32 broken=broken
+            end
+            @test @inferred(quantile(d32, 0.5)) isa Int
+            @test @inferred(cquantile(d32, 0.5)) isa Int
+        end
+
+        @testset "cdf" begin
+            cs = map(Base.Fix1(cdf, d), xs)
+            gs = map(Base.Fix1(ccdf, d), xs)
+            @test issorted(cs)
+            @test issorted(gs; rev=true)
+            @test all(cs .+ gs .≈ 1)
+            @test cs ≈ cumsum(map(Base.Fix1(pdf, d), xs))
+            @test all(logcdf(d, k) ≈ log(cdf(d, k)) for k in xs)
+            @test all(logccdf(d, k) ≈ log(ccdf(d, k)) for k in xs)
+
+            @test iszero(cdf(d, -Inf))
+            @test iszero(cdf(d, 3))
+            @test isone(cdf(d, 8))
+            @test isone(cdf(d, Inf))
+            @test isone(ccdf(d, -Inf))
+            @test iszero(ccdf(d, 8))
+            @test iszero(ccdf(d, Inf))
+            for f in (cdf, ccdf, logcdf, logccdf)
+                @test isnan(f(d, NaN))
+                @test f(d, 5.5) == f(d, 5)
+            end
+        end
+
+        # `ω = 1` reduces to the hypergeometric distribution, up to the accuracy of the
+        # numerical integration in the Wallenius pmf
+        @testset "hypergeometric limit" begin
+            d1 = D(8, 6, 10, 1)
+            h = Hypergeometric(8, 6, 10)
+            rtol = D === FisherNoncentralHypergeometric ? 1e-13 : 1e-7
+            @test mean(d1) ≈ mean(h) rtol=rtol
+            @test var(d1) ≈ var(h) rtol=rtol
+            @test mode(d1) == mode(h)
+            @test all(isapprox(pdf(d1, k), pdf(h, k); rtol=rtol) for k in support(h))
+            @test all(isapprox(cdf(d1, k), cdf(h, k); rtol=rtol) for k in support(h))
+        end
+
+        @testset "quantile" begin
+            # https://github.com/JuliaStats/Distributions.jl/issues/2090
+            # `quantile(d, 0)` and `quantile(d, 1)` used to throw a `BoundsError`
+            @testset "$dq" for dq in (D(8, 6, 10, 1), d, D(50, 500, 30, 0.3))
+                @test @inferred(quantile(dq, 0)) == minimum(dq)
+                @test @inferred(quantile(dq, 1)) == maximum(dq)
+                @test @inferred(cquantile(dq, 0)) == maximum(dq)
+                @test @inferred(cquantile(dq, 1)) == minimum(dq)
+                @test @inferred(quantile(dq, 1 // 2)) == quantile(dq, 0.5) == median(dq)
+                @test @inferred(quantile(dq, 0.5f0)) isa Int
+                test_quantile_invariants(dq)
+            end
+
+            for p in (-0.1, 1.1, NaN)
+                err = DomainError(p, "`p` must satisfy `0 <= p <= 1`")
+                @test_throws err quantile(d, p)
+                @test_throws err cquantile(d, p)
+            end
+        end
+    end
+
+    @testset "Fisher: exact reference probabilities" begin
+        @testset "$d" for d in (FisherNoncentralHypergeometric(8, 6, 10, 2),
+                                FisherNoncentralHypergeometric(50, 500, 30, 0.3),
+                                FisherNoncentralHypergeometric(80, 60, 100, 10))
+            ps = fisher_refprobs(d)
+            xs = support(d)
+            @test all(isapprox(pdf(d, k), ps[i]; rtol=1e-13)
+                      for (i, k) in enumerate(xs))
+            @test all(isapprox(cdf(d, k), sum(ps[1:i]); rtol=1e-13)
+                      for (i, k) in enumerate(xs))
+            @test all(isapprox(ccdf(d, k), sum(ps[(i + 1):end]); rtol=1e-13)
+                      for (i, k) in enumerate(xs) if k < last(xs))
+            @test iszero(ccdf(d, last(xs)))
+
+            μ = sum(k * ps[i] for (i, k) in enumerate(xs))
+            @test mean(d) ≈ μ rtol=1e-12
+            @test var(d) ≈ sum((k - μ)^2 * ps[i] for (i, k) in enumerate(xs)) rtol=1e-12
+        end
+
+        # `1 - cdf(d, k)` cancels to zero in the upper tail
+        d = FisherNoncentralHypergeometric(50, 500, 30, 0.3)
+        @test iszero(1 - cdf(d, 29))
+        @test isfinite(logccdf(d, 29))
+
+        # terms in the lower tail are negligible relative to the normalizing constant, but
+        # not relative to `cdf(d, k)`
+        d = FisherNoncentralHypergeometric(80, 60, 100, 10)
+        @test cdf(d, 51) > pdf(d, 51)
+    end
+end

--- a/test/univariate/discrete/poissonbinomial.jl
+++ b/test/univariate/discrete/poissonbinomial.jl
@@ -146,6 +146,31 @@ end
     @test x ≈ fftw_fft
 end
 
+@testset "quantile" begin
+    # https://github.com/JuliaStats/Distributions.jl/issues/2090
+    @test @inferred(quantile(PoissonBinomial(range(0.05, 0.95; length=100)), 1)) == 100
+    @test @inferred(quantile(PoissonBinomial(fill(0.9, 800)), 1)) == 800
+
+    d = PoissonBinomial([0.1, 0.2, 0.3])
+    @test @inferred(quantile(d, 1//2)) == quantile(d, 0.5) == median(d)
+    @test @inferred(quantile(d, 0.5f0)) isa Int
+    for p in (-0.1, 1.1, NaN)
+        err = DomainError(p, "`p` must satisfy `0 <= p <= 1`")
+        @test_throws err quantile(d, p)
+        @test_throws err cquantile(d, p)
+    end
+
+    # `maximum(d)` is not attained if some success probability is zero
+    @test @inferred(quantile(PoissonBinomial([0.0, 0.5]), 1)) == 1
+
+    @testset "$(succprob(d))" for d in (PoissonBinomial([0.1, 0.2, 0.3]),
+                                        PoissonBinomial(fill(0.8, 6)),
+                                        PoissonBinomial(range(0.05, 0.95; length=100)),
+                                        PoissonBinomial(fill(0.9, 800)))
+        test_quantile_invariants(d)
+    end
+end
+
 @testset "automatic differentiation" begin
     # Test autodiff using ForwardDiff
     f = x -> logpdf(PoissonBinomial(x), 0)


### PR DESCRIPTION
Fixes #2090.

`quantile` and `cdf` were derived through independent numerical paths and never checked
against each other. `cdf` uses `integerunitrange_cdf`, which sums the shorter tail, whereas
`quantile` rebuilt a `Categorical` and inherited `DiscreteNonParametric`'s left-to-right
running sum. That sum overshoots `1` by `1.3e-15`, and the same loop was copy-pasted in
three places:

| | before | expected |
|---|---|---|
| `quantile(BetaBinomial(1000, 0.1, 20), 1)` | 777 | 1000 |
| `quantile(PoissonBinomial(fill(0.9, 800)), 1)` | 778 | 800 |
| `quantile(FisherNoncentralHypergeometric(50, 500, 30, 0.3), 0)` and `…, 1)` | `BoundsError` | 0 and 30 |
| `quantile(WalleniusNoncentralHypergeometric(50, 500, 30, 0.3), 0)` and `…, 1)` | `BoundsError` | 0 and 30 |

## Changes

- Add `integerunitrange_quantile`/`_cquantile`, which accumulate the lower tail if
  `p <= 1/2` and the upper tail otherwise, as `integerunitrange_cdf` does. The two-sided
  form is what makes `p = 1` come out right, since `cdf` rounds to `1` long before the
  largest support point (`cdf(BetaBinomial(1000, 0.1, 20), 814) == 1`). Each `pdf` is
  accumulated once, the search terminates early, and no probability vector is allocated.
- Use them for the four distributions above, rework `quantile(::DiscreteNonParametric, _)`
  the same way, and delete the three copies of the running sum — including the one in
  `median(::Categorical)`, which could index `p[k + 1]`.
- Widen `p::Float64` to `p::Real`, so `quantile(d, 1//2)` and `quantile(d, 0.5f0)` work.
- Clamp the tail sums in the four `integerunitrange_*` functions:
  `cdf(PoissonBinomial(fill(0.9, 800)), 400)` was `-8.9e-16`, and `logcdf(…, 500)` threw a
  `DomainError` from `log1mexp` of a positive argument.
- Add `pdf_int`/`logpdf_int` next to `cdf_int` and friends, and use them for the three
  distributions that rounded `Real` to `Int` by hand.
  `pdf(FisherNoncentralHypergeometric(8, 6, 10, 1), 6.5)` was a `StackOverflowError`,
  because the distribution defined neither method and the two generic fallbacks called each
  other.
- `FisherNoncentralHypergeometric`: add an accurate `ccdf`, factored with `cdf` over a
  shared routine. Both tails now terminate only once terms stop contributing to the tail
  they belong to, rather than to the normalizing constant. `cdf(Fisher(80, 60, 100, 10), 51)`
  was off by 3.7% (it dropped `40:50` entirely), and
  `ccdf(Fisher(50, 500, 30, 0.3), 29)` is now `2.6e-51` where `1 - cdf` cancelled to `0`.
- `BetaBinomial`: closed-form `mode`/`modes` from the pmf ratio, replacing a detour through
  `Categorical`. Ties are resolved exactly rather than by `pdf` roundoff, so
  `modes(BetaBinomial(20, 1, 1))` is all 21 support points instead of `2:18`.

## Tests

- `test_extreme_quantiles` in the discrete `test_distr`: 33 failures before this PR, none
  after.
- `test_quantile_invariants`, opt-in per distribution: admissibility, minimality via
  `cdf(d, q) < p + pdf(d, q)`, the `ccdf` mirror, and monotonicity. Not in `test_distr`,
  because the Rmath-backed distributions do not satisfy it (`Hypergeometric(3, 2, 2)` is
  1 ulp inconsistent with its own `cdf`).
- New `test/univariate/discrete/noncentralhypergeometric.jl`, which had no test file. It
  checks `pdf`, `cdf`, `ccdf`, `mean` and `var` of `FisherNoncentralHypergeometric` against
  exact `BigFloat` weights.

## Behaviour changes

- Out-of-domain `p` throws `DomainError` uniformly, instead of `T(NaN)` for
  `NoncentralHypergeometric` and a `MethodError` for `DiscreteNonParametric`
  (`throw(DomainError())` is not a valid constructor).
- `pdf`/`logpdf` at `NaN` return `NaN` rather than `0`/`-Inf` for the four distributions,
  consistently with `cdf` and with the continuous distributions.
- `median(::BetaBinomial)`, `median(::PoissonBinomial)` and `median(::Categorical)` are
  removed in favour of the generic `median(d) = quantile(d, 1//2)`; values are unchanged.
- `FisherNoncentralHypergeometric` preserves a `Float32` `ω` in `pdf`, `cdf` and `ccdf`.
- On exact ties `quantile` returns the smaller admissible support point.

## Follow-ups

- The `WalleniusNoncentralHypergeometric` pmf is limited to about `5e-9` by `quadgk`'s
  default tolerance, and underflows to zero for 112 of 684 parameter sets because the
  integrand is concentrated on `t ∈ (0, exp(-D))`. Neither an `expm1` integrand nor a
  tighter tolerance helps; it needs the Beta-kernel reformulation. It also loses the
  parameter type, which is pinned as `broken` in the new test file.
- `Bernoulli`, `BernoulliLogit` and `Dirac` still return `NaN` for out-of-domain `p`, and
  eight discrete distributions still return `0` for `pdf(d, NaN)`.
- `integerunitrange_cdf` is non-monotone across the support midpoint for extreme parameters.
- `FisherNoncentralHypergeometric` is still `O(n²)` for a full quantile.
